### PR TITLE
Travis fixup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ dotnet_tests:
 	echo "run dotnet tests"
 
 java_tests:
-	cd java && mvn install test;
+	cd java && mvn install test -Dmaven.javadoc.skip=true;
 
 python_tests:
 	cd python && pip install -r requirements.txt && pytest;


### PR DESCRIPTION
Looks like the culprit to failed CI builds were errors in building Javadocs. Since I don't think building Javadocs is a priority right now, I've disabled this. 