### PR TITLE
[java] stop method requires pass/fail information

### DIFF
--- a/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
@@ -1,6 +1,7 @@
 package com.saucelabs.simplesauce;
 
 import lombok.Getter;
+import org.openqa.selenium.JavascriptExecutor;
 import lombok.Setter;
 import org.openqa.selenium.InvalidArgumentException;
 import org.openqa.selenium.MutableCapabilities;
@@ -117,9 +118,28 @@ public class SauceSession {
         return new RemoteWebDriver(getSauceUrl(), currentSessionCapabilities);
     }
 
-    public void stop() {
-        if(driver !=null)
+    protected JavascriptExecutor getJSExecutor() {
+        return (JavascriptExecutor) driver;
+    }
+
+    public void stop(Boolean passed) {
+        String result = passed ? "passed" : "failed";
+        stop(result);
+    }
+
+    public void stop(String result) {
+        updateResult(result);
+        stop();
+    }
+
+    private void updateResult(String result) {
+        getJSExecutor().executeScript("sauce:job-result=" + result);
+    }
+
+    private void stop() {
+        if(driver !=null) {
             driver.quit();
+        }
     }
 
     protected String getEnvironmentVariable(String key) {

--- a/java/src/main/java/com/saucelabs/simplesauce/examples/BasicUsage.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/examples/BasicUsage.java
@@ -11,6 +11,6 @@ public class BasicUsage {
 
         sauce.getDriver().get("https://www.saucedemo.com/");
 
-        sauce.stop();
+        sauce.stop(true);
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
@@ -21,6 +22,7 @@ public class SauceSessionTest {
     private SauceSession sauce;
     private RemoteWebDriver dummyRemoteDriver = mock(RemoteWebDriver.class);
     private SauceOptions options = new SauceOptions();
+    private JavascriptExecutor dummyJSExecutor = mock(JavascriptExecutor.class);
 
     @Rule
     public MockitoRule initRule = MockitoJUnit.rule();
@@ -124,7 +126,7 @@ public class SauceSessionTest {
 
     @Test(expected = SauceEnvironmentVariablesNotSetException.class)
     public void startThrowsErrorWithoutUsername() {
-        doReturn(null).when(sauce).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        doReturn(null).when(sauce).getEnvironmentVariable("SAUCE_USERNAME");
         sauce.start();
     }
 
@@ -135,10 +137,34 @@ public class SauceSessionTest {
     }
 
     @Test
-    public void stop_noParams_callsDriverQuit() {
+    public void stopWithBooleanTrue() {
+        doReturn(dummyJSExecutor).when(sauce).getJSExecutor();
         sauce.start();
-        sauce.stop();
+        sauce.stop(true);
+        verify(dummyJSExecutor).executeScript("sauce:job-result=passed");
+    }
 
-        verify(dummyRemoteDriver).quit();
+    @Test
+    public void stopWithBooleanFalse() {
+        doReturn(dummyJSExecutor).when(sauce).getJSExecutor();
+        sauce.start();
+        sauce.stop(false);
+        verify(dummyJSExecutor).executeScript("sauce:job-result=failed");
+    }
+
+    @Test
+    public void stopWithStringPassed() {
+        doReturn(dummyJSExecutor).when(sauce).getJSExecutor();
+        sauce.start();
+        sauce.stop("passed");
+        verify(dummyJSExecutor).executeScript("sauce:job-result=passed");
+    }
+
+    @Test
+    public void stopWithStringFailed() {
+        doReturn(dummyJSExecutor).when(sauce).getJSExecutor();
+        sauce.start();
+        sauce.stop("failed");
+        verify(dummyJSExecutor).executeScript("sauce:job-result=failed");
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/acceptance/SauceSessionAcceptanceTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/acceptance/SauceSessionAcceptanceTest.java
@@ -16,7 +16,7 @@ public class SauceSessionAcceptanceTest {
 
     @After
     public void cleanUp() {
-        sauce.stop();
+        sauce.stop(true);
     }
 
     @Test


### PR DESCRIPTION
I started with having a `TestResult` enum but then I realized that doesn't make sense for programmatically setting this. Do we want to also support passing in a string "pass" and "fail?" I think Python does that, but I'm not sure I understand the use case when any evaluation is going to end up as a boolean.