### PR TITLE
Several fixes to Java - notably conventions, readability, accessors/m…

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -103,9 +103,11 @@ mvn install
 in the `java/` directory. This will allow you to import Simple Sauce as a Maven dependency in other local projects on your laptop as a snapshot of the state based on the commit that you build from. To add this reference via Maven, add
 
 ```xml
-<groupId>com.saucelabs</groupId>
-<artifactId>simple_sauce</artifactId>
-<version>1.0-SNAPSHOT</version>
+<dependency>
+    <groupId>com.saucelabs</groupId>
+    <artifactId>simple_sauce</artifactId>
+    <version>1.0-SNAPSHOT</version>
+</dependency>
 ```
 
 to other projects' `pom.xml` file to access Simple Sauce. Note that adding these coordinates to other Maven projects will get the latest `1.0-SNAPSHOT` version that was built, and so using these coordinates are recommended for development and not for general usage.

--- a/java/src/main/java/com/saucelabs/simplesauce/ConcreteSystemManager.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/ConcreteSystemManager.java
@@ -1,9 +1,0 @@
-package com.saucelabs.simplesauce;
-
-import com.saucelabs.simplesauce.interfaces.EnvironmentManager;
-
-public class ConcreteSystemManager implements EnvironmentManager {
-    public String getEnvironmentVariable(String variable) {
-        return System.getenv(variable);
-    }
-}

--- a/java/src/main/java/com/saucelabs/simplesauce/DataCenter.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/DataCenter.java
@@ -1,9 +1,15 @@
 package com.saucelabs.simplesauce;
 
-enum DataCenter
-{
-    ;
-    public static final String USWest = "https://ondemand.saucelabs.com/wd/hub";
-    public static final String US_EAST  = "https://ondemand.us-east-1.saucelabs.com/wd/hub";
-    public static final String EU_CENTRAL = "https://ondemand.eu-central-1.saucelabs.com/wd/hub";
+import lombok.Getter;
+
+enum DataCenter {
+    US_WEST("https://ondemand.saucelabs.com/wd/hub"),
+    US_EAST("https://ondemand.us-east-1.saucelabs.com/wd/hub"),
+    EU_CENTRAL("https://ondemand.eu-central-1.saucelabs.com/wd/hub");
+
+    @Getter private final String endpoint;
+
+    DataCenter(String endpoint) {
+        this.endpoint = endpoint;
+    }
 }

--- a/java/src/main/java/com/saucelabs/simplesauce/EnvironmentManager.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/EnvironmentManager.java
@@ -1,5 +1,6 @@
-package com.saucelabs.simplesauce.interfaces;
+package com.saucelabs.simplesauce;
 
 public interface EnvironmentManager {
+
     String getEnvironmentVariable(String variable);
 }

--- a/java/src/main/java/com/saucelabs/simplesauce/EnvironmentManagerImpl.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/EnvironmentManagerImpl.java
@@ -1,0 +1,12 @@
+package com.saucelabs.simplesauce;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class EnvironmentManagerImpl implements EnvironmentManager {
+
+    @VisibleForTesting
+    //This exists mostly so that we can mock getting environment variables during unit tests
+    public String getEnvironmentVariable(String variable) {
+        return System.getenv(variable);
+    }
+}

--- a/java/src/main/java/com/saucelabs/simplesauce/IEVersion.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/IEVersion.java
@@ -1,6 +1,13 @@
 package com.saucelabs.simplesauce;
 
+import lombok.Getter;
+
 enum IEVersion {
-    ;
-    public static final String _11 = "11.285";
+    _11("11.285");
+
+    @Getter private final String version;
+
+    IEVersion(String version) {
+        this.version = version;
+    }
 }

--- a/java/src/main/java/com/saucelabs/simplesauce/Platforms.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/Platforms.java
@@ -1,32 +1,45 @@
 package com.saucelabs.simplesauce;
 
-public class Platforms
-{
-	private static final String WINDOWS_10 = "Windows 10";
-	public static final String WINDOWS_8_1 = "Windows 8.1";
-	public static final String WINDOWS_8 = "Windows 8";
+import lombok.Getter;
 
-	public static final String MAC_OS_MOJAVE = "macOS 10.14";
-	public static final String MAC_OS_HIGH_SIERRA = "macOS 10.13";
-	private static final String MAC_OS_SIERRA = "macOS 10.12";
-	@SuppressWarnings("SpellCheckingInspection")
-	public static final String MAC_OS_EL_CAPITAN = "OS X 10.11";
-	public static final String MAC_OS_YOSEMITE = "OS X 10.10";
+enum Platforms {
+	WINDOWS_10("Windows 10"),
+	WINDOWS_8_1("Windows 8.1"),
+	WINDOWS_8("Windows 8"),
+	MAC_OS_MOJAVE("macOS 10.14"),
+	MAC_OS_HIGH_SIERRA("macOS 10.13"),
+	MAC_OS_SIERRA("macOS 10.12"),
+	MAC_OS_EL_CAPITAN("OS X 10.11"),
+	MAC_OS_YOSEMITE("OS X 10.10");
 
-	private static class WINDOWS
-	{
-		public static String LATEST = WINDOWS_10;
+	@Getter private final String osVersion;
+
+	//TODO Update this method whenever the "latest" has to change
+	public static Platforms windowsLatest() {
+		return WINDOWS_10;
+	}
+
+	//TODO Update this method whenever the "latest" has to change
+	public static Platforms macLatest() {
+		return MAC_OS_MOJAVE;
+	}
+
+	Platforms(String osVersion) {
+		this.osVersion = osVersion;
 	}
 
 	@SuppressWarnings("SpellCheckingInspection")
-	public static class MAC_OS
-	{
-		public static String MOJAVE = MAC_OS_MOJAVE;
-		public static String HIGH_SIERRA = MAC_OS_HIGH_SIERRA;
-		public static String SIERRA = MAC_OS_SIERRA;
-		public static String EL_CAPITAN = MAC_OS_EL_CAPITAN;
-		public static String YOSEMITE = MAC_OS_YOSEMITE;
+	public enum MAC_OS {
+		MOJAVE(MAC_OS_MOJAVE),
+		HIGH_SIERRA(MAC_OS_HIGH_SIERRA),
+		SIERRA(MAC_OS_SIERRA),
+		EL_CAPITAN(MAC_OS_EL_CAPITAN),
+		YOSEMITE(MAC_OS_YOSEMITE);
 
-		public static String LATEST = MAC_OS_MOJAVE;
+		@Getter private Platforms platform;
+
+		MAC_OS(Platforms platform) {
+			this.platform = platform;
+		}
 	}
 }

--- a/java/src/main/java/com/saucelabs/simplesauce/SafariVersion.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SafariVersion.java
@@ -1,5 +1,13 @@
 package com.saucelabs.simplesauce;
 
-class SafariVersion {
-    public static final String _8 = "8.0";
+import lombok.Getter;
+
+enum SafariVersion {
+    _8("8.0");
+
+    @Getter private final String version;
+
+    SafariVersion(String version) {
+        this.version = version;
+    }
 }

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceDriverImpl.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceDriverImpl.java
@@ -1,6 +1,5 @@
 package com.saucelabs.simplesauce;
 
-import com.saucelabs.simplesauce.interfaces.SauceRemoteDriver;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
@@ -4,34 +4,36 @@ import com.saucelabs.simplesauce.enums.MacVersion;
 import lombok.Getter;
 import lombok.Setter;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.BrowserType;
 
 public class SauceOptions {
-    //TODO can probably use BrowserType enum from Selenium to do BrowserType.CHROME
-    @Getter
-    @Setter
-    public String browser = "Chrome";
+    @Getter @Setter private String browserName = BrowserType.CHROME;
+    @Getter @Setter private String browserVersion = "latest";
+    @Getter @Setter private String operatingSystem = Platforms.windowsLatest().getOsVersion();
+    @Getter private ChromeOptions chromeOptions;
 
-    @Getter @Setter public String browserVersion = "latest";
-    @Getter @Setter public String operatingSystem = "Windows 10";
-    @Getter public  ChromeOptions chromeOptions;
-
-    public SauceOptions withChrome()
-    {
+    public SauceOptions withChrome() {
         chromeOptions = new ChromeOptions();
         //TODO no longer needed with Chrome 75+
         chromeOptions.setExperimentalOption("w3c", true);
-        browser = "Chrome";
+        browserName = BrowserType.CHROME;
         return this;
     }
     public SauceOptions withSafari()
     {
         return withMac(MacVersion.Mojave);
     }
-    public SauceOptions withSafari(final String version)
-    {
+
+    public SauceOptions withSafari(SafariVersion version) {
+        browserName = BrowserType.SAFARI;
+        browserVersion = version.getVersion();
+        return this;
+    }
+
+    public SauceOptions withSafari(final String version) {
         String _version = version;
         if (_version.isEmpty()) { _version = "latest"; }
-        browser = "safari";
+        browserName = BrowserType.SAFARI;
         browserVersion = _version;
         return this;
     }
@@ -42,7 +44,7 @@ public class SauceOptions {
     }
 
     public SauceOptions withWindows10() {
-        operatingSystem = "Windows 10";
+        operatingSystem = "windows 10";
         return this;
     }
     public SauceOptions withWindows8_1() {
@@ -60,7 +62,7 @@ public class SauceOptions {
     }
 
     public SauceOptions withEdge() {
-        browser = "Edge";
+        browserName = "Edge";
         browserVersion = "18.17763";
         return this;
     }
@@ -102,27 +104,31 @@ public class SauceOptions {
         return this;
     }
 
-    public SauceOptions withFirefox()
-    {
-        browser = "Firefox";
+    public SauceOptions withFirefox() {
+        browserName = "Firefox";
+        return this;
+    }
+
+    public SauceOptions withIE(IEVersion version) {
+        this.browserVersion = version.getVersion();
         return this;
     }
 
     public SauceOptions withIE(String version) {
-        browser = "IE";
+        browserName = "IE";
         browserVersion = version;
         return this;
     }
 
     public SauceOptions withIE() {
-        browser = "IE";
+        browserName = "IE";
         browserVersion = "latest";
         return this;
     }
 
     public SauceOptions withMac(MacVersion macVersion) {
         operatingSystem = macVersion.label;
-        browser = "Safari";
+        browserName = "Safari";
         return this;
     }
 }

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceRemoteDriver.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceRemoteDriver.java
@@ -1,4 +1,4 @@
-package com.saucelabs.simplesauce.interfaces;
+package com.saucelabs.simplesauce;
 
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
@@ -25,7 +25,7 @@ public class SauceSession {
     //TODO 2 same variables being used differently
     private MutableCapabilities mutableCapabilities;
     @Getter private MutableCapabilities currentSessionCapabilities;
-    @Getter private final SauceRemoteDriver driverManager;
+    @Getter private final SauceRemoteDriver sauceDriver;
     @Getter private WebDriver webDriver;
 
     public MutableCapabilities getSauceOptionsCapability(){
@@ -34,13 +34,13 @@ public class SauceSession {
 
     public SauceSession() {
         currentSessionCapabilities = new MutableCapabilities();
-        driverManager = new SauceDriverImpl();
+        sauceDriver = new SauceDriverImpl();
         environmentManager = new EnvironmentManagerImpl();
         sauceOptions = new SauceOptions();
     }
 
     public SauceSession(SauceRemoteDriver remoteManager, EnvironmentManager environmentManager) {
-        driverManager = remoteManager;
+        sauceDriver = remoteManager;
         currentSessionCapabilities = new MutableCapabilities();
         this.environmentManager = environmentManager;
         sauceOptions = new SauceOptions();
@@ -50,12 +50,12 @@ public class SauceSession {
         sauceOptions = options;
         currentSessionCapabilities = new MutableCapabilities();
         environmentManager = new EnvironmentManagerImpl();
-        driverManager = new SauceDriverImpl();
+        sauceDriver = new SauceDriverImpl();
     }
 
     public SauceSession(SauceOptions options, SauceRemoteDriver remoteManager, EnvironmentManager environmentManager) {
         sauceOptions = options;
-        driverManager = remoteManager;
+        sauceDriver = remoteManager;
         currentSessionCapabilities = new MutableCapabilities();
         this.environmentManager = environmentManager;
     }
@@ -120,7 +120,7 @@ public class SauceSession {
 
     private void tryToCreateRemoteWebDriver(String sauceLabsUrl) {
         try {
-            webDriver = this.driverManager.createRemoteWebDriver(sauceLabsUrl, currentSessionCapabilities);
+            webDriver = this.sauceDriver.createRemoteWebDriver(sauceLabsUrl, currentSessionCapabilities);
         }
         catch (MalformedURLException e) {
             throw new InvalidArgumentException("Invalid URL");

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceTimeout.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceTimeout.java
@@ -4,14 +4,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 public class SauceTimeout {
-    @Getter
-    @Setter
-    private int commandTimeout;
-    @Getter
-    @Setter
-    private int idleTimeout;
-    @Getter
-    private int maxTestDurationTimeout;
+    @Getter @Setter private int commandTimeout;
+    @Getter @Setter private int idleTimeout;
+    @Getter private int maxTestDurationTimeout;
 
     public void setMaxTestDurationTimeout(int maxTestDurationInSec) throws MaxTestDurationTimeoutExceededException {
         if(maxTestDurationInSec > 1800)

--- a/java/src/main/java/com/saucelabs/simplesauce/examples/BasicUsage.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/examples/BasicUsage.java
@@ -9,7 +9,7 @@ public class BasicUsage {
 
         sauce.start();
 
-        sauce.getDriver().get("https://www.saucedemo.com/");
+        sauce.getWebDriver().get("https://www.saucedemo.com/");
 
         sauce.stop();
     }

--- a/java/src/main/java/com/saucelabs/simplesauce/examples/UsingJUnit.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/examples/UsingJUnit.java
@@ -1,7 +1,11 @@
 package com.saucelabs.simplesauce.examples;
 
 import com.saucelabs.simplesauce.SauceSession;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.openqa.selenium.WebDriver;
 
 public class UsingJUnit {

--- a/java/src/main/java/com/saucelabs/simplesauce/examples/UsingJUnit.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/examples/UsingJUnit.java
@@ -1,10 +1,7 @@
 package com.saucelabs.simplesauce.examples;
 
 import com.saucelabs.simplesauce.SauceSession;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.*;
 import org.openqa.selenium.WebDriver;
 
 public class UsingJUnit {
@@ -30,7 +27,8 @@ public class UsingJUnit {
     }
 
     @Test
-    public void failingTest(){
+    @Ignore
+    public void failingTest() {
         driver.get("https://www.saucedemo.com");
 
         Assert.assertTrue(driver.getCurrentUrl().contains("Swag Labs"));

--- a/java/src/test/java/com/saucelabs/simplesauce/BaseConfigurationTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/BaseConfigurationTest.java
@@ -6,8 +6,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class BaseConfigurationTest {
-    SauceSession sauce;
-    SauceOptions sauceOptions;
+    protected SauceSession sauce;
+    protected SauceOptions sauceOptions;
     private SauceRemoteDriver dummyRemoteDriver;
     private EnvironmentManager dummyEnvironmentManager;
 

--- a/java/src/test/java/com/saucelabs/simplesauce/BaseConfigurationTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/BaseConfigurationTest.java
@@ -1,21 +1,18 @@
 package com.saucelabs.simplesauce;
 
-import com.saucelabs.simplesauce.interfaces.EnvironmentManager;
-import com.saucelabs.simplesauce.interfaces.SauceRemoteDriver;
 import org.junit.Before;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class BaseConfigurationTest {
-    public SauceSession sauce;
-    protected SauceRemoteDriver dummyRemoteDriver;
-    protected EnvironmentManager dummyEnvironmentManager;
-    protected SauceOptions sauceOptions;
+    SauceSession sauce;
+    SauceOptions sauceOptions;
+    private SauceRemoteDriver dummyRemoteDriver;
+    private EnvironmentManager dummyEnvironmentManager;
 
     @Before
-    public void setUp()
-    {
+    public void setUp() {
         dummyRemoteDriver = mock(SauceRemoteDriver.class);
         dummyEnvironmentManager = mock(EnvironmentManager.class);
         sauceOptions = new SauceOptions();
@@ -25,7 +22,7 @@ class BaseConfigurationTest {
         when(dummyEnvironmentManager.getEnvironmentVariable("SAUCE_ACCESS_KEY")).thenReturn("accessKey");
     }
 
-    public SauceSession instantiateSauceSession() {
+    SauceSession instantiateSauceSession() {
         return new SauceSession(sauceOptions, dummyRemoteDriver, dummyEnvironmentManager);
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/DataCenterTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/DataCenterTest.java
@@ -10,18 +10,18 @@ public class DataCenterTest
     public void usWestDataCenterUrl_isCorrect()
     {
         assertEquals("https://ondemand.saucelabs.com/wd/hub",
-                DataCenter.USWest);
+                DataCenter.US_WEST.getEndpoint());
     }
     @Test
     public void usEastDataCenterUrl_isCorrect()
     {
         assertEquals("https://ondemand.us-east-1.saucelabs.com/wd/hub",
-                DataCenter.US_EAST);
+                DataCenter.US_EAST.getEndpoint());
     }
     @Test
     public void euCentralDataCenterUrl_isCorrect()
     {
         assertEquals("https://ondemand.eu-central-1.saucelabs.com/wd/hub",
-                DataCenter.EU_CENTRAL);
+                DataCenter.EU_CENTRAL.getEndpoint());
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/EdgeTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/EdgeTest.java
@@ -4,14 +4,14 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class EdgeTest extends BaseConfigurationTest{
+public class EdgeTest extends BaseConfigurationTest {
     @Test
     public void withEdge_default() {
         sauceOptions.withEdge();
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualBrowserSetInConfig = sauce.currentSessionCapabilities.getVersion();
+        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
         assertEquals("18.17763", actualBrowserSetInConfig);
     }
 
@@ -21,52 +21,57 @@ public class EdgeTest extends BaseConfigurationTest{
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualBrowserSetInConfig = sauce.currentSessionCapabilities.getVersion();
+        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
         assertEquals("18.17763", actualBrowserSetInConfig);
     }
+
     @Test
     public void withEdge17_returnsBrowserVersion17_17134() {
         sauceOptions.withEdge17();
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualBrowserSetInConfig = sauce.currentSessionCapabilities.getVersion();
+        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
         assertEquals("17.17134", actualBrowserSetInConfig);
     }
+
     @Test
     public void withEdge16_returnsBrowserVersion16_16299() {
         sauceOptions.withEdge16();
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualBrowserSetInConfig = sauce.currentSessionCapabilities.getVersion();
+        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
         assertEquals("16.16299", actualBrowserSetInConfig);
     }
+
     @Test
     public void withEdge15_returnsBrowserVersion15_15063() {
         sauceOptions.withEdge15();
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualBrowserSetInConfig = sauce.currentSessionCapabilities.getVersion();
+        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
         assertEquals("15.15063", actualBrowserSetInConfig);
     }
+
     @Test
     public void withEdge14_returnsBrowserVersion14_14393() {
         sauceOptions.withEdge14();
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualBrowserSetInConfig = sauce.currentSessionCapabilities.getVersion();
+        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
         assertEquals("14.14393", actualBrowserSetInConfig);
     }
+
     @Test
     public void withEdge13_returnsBrowserVersion13_10586() {
         sauceOptions.withEdge13();
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualBrowserSetInConfig = sauce.currentSessionCapabilities.getVersion();
+        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
         assertEquals("13.10586", actualBrowserSetInConfig);
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/IETest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/IETest.java
@@ -5,14 +5,23 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public class IETest extends BaseConfigurationTest{
-
     @Test
-    public void withIE_validIeVersion() {
+    public void withIE_validIeVersionEnum() {
         sauceOptions.withIE(IEVersion._11);
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualBrowserSetInConfig = sauce.currentSessionCapabilities.getVersion();
+        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
+        assertEquals("11.285", actualBrowserSetInConfig);
+    }
+
+    @Test
+    public void withIE_validIeVersionString() {
+        sauceOptions.withIE(IEVersion._11.getVersion());
+        sauce = instantiateSauceSession();
+
+        sauce.start();
+        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
         assertEquals("11.285", actualBrowserSetInConfig);
     }
 
@@ -22,7 +31,7 @@ public class IETest extends BaseConfigurationTest{
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualBrowserSetInConfig = sauce.currentSessionCapabilities.getVersion();
+        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
         assertEquals("latest", actualBrowserSetInConfig);
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/LinuxTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/LinuxTest.java
@@ -11,7 +11,7 @@ public class LinuxTest extends BaseConfigurationTest {
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualOsSetInConfig = sauce.currentSessionCapabilities.getPlatform().toString();
+        String actualOsSetInConfig = sauce.getCurrentSessionCapabilities().getPlatform().toString();
         assertEquals("linux", actualOsSetInConfig.toLowerCase());
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/MacOsTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/MacOsTest.java
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(DataProviderRunner.class)
-public class MacOsTest extends BaseConfigurationTest{
+public class MacOsTest extends BaseConfigurationTest {
     @DataProvider
     public static Object[][] expectedMacOsVersions() {
         return new Object[][] {
@@ -27,67 +27,75 @@ public class MacOsTest extends BaseConfigurationTest{
     public void withMacOs_returnsValidOsConfiguration(MacVersion version, String expectedMacOsVersion) {
         sauceOptions.withMac(version);
         sauce = instantiateSauceSession();
-
         sauce.start();
+
         String actualOsThatWasSet = getSessionPlatformString();
         assertEquals(expectedMacOsVersion, actualOsThatWasSet);
     }
 
     private String getSessionPlatformString() {
-        return sauce.currentSessionCapabilities.getPlatform().toString();
+        return sauce.getCurrentSessionCapabilities().getPlatform().toString();
     }
 
     @Test
     public void defaultSafari_browserVersionIs12_0() {
         sauceOptions.withSafari();
         sauce = instantiateSauceSession();
-
         sauce.start();
 
         //TODO mockSauceSession.sauceSessionCapabilities can be turned into a method, maybe on the session
         //class that allows easier access to the caps
-        String safariVersionSetThroughSauceSession = sauce.currentSessionCapabilities.getVersion();
+        String safariVersionSetThroughSauceSession = sauce.getCurrentSessionCapabilities().getVersion();
         assertEquals("latest", safariVersionSetThroughSauceSession);
     }
+
     @Test
     public void defaultSafari_macOsVersionIsMojave() {
         sauceOptions.withSafari();
         sauce = instantiateSauceSession();
-
         sauce.start();
 
         String safariVersionSetThroughSauceSession = getSessionPlatformString();
-        assertEquals(Platforms.MAC_OS.MOJAVE, safariVersionSetThroughSauceSession);
+        assertEquals(Platforms.MAC_OS.MOJAVE.getPlatform().getOsVersion(), safariVersionSetThroughSauceSession);
     }
+
     @Test
-    public void withSafari_browserName_setToSafari() {
+    public void withSafari_browserName_setToSafariEnum() {
         sauceOptions.withSafari(SafariVersion._8);
         sauce = instantiateSauceSession();
-
         sauce.start();
 
-        String actualBrowserNameSetThroughSauceSession = sauce.currentSessionCapabilities.getBrowserName();
+        String actualBrowserNameSetThroughSauceSession = sauce.getCurrentSessionCapabilities().getBrowserName();
         assertEquals("safari", actualBrowserNameSetThroughSauceSession);
     }
+
+    @Test
+    public void withSafari_browserName_setToSafariString() {
+        sauceOptions.withSafari(SafariVersion._8.getVersion());
+        sauce = instantiateSauceSession();
+        sauce.start();
+
+        String actualBrowserNameSetThroughSauceSession = sauce.getCurrentSessionCapabilities().getBrowserName();
+        assertEquals("safari", actualBrowserNameSetThroughSauceSession);
+    }
+
     @Test
     public void withSafari_versionChangedFromDefault_returnsCorrectVersion() {
         sauceOptions.withSafari(SafariVersion._8);
         sauce = instantiateSauceSession();
-
         sauce.start();
 
-        String actualBrowserVersionSetThroughSauceSession = sauce.currentSessionCapabilities.getVersion();
+        String actualBrowserVersionSetThroughSauceSession = sauce.getCurrentSessionCapabilities().getVersion();
         assertEquals("8.0", actualBrowserVersionSetThroughSauceSession);
     }
     @Test
     public void withSafari_versionNotSet_returnsLatest() {
         sauceOptions.withSafari("");
         sauce = instantiateSauceSession();
-
         sauce.start();
 
         String actualBrowserVersionSetThroughSauceSession =
-                sauce.currentSessionCapabilities.getVersion();
+                sauce.getCurrentSessionCapabilities().getVersion();
         assertEquals("latest", actualBrowserVersionSetThroughSauceSession);
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceEnvironmentVariableNotSetExceptionTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceEnvironmentVariableNotSetExceptionTest.java
@@ -1,7 +1,5 @@
 package com.saucelabs.simplesauce;
 
-import com.saucelabs.simplesauce.interfaces.EnvironmentManager;
-import com.saucelabs.simplesauce.interfaces.SauceRemoteDriver;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
@@ -1,7 +1,5 @@
 package com.saucelabs.simplesauce;
 
-import com.saucelabs.simplesauce.interfaces.EnvironmentManager;
-import com.saucelabs.simplesauce.interfaces.SauceRemoteDriver;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,11 +17,13 @@ public class SauceOptionsTest {
     {
         options = new SauceOptions();
     }
+
     @Test
     public void sauceSession_takesSauceOptions() {
         sauceSession = new SauceSession(options);
         assertNotNull(sauceSession);
     }
+
     @Test
     public void sauceSession_defaultSauceOptions_returnsChromeBrowser() {
         SauceRemoteDriver fakeRemoteDriver = mock(SauceRemoteDriver.class);
@@ -33,26 +33,28 @@ public class SauceOptionsTest {
 
         sauceSession = new SauceSession(options,fakeRemoteDriver, fakeEnvironmentManager);
         sauceSession.start();
-        String actualBrowser = sauceSession.currentSessionCapabilities.getCapability("browserName").toString();
-        assertEquals("Chrome", actualBrowser);
+        String actualBrowser = sauceSession.getCurrentSessionCapabilities().getCapability("browserName").toString();
+        assertEquals("chrome", actualBrowser);
     }
 
     @Test
     public void sauceOptions_defaultBrowser_setToChrome() {
-        assertEquals("Chrome", options.browser);
+        assertEquals("chrome", options.getBrowserName());
     }
+
     @Test
     public void sauceOptions_defaultBrowserVersion_setToLatest() {
-        assertEquals("latest", options.browserVersion);
+        assertEquals("latest", options.getBrowserVersion());
     }
+
     @Test
     public void sauceOptions_defaultOS_setToWindows() {
-        assertEquals("Windows 10", options.operatingSystem);
+        assertEquals("Windows 10", options.getOperatingSystem());
     }
+
     @Test
     public void withChrome_browser_setToChrome() {
         options.withChrome();
-        assertEquals("Chrome", options.browser);
-        assertNotNull(options.chromeOptions);
+        assertNotNull(options.getChromeOptions());
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
@@ -1,18 +1,20 @@
 package com.saucelabs.simplesauce;
 
-import com.saucelabs.simplesauce.interfaces.EnvironmentManager;
-import com.saucelabs.simplesauce.interfaces.SauceRemoteDriver;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.openqa.selenium.MutableCapabilities;
+
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.SessionId;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class SauceSessionTest {
-
-
+    //TODO duplication in 3 classes, excluding DataCenterTest
     private SauceSession sauce;
     private EnvironmentManager dummyEnvironmentManager;
     private SauceRemoteDriver dummyRemoteDriver;
@@ -30,6 +32,7 @@ public class SauceSessionTest {
 
         sauce.start();
     }
+
     @Test
     public void sauceSession_defaultSauceOptions_returnsChromeBrowser() {
         options = new SauceOptions();
@@ -37,29 +40,32 @@ public class SauceSessionTest {
 
         sauce = new SauceSession(options, dummyRemoteDriver, dummyEnvironmentManager);
         sauce.start();
-        String actualBrowser = sauce.currentSessionCapabilities.getCapability("browserName").toString();
-        assertEquals("Chrome", actualBrowser);
+        String actualBrowser = sauce.getCurrentSessionCapabilities().getCapability("browserName").toString();
+        assertEquals("chrome", actualBrowser);
     }
+
     @Test
     public void startSession_defaultConfig_usWestDataCenter() {
-        String expectedDataCenterUrl = DataCenter.USWest;
-        assertEquals(expectedDataCenterUrl, sauce.sauceDataCenter);
+        String expectedDataCenterUrl = DataCenter.US_WEST.getEndpoint();
+        assertEquals(expectedDataCenterUrl, sauce.getSauceDataCenter());
     }
+
     @Test
-    public void getUserName_usernameSetInEnvironmentVariable_returnsValue()  {
+    public void getUserName_usernameSetInEnvironmentVariable_returnsValue() {
         when(dummyEnvironmentManager.getEnvironmentVariable("SAUCE_USERNAME")).thenReturn("test-name");
         String actualUserName = sauce.getUserName();
         assertNotEquals("",actualUserName);
     }
+
     @Test
     public void getAccessKey_keySetInEnvironmentVariable_returnsValue() {
         when(dummyEnvironmentManager.getEnvironmentVariable("SAUCE_ACCESS_KEY")).thenReturn("accessKey");
         String actualAccessKey = sauce.getAccessKey();
         assertNotEquals("", actualAccessKey);
     }
+
     @Test
-    public void defaultConstructor_instantiated_setsConcreteDriverManager()
-    {
+    public void defaultConstructor_instantiated_setsConcreteDriverManager() {
         SauceSession concreteSauceSession = new SauceSession();
         assertTrue(concreteSauceSession.getDriverManager() instanceof SauceDriverImpl);
     }
@@ -67,51 +73,59 @@ public class SauceSessionTest {
     @Test
     public void startSession_setsBrowserKey() {
         String expectedBrowserCapabilityKey = "browserName";
-        String actualBrowser = sauce.currentSessionCapabilities.getCapability(expectedBrowserCapabilityKey).toString();
+        String actualBrowser = sauce.getCurrentSessionCapabilities().getCapability(expectedBrowserCapabilityKey).toString();
         assertNotEquals("", actualBrowser);
     }
+
     @Test
     public void start_setsPlatformNameKey() {
         String correctPlatformKey = "platformName";
-        String browserSetInSauceSession = sauce.currentSessionCapabilities.getCapability(correctPlatformKey).toString();
+        String browserSetInSauceSession = sauce.getCurrentSessionCapabilities().getCapability(correctPlatformKey).toString();
         assertEquals("Windows 10", browserSetInSauceSession);
     }
+
     @Test
     public void defaultBrowserIsLatest() {
         String correctKey = "browserVersion";
-        String browserSetThroughSauceSession = sauce.currentSessionCapabilities.getCapability(correctKey).toString();
+        String browserSetThroughSauceSession = sauce.getCurrentSessionCapabilities().getCapability(correctKey).toString();
         assertEquals("latest", browserSetThroughSauceSession);
     }
+
     @Test
-    public void defaultIsChrome()
-    {
-        String actualBrowser = sauce.currentSessionCapabilities.getBrowserName();
-        assertEquals("Chrome", actualBrowser);
+    public void defaultIsChrome() {
+        String actualBrowser = sauce.getCurrentSessionCapabilities().getBrowserName();
+        assertEquals("chrome", actualBrowser);
     }
+
     @Test
     public void defaultIsWindows10() {
-        String actualOs = sauce.currentSessionCapabilities.getPlatform().name();
+        String actualOs = sauce.getCurrentSessionCapabilities().getPlatform().name();
         assertEquals("WIN10", actualOs);
     }
+
     @Test
     public void sauceOptions_defaultConfiguration_setsSauceOptions() {
-        boolean hasAccessKey = sauce.getSauceOptionsCapability().asMap().containsKey("accessKey");
-        assertTrue("You need to have Sauce Credentials set (SAUCE_USERNAME, SAUCE_ACCESSKEY) before this unit test will pass", hasAccessKey);
+        MutableCapabilities sauceOptions = (MutableCapabilities) sauce.getCurrentSessionCapabilities().getCapability("sauce:options");
+        String accessKey = (String) sauceOptions.getCapability("accessKey");
+        assertEquals("You need to have Sauce Credentials set (SAUCE_USERNAME, SAUCE_ACCESSKEY) before this unit test will pass", "accessKey", accessKey);
     }
+
     @Test
     public void sauceOptions_startWithChrome_startsChrome() {
+        dummyRemoteDriver = mock(SauceRemoteDriver.class);
         options = new SauceOptions();
         options.withChrome();
 
         sauce = new SauceSession(options, dummyRemoteDriver, dummyEnvironmentManager);
         sauce.start();
 
-        String actualBrowser = sauce.currentSessionCapabilities.getBrowserName();
-        assertEquals("Chrome", actualBrowser);
+        String actualBrowser = sauce.getCurrentSessionCapabilities().getBrowserName();
+        assertEquals("chrome", actualBrowser);
     }
+
     @Test
     public void stop_callsDriverQuit() {
-        WebDriver mockDriver = mock(WebDriver.class);
+        RemoteWebDriver mockDriver = mock(RemoteWebDriver.class);
 
         sauce.start();
         sauce.stop(mockDriver);

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
@@ -1,6 +1,5 @@
 package com.saucelabs.simplesauce;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -8,7 +7,6 @@ import org.openqa.selenium.MutableCapabilities;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.RemoteWebDriver;
-import org.openqa.selenium.remote.SessionId;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -67,7 +65,7 @@ public class SauceSessionTest {
     @Test
     public void defaultConstructor_instantiated_setsConcreteDriverManager() {
         SauceSession concreteSauceSession = new SauceSession();
-        assertTrue(concreteSauceSession.getDriverManager() instanceof SauceDriverImpl);
+        assertTrue(concreteSauceSession.getSauceDriver() instanceof SauceDriverImpl);
     }
 
     @Test

--- a/java/src/test/java/com/saucelabs/simplesauce/TimeoutTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/TimeoutTest.java
@@ -8,39 +8,39 @@ import static org.junit.Assert.assertEquals;
 public class TimeoutTest extends BaseConfigurationTest {
     @Test
     public void commandTimeout_canBeSet() {
-        sauce.timeouts.setCommandTimeout(100);
+        sauce.getTimeouts().setCommandTimeout(100);
         sauce.start();
         assertCorrectCommandSetOnRemoteSession("commandTimeout", 100);
     }
 
     private void assertCorrectCommandSetOnRemoteSession(String commandTimeout, int expectedTimeout) {
-        Object sauceOptions = sauce.currentSessionCapabilities.asMap().get("sauce:options");
+        Object sauceOptions = sauce.getCurrentSessionCapabilities().asMap().get("sauce:options");
         Object commandTimeoutSetInCaps = ((MutableCapabilities) sauceOptions).getCapability(commandTimeout);
         assertEquals(expectedTimeout, commandTimeoutSetInCaps);
     }
 
     @Test
     public void idleTimeout_canBeSet() {
-        sauce.timeouts.setIdleTimeout(100);
+        sauce.getTimeouts().setIdleTimeout(100);
         sauce.start();
         assertCorrectCommandSetOnRemoteSession("idleTimeout", 100);
     }
     @Test
     public void maxDuration_canBeSet() throws MaxTestDurationTimeoutExceededException {
         int maxTestDurationInSec = 1800;
-        sauce.timeouts.setMaxTestDurationTimeout(maxTestDurationInSec);
+        sauce.getTimeouts().setMaxTestDurationTimeout(maxTestDurationInSec);
         sauce.start();
         assertCorrectCommandSetOnRemoteSession("maxDuration", maxTestDurationInSec);
     }
     @Test(expected = MaxTestDurationTimeoutExceededException.class)
     public void maxDuration_setTo1HigherThanMax_throwsException() throws MaxTestDurationTimeoutExceededException {
         int maxTestDurationInSec = 1801;
-        sauce.timeouts.setMaxTestDurationTimeout(maxTestDurationInSec);
+        sauce.getTimeouts().setMaxTestDurationTimeout(maxTestDurationInSec);
     }
     @Test()
     public void maxDuration_setTo1LowerThanMax_noException() throws MaxTestDurationTimeoutExceededException {
         int maxTestDurationInSec = 1799;
-        sauce.timeouts.setMaxTestDurationTimeout(maxTestDurationInSec);
+        sauce.getTimeouts().setMaxTestDurationTimeout(maxTestDurationInSec);
         sauce.start();
         assertCorrectCommandSetOnRemoteSession("maxDuration", maxTestDurationInSec);
     }

--- a/java/src/test/java/com/saucelabs/simplesauce/WindowsTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/WindowsTest.java
@@ -11,7 +11,7 @@ public class WindowsTest extends BaseConfigurationTest {
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualOsSetInConfig = sauce.currentSessionCapabilities.getPlatform().toString();
+        String actualOsSetInConfig = sauce.getCurrentSessionCapabilities().getPlatform().toString();
         assertEquals("WIN10", actualOsSetInConfig);
     }
     @Test
@@ -20,7 +20,7 @@ public class WindowsTest extends BaseConfigurationTest {
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualOsSetInConfig = sauce.currentSessionCapabilities.getPlatform().toString();
+        String actualOsSetInConfig = sauce.getCurrentSessionCapabilities().getPlatform().toString();
         assertEquals("WIN8_1", actualOsSetInConfig);
     }
     @Test
@@ -29,7 +29,7 @@ public class WindowsTest extends BaseConfigurationTest {
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualOsSetInConfig = sauce.currentSessionCapabilities.getPlatform().toString();
+        String actualOsSetInConfig = sauce.getCurrentSessionCapabilities().getPlatform().toString();
         assertEquals("WIN8", actualOsSetInConfig);
     }
     @Test
@@ -38,7 +38,7 @@ public class WindowsTest extends BaseConfigurationTest {
         sauce = instantiateSauceSession();
 
         sauce.start();
-        String actualOsSetInConfig = sauce.currentSessionCapabilities.getPlatform().toString();
+        String actualOsSetInConfig = sauce.getCurrentSessionCapabilities().getPlatform().toString();
         assertEquals("VISTA", actualOsSetInConfig);
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/acceptance/SauceSessionAcceptanceTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/acceptance/SauceSessionAcceptanceTest.java
@@ -19,6 +19,7 @@ public class SauceSessionAcceptanceTest {
     {
         sauce.stop(webDriver);
     }
+
     @Test
     public void sauceSession_defaultSauceOptions_startsRealSession() {
         SauceOptions options = new SauceOptions();
@@ -27,6 +28,7 @@ public class SauceSessionAcceptanceTest {
         String sessionId = ((RemoteWebDriver) webDriver).getSessionId().toString();
         assertFalse(sessionId.isEmpty());
     }
+
     @Test
     public void runTestOnWindows10() {
         SauceOptions options = new SauceOptions();
@@ -38,6 +40,7 @@ public class SauceSessionAcceptanceTest {
         //TODO why in the F is this returning XP even though in Sauce it shows Windows 10
         assertEquals("XP", actualOs);
     }
+
     @Test
     public void runTestOnFirefox() {
         SauceOptions options = new SauceOptions();
@@ -48,6 +51,7 @@ public class SauceSessionAcceptanceTest {
         String actualBrowser = getBrowserNameFromRemoteCapabilities();
         assertEquals("firefox", actualBrowser);
     }
+
     @Test
     public void withSafari_default_isMojave() {
         SauceOptions options = new SauceOptions();
@@ -58,6 +62,7 @@ public class SauceSessionAcceptanceTest {
         String actualPlatform = (((RemoteWebDriver) webDriver).getCapabilities()).getPlatform().toString();
         assertEquals("MAC", actualPlatform);
     }
+
     @Test
     public void withSafari_default_isBrowserVersion12_0() {
         SauceOptions options = new SauceOptions();


### PR DESCRIPTION
…utators, and some work on the enums

- Fixed a lot of private/public/protected/package-protected issues
- Unified the enums so that if there’s a string property being set, there’s always a getter for it, as opposed to some of them relying on the toString() method
- Changed instances of “Chrome” to use Selenium’s BrowserName.CHROME constant, which means all-lowercase everywhere
- Renamed SauceOptions.getBrowser() and its corresponding private member variable to getBrowserName() to match the W3C name
- One-line If statements without braces are frowned upon
- Changed one unit test (sauceOptions_defaultConfiguration_setsSauceOptions) substantially—I’m not sure how it could have worked before, so I may have changed something
- Readability: Most Java coders prefer braces on the same line as the if/while/for/method name, but I might be able to accommodate this
- Readability: I greatly prefer a line of whitespace in between methods… separates things visually a bit better
- SauceSessionAcceptanceTest.java, runTestOnWindows10 - the reason it’s coming back as XP is buried deep in org.openqa.selenium.Platform, where capabilities are munged and rewritten. It’s in a method called startSession
- This might actually be a Sauce bug—Sauce’s response to a very clear “windows 10” is “windows nt”, which Selenium rewrites as XP (RemoteWebDriver, line 231, Platform, line 46)
- You can see in the Sauce job that the request is “windows 10”, but the result.platformName (View Logs tab) is “windows nt”
- I suspect Sauce is doing something wonky with how they handle the driver creation on their side, but I could be wrong

There's a lot here, and for that I apologize. I could potentially break this up into multiple commits if that would make things easier. Also, if I've made choices you disagree with, let me know--this isn't a dictatorship and I don't always know best. 