### PR TITLE
fixup example getter

### DIFF
--- a/java/src/main/java/com/saucelabs/simplesauce/examples/BasicUsage.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/examples/BasicUsage.java
@@ -9,7 +9,7 @@ public class BasicUsage {
 
         sauce.start();
 
-        sauce.getDriver().get("https://www.saucedemo.com/");
+        sauce.getWebDriver().get("https://www.saucedemo.com/");
 
         sauce.stop();
     }


### PR DESCRIPTION
Fix for issue #78, renamed example to using the correct getter value, `getWebDriver()` instead of `getDriver()`