### PR TITLE
Fix duplicate withEdge() methods

### DIFF
--- a/java/src/main/java/com/saucelabs/simplesauce/EdgeVersion.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/EdgeVersion.java
@@ -1,0 +1,16 @@
+package com.saucelabs.simplesauce;
+
+public enum EdgeVersion {
+    E16("16_16299"),
+    E15("15_15063"),
+    E14("14_14393"),
+    E13("13_10586"),
+    E17("17_17134"),
+    E18("18_17763");
+
+    public String label;
+
+    EdgeVersion(String label) {
+        this.label = label;
+    }
+}

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
@@ -17,13 +17,15 @@ import org.openqa.selenium.safari.SafariOptions;
 import java.net.MalformedURLException;
 
 public class SauceSession {
-    @Getter @Setter public final String sauceDataCenter = DataCenter.USWest;
+    @Getter
+    @Setter
+    public final String sauceDataCenter = DataCenter.USWest;
     private final EnvironmentManager environmentManager;
     public SauceTimeout timeouts = new SauceTimeout();
 
     //todo there is some weird bug when this is set to Linux, the session can't be started
-	private String operatingSystem = "Windows 10";
-	private String browserName = "Chrome";
+    private String operatingSystem = "Windows 10";
+    private String browserName = "Chrome";
     private final String sauceOptionsTag = "sauce:options";
     private ChromeOptions chromeOptions;
     private FirefoxOptions firefoxOptions;
@@ -35,7 +37,9 @@ public class SauceSession {
     private WebDriver webDriver;
     private EdgeOptions edgeOptions;
     private InternetExplorerOptions ieOptions;
-    @Getter @Setter public String sauceLabsUrl;
+    @Getter
+    @Setter
+    public String sauceLabsUrl;
 
     public SauceSession() {
         sauceSessionCapabilities = new MutableCapabilities();
@@ -54,16 +58,13 @@ public class SauceSession {
         setBrowserSpecificCapabilities(browserName);
         sauceSessionCapabilities = setRemoteDriverCapabilities(sauceOptions);
         sauceLabsUrl = sauceDataCenter;
-        try
-        {
+        try {
             webDriver = remoteDriverImplementation.createRemoteWebDriver(sauceLabsUrl, sauceSessionCapabilities);
-        }
-        catch (MalformedURLException e)
-        {
+        } catch (MalformedURLException e) {
             throw new InvalidArgumentException("Invalid URL");
         }
         return this.webDriver;
-	}
+    }
 
     private MutableCapabilities setRemoteDriverCapabilities(MutableCapabilities sauceOptions) {
         sauceSessionCapabilities.setCapability(sauceOptionsTag, sauceOptions);
@@ -77,77 +78,65 @@ public class SauceSession {
         sauceOptions = new MutableCapabilities();
         sauceOptions.setCapability("username", getUserName());
         sauceOptions.setCapability("accessKey", getAccessKey());
-        if(timeouts.getCommandTimeout() != 0)
+        if (timeouts.getCommandTimeout() != 0)
             sauceOptions.setCapability("commandTimeout", timeouts.getCommandTimeout());
-        if(timeouts.getIdleTimeout() != 0)
+        if (timeouts.getIdleTimeout() != 0)
             sauceOptions.setCapability("idleTimeout", timeouts.getIdleTimeout());
         return sauceOptions;
     }
 
     //TODO this needs to be moved to it's own class because it keeps changing
-    private void setBrowserSpecificCapabilities(String browserName)
-    {
-        if (browserName.equalsIgnoreCase("Chrome"))
-        {
+    private void setBrowserSpecificCapabilities(String browserName) {
+        if (browserName.equalsIgnoreCase("Chrome")) {
             sauceSessionCapabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
-        }
-        else if (browserName.equalsIgnoreCase("Firefox"))
-        {
+        } else if (browserName.equalsIgnoreCase("Firefox")) {
             sauceSessionCapabilities.setCapability(FirefoxOptions.FIREFOX_OPTIONS, firefoxOptions);
-        }
-        else if(browserName.equalsIgnoreCase("Safari"))
-        {
+        } else if (browserName.equalsIgnoreCase("Safari")) {
             SafariOptions safariOptions = new SafariOptions();
             sauceSessionCapabilities.setCapability(SafariOptions.CAPABILITY, safariOptions);
-        }
-        else if(browserName.equalsIgnoreCase("Edge"))
-        {
+        } else if (browserName.equalsIgnoreCase("Edge")) {
             sauceSessionCapabilities.setCapability("Edge", edgeOptions);
-        }
-        else if(browserName.equalsIgnoreCase("IE"))
-        {
+        } else if (browserName.equalsIgnoreCase("IE")) {
             sauceSessionCapabilities.setCapability("se:ieOptions", ieOptions);
-        }
-        else {
+        } else {
             throw new IllegalArgumentException("The browser=>" + browserName + " that you passed in is not a valid option.");
         }
     }
 
-	public SauceSession withChrome()
-	{
-	    chromeOptions = new ChromeOptions();
-		chromeOptions.setExperimentalOption("w3c", true);
-		browserName = "Chrome";
-		return this;
-	}
+    public SauceSession withChrome() {
+        chromeOptions = new ChromeOptions();
+        chromeOptions.setExperimentalOption("w3c", true);
+        browserName = "Chrome";
+        return this;
+    }
 
-    public SauceSession withSafari(String version)
-    {
+    public SauceSession withSafari(String version) {
         //TODO: I did this but I hate it :(
         //I wish I could just have a default value set for the version param
-        if(version.equalsIgnoreCase(""))
+        if (version.equalsIgnoreCase(""))
             version = "latest";
         browserName = "safari";
         this.browserVersion = version;
         return this;
     }
-    public SauceSession withSafari()
-    {
+
+    public SauceSession withSafari() {
         return withMacOsMojave();
     }
 
-    public SauceSession withFirefox()
-	{
-		browserName = "Firefox";
-		return this;
-	}
+    public SauceSession withFirefox() {
+        browserName = "Firefox";
+        return this;
+    }
 
     public RemoteDriverInterface getDriverManager() {
         return remoteDriverImplementation;
     }
-    public MutableCapabilities getSauceOptionsCapability(){
+
+    public MutableCapabilities getSauceOptionsCapability() {
         return ((MutableCapabilities) sauceSessionCapabilities.getCapability(sauceOptionsTag));
     }
+
     public WebDriver getDriver() {
         return webDriver;
     }
@@ -158,8 +147,8 @@ public class SauceSession {
         browserVersion = "12.0";
         return this;
     }
-    public SauceSession withMacOsHighSierra()
-    {
+
+    public SauceSession withMacOsHighSierra() {
         this.operatingSystem = "macOS 10.13";
         browserName = "Safari";
         return this;
@@ -184,13 +173,12 @@ public class SauceSession {
     }
 
 
-    public void stop()
-    {
-        if(webDriver != null)
+    public void stop() {
+        if (webDriver != null)
             webDriver.quit();
     }
 
-    public String getUserName() throws SauceEnvironmentVariablesNotSetException{
+    public String getUserName() throws SauceEnvironmentVariablesNotSetException {
         String userName = environmentManager.getEnvironmentVariable("SAUCE_USERNAME");
         return checkIfEmpty(userName);
     }
@@ -223,12 +211,13 @@ public class SauceSession {
         browserName = "Safari";
         return this;
     }
+
     //FIXED notice the duplication below with edge. Used enumeration
     //Maybe could be moved to a separate class so we can do withEdge().16_16299();
     //Or withEdge().version(EdgeVersion.16_16299);
     public SauceSession withEdge(EdgeVersion version) {
         browserName = "Edge";
-        browserVersion = version.name().substring(1);
+        browserVersion = version.label;
         return this;
     }
 
@@ -255,15 +244,5 @@ public class SauceSession {
     public SauceSession withLinux() {
         operatingSystem = "Linux";
         return this;
-    }
-
-    public enum EdgeVersion {
-        E16_16299,
-        E15_15063,
-        E14_14393,
-        E13_10586,
-        E17_17134,
-        E18_17763,
-
     }
 }

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
@@ -223,42 +223,12 @@ public class SauceSession {
         browserName = "Safari";
         return this;
     }
-    //TODO notice the duplication below with edge.
+    //FIXED notice the duplication below with edge. Used enumeration
     //Maybe could be moved to a separate class so we can do withEdge().16_16299();
     //Or withEdge().version(EdgeVersion.16_16299);
-    public SauceSession withEdge16_16299() {
+    public SauceSession withEdge(EdgeVersion version) {
         browserName = "Edge";
-        browserVersion = "16.16299";
-        return this;
-    }
-
-    public SauceSession withEdge15_15063() {
-        browserName = "Edge";
-        browserVersion = "15.15063";
-        return this;
-    }
-
-    public SauceSession withEdge14_14393() {
-        browserName = "Edge";
-        browserVersion = "14.14393";
-        return this;
-    }
-
-    public SauceSession withEdge13_10586() {
-        browserName = "Edge";
-        browserVersion = "13.10586";
-        return this;
-    }
-
-    public SauceSession withEdge17_17134() {
-        browserName = "Edge";
-        browserVersion = "17.17134";
-        return this;
-    }
-
-    public SauceSession withEdge18_17763() {
-        browserName = "Edge";
-        browserVersion = "18.17763";
+        browserVersion = version.name().substring(1);
         return this;
     }
 
@@ -285,5 +255,15 @@ public class SauceSession {
     public SauceSession withLinux() {
         operatingSystem = "Linux";
         return this;
+    }
+
+    public enum EdgeVersion {
+        E16_16299,
+        E15_15063,
+        E14_14393,
+        E13_10586,
+        E17_17134,
+        E18_17763,
+
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/unit/EdgeTests.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/unit/EdgeTests.java
@@ -1,5 +1,6 @@
 package com.saucelabs.simplesauce.unit;
 
+import com.saucelabs.simplesauce.SauceSession;
 import org.junit.Test;
 
 import java.net.MalformedURLException;
@@ -7,45 +8,13 @@ import static org.junit.Assert.assertEquals;
 
 public class EdgeTests extends BaseConfigurationTest{
     @Test
-    public void withEdge18_17763_returnsBrowserVersion18_17763() {
-        fakeSauceSession.withEdge18_17763();
-        fakeSauceSession.start();
-        String actualBrowserSetInConfig = fakeSauceSession.sauceSessionCapabilities.getVersion();
-        assertEquals("18.17763", actualBrowserSetInConfig);
-    }
-    @Test
-    public void withEdge17_17134_returnsBrowserVersion17_17134() {
-        fakeSauceSession.withEdge17_17134();
-        fakeSauceSession.start();
-        String actualBrowserSetInConfig = fakeSauceSession.sauceSessionCapabilities.getVersion();
-        assertEquals("17.17134", actualBrowserSetInConfig);
-    }
-    @Test
-    public void withEdge16_16299_returnsBrowserVersion16_16299() {
-        fakeSauceSession.withEdge16_16299();
-        fakeSauceSession.start();
-        String actualBrowserSetInConfig = fakeSauceSession.sauceSessionCapabilities.getVersion();
-        assertEquals("16.16299", actualBrowserSetInConfig);
-    }
-    @Test
-    public void withEdge15_15063_returnsBrowserVersion15_15063() {
-        fakeSauceSession.withEdge15_15063();
-        fakeSauceSession.start();
-        String actualBrowserSetInConfig = fakeSauceSession.sauceSessionCapabilities.getVersion();
-        assertEquals("15.15063", actualBrowserSetInConfig);
-    }
-    @Test
-    public void withEdge14_14393_returnsBrowserVersion14_14393() {
-        fakeSauceSession.withEdge14_14393();
-        fakeSauceSession.start();
-        String actualBrowserSetInConfig = fakeSauceSession.sauceSessionCapabilities.getVersion();
-        assertEquals("14.14393", actualBrowserSetInConfig);
-    }
-    @Test
-    public void withEdge13_10586_returnsBrowserVersion13_10586() {
-        fakeSauceSession.withEdge13_10586();
-        fakeSauceSession.start();
-        String actualBrowserSetInConfig = fakeSauceSession.sauceSessionCapabilities.getVersion();
-        assertEquals("13.10586", actualBrowserSetInConfig);
+    public void withEdgeReturnsCorrectBrowserVersion() {
+        for(SauceSession.EdgeVersion version : SauceSession.EdgeVersion.values()) {
+            fakeSauceSession.withEdge(version);
+            fakeSauceSession.start();
+            String actualBrowserSetInConfig = fakeSauceSession.sauceSessionCapabilities.getVersion();
+            String expectedVersionString = version.name().substring(1);
+            assertEquals(expectedVersionString, actualBrowserSetInConfig);
+        }
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/unit/EdgeTests.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/unit/EdgeTests.java
@@ -1,10 +1,8 @@
 package com.saucelabs.simplesauce.unit;
 
 import com.saucelabs.simplesauce.EdgeVersion;
-import com.saucelabs.simplesauce.SauceSession;
 import org.junit.Test;
 
-import java.net.MalformedURLException;
 import static org.junit.Assert.assertEquals;
 
 public class EdgeTests extends BaseConfigurationTest{

--- a/java/src/test/java/com/saucelabs/simplesauce/unit/EdgeTests.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/unit/EdgeTests.java
@@ -1,5 +1,6 @@
 package com.saucelabs.simplesauce.unit;
 
+import com.saucelabs.simplesauce.EdgeVersion;
 import com.saucelabs.simplesauce.SauceSession;
 import org.junit.Test;
 
@@ -9,11 +10,11 @@ import static org.junit.Assert.assertEquals;
 public class EdgeTests extends BaseConfigurationTest{
     @Test
     public void withEdgeReturnsCorrectBrowserVersion() {
-        for(SauceSession.EdgeVersion version : SauceSession.EdgeVersion.values()) {
+        for(EdgeVersion version : EdgeVersion.values()) {
             fakeSauceSession.withEdge(version);
             fakeSauceSession.start();
             String actualBrowserSetInConfig = fakeSauceSession.sauceSessionCapabilities.getVersion();
-            String expectedVersionString = version.name().substring(1);
+            String expectedVersionString = version.label;
             assertEquals(expectedVersionString, actualBrowserSetInConfig);
         }
     }


### PR DESCRIPTION
I saw that in the Java bindings the methods regarding the Edge browser were duplicated unnecessarily for each version. To make the code cleaner, I created an enumeration set for each version, and removed all but one method that takes in the version as a parameter.

Issue #46