### PR TITLE
Java separate concerns

### DIFF
--- a/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
@@ -3,8 +3,12 @@ package com.saucelabs.simplesauce;
 import com.saucelabs.simplesauce.enums.MacVersion;
 import lombok.Getter;
 import lombok.Setter;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.ie.InternetExplorerOptions;
+import org.openqa.selenium.safari.SafariOptions;
 import org.openqa.selenium.remote.BrowserType;
 import org.openqa.selenium.remote.CapabilityType;
 
@@ -23,10 +27,30 @@ public class SauceOptions {
         this(new MutableCapabilities());
     }
 
-    public SauceOptions(Capabilities capabilities) {
-        seleniumCapabilities = new MutableCapabilities(capabilities);
-        if (capabilities.getCapability("browserName") != null) {
-            browserName = (String) capabilities.getCapability("browserName");
+    public SauceOptions(ChromeOptions options) {
+        this(new MutableCapabilities(options));
+    }
+
+    public SauceOptions(EdgeOptions options) {
+        this(new MutableCapabilities(options));
+    }
+
+    public SauceOptions(FirefoxOptions options) {
+        this(new MutableCapabilities(options));
+    }
+
+    public SauceOptions(InternetExplorerOptions options) {
+        this(new MutableCapabilities(options));
+    }
+
+    public SauceOptions(SafariOptions options) {
+        this(new MutableCapabilities(options));
+    }
+
+    private SauceOptions(MutableCapabilities options) {
+        seleniumCapabilities = new MutableCapabilities(options.asMap());
+        if (options.getCapability("browserName") != null) {
+            browserName = (String) options.getCapability("browserName");
         }
     }
 

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
@@ -3,19 +3,41 @@ package com.saucelabs.simplesauce;
 import com.saucelabs.simplesauce.enums.MacVersion;
 import lombok.Getter;
 import lombok.Setter;
-import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.BrowserType;
+import org.openqa.selenium.remote.CapabilityType;
+
+import java.util.HashMap;
 
 public class SauceOptions {
+    @Getter private MutableCapabilities seleniumCapabilities;
+
     @Getter @Setter private String browserName = BrowserType.CHROME;
     @Getter @Setter private String browserVersion = "latest";
     @Getter @Setter private String platformName = Platforms.windowsLatest().getOsVersion();
-    @Getter private ChromeOptions chromeOptions;
+    @Getter private final SauceTimeout sauceTimeout = new SauceTimeout();
+
+    public SauceOptions() {
+        this(new MutableCapabilities());
+    }
+
+    public SauceOptions(Capabilities capabilities) {
+        seleniumCapabilities = new MutableCapabilities(capabilities);
+        if (capabilities.getCapability("browserName") != null) {
+            browserName = (String) capabilities.getCapability("browserName");
+        }
+    }
+
+    public MutableCapabilities toCapabilities() {
+        seleniumCapabilities.setCapability(CapabilityType.BROWSER_NAME, browserName);
+        seleniumCapabilities.setCapability(CapabilityType.PLATFORM_NAME, platformName);
+        seleniumCapabilities.setCapability(CapabilityType.BROWSER_VERSION, browserVersion);
+        seleniumCapabilities.setCapability("sauce:options", new HashMap<>());
+        return seleniumCapabilities;
+    }
 
     public SauceOptions withChrome() {
-        chromeOptions = new ChromeOptions();
-        //TODO no longer needed with Chrome 75+
-        chromeOptions.setExperimentalOption("w3c", true);
         browserName = BrowserType.CHROME;
         return this;
     }

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
@@ -17,6 +17,7 @@ public class SauceOptions {
     @Getter @Setter private String browserVersion = "latest";
     @Getter @Setter private String platformName = Platforms.windowsLatest().getOsVersion();
     @Getter private final SauceTimeout sauceTimeout = new SauceTimeout();
+    @Setter private String build;
 
     public SauceOptions() {
         this(new MutableCapabilities());
@@ -35,6 +36,37 @@ public class SauceOptions {
         seleniumCapabilities.setCapability(CapabilityType.BROWSER_VERSION, browserVersion);
         seleniumCapabilities.setCapability("sauce:options", new HashMap<>());
         return seleniumCapabilities;
+    }
+
+    public String getBuild() {
+        if (build != null) {
+            return build;
+            // Jenkins
+        } else if (getEnvironmentVariable("BUILD_TAG") != null) {
+            return getEnvironmentVariable("BUILD_NAME") + ": " + getEnvironmentVariable("BUILD_NUMBER");
+            // Bamboo
+        } else if (getEnvironmentVariable("bamboo_agentId") != null) {
+            return getEnvironmentVariable("bamboo_shortJobName") + ": " + getEnvironmentVariable("bamboo_buildNumber");
+            // Travis
+        } else if (getEnvironmentVariable("TRAVIS_JOB_ID") != null) {
+            return getEnvironmentVariable("TRAVIS_JOB_NAME") + ": " + getEnvironmentVariable("TRAVIS_JOB_NUMBER");
+            // CircleCI
+        } else if (getEnvironmentVariable("CIRCLE_JOB") != null) {
+            return getEnvironmentVariable("CIRCLE_JOB") + ": " + getEnvironmentVariable("CIRCLE_BUILD_NUM");
+            // Gitlab
+        } else if (getEnvironmentVariable("CI") != null) {
+            return getEnvironmentVariable("CI_JOB_NAME") + ": " + getEnvironmentVariable("CI_JOB_ID");
+            // Team City
+        } else if (getEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null) {
+            return getEnvironmentVariable("TEAMCITY_PROJECT_NAME") + ": " + getEnvironmentVariable("BUILD_NUMBER");
+            // Default
+        } else {
+            return "Build Time: " + System.currentTimeMillis();
+        }
+    }
+
+    protected String getEnvironmentVariable(String key) {
+        return System.getenv(key);
     }
 
     public SauceOptions withChrome() {

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
@@ -9,7 +9,7 @@ import org.openqa.selenium.remote.BrowserType;
 public class SauceOptions {
     @Getter @Setter private String browserName = BrowserType.CHROME;
     @Getter @Setter private String browserVersion = "latest";
-    @Getter @Setter private String operatingSystem = Platforms.windowsLatest().getOsVersion();
+    @Getter @Setter private String platformName = Platforms.windowsLatest().getOsVersion();
     @Getter private ChromeOptions chromeOptions;
 
     public SauceOptions withChrome() {
@@ -19,8 +19,8 @@ public class SauceOptions {
         browserName = BrowserType.CHROME;
         return this;
     }
-    public SauceOptions withSafari()
-    {
+
+    public SauceOptions withSafari() {
         return withMac(MacVersion.Mojave);
     }
 
@@ -32,32 +32,36 @@ public class SauceOptions {
 
     public SauceOptions withSafari(final String version) {
         String _version = version;
-        if (_version.isEmpty()) { _version = "latest"; }
+        if (_version.isEmpty()) {
+            _version = "latest";
+        }
         browserName = BrowserType.SAFARI;
         browserVersion = _version;
         return this;
     }
 
     public SauceOptions withLinux() {
-        operatingSystem = "Linux";
+        platformName = "Linux";
         return this;
     }
 
     public SauceOptions withWindows10() {
-        operatingSystem = "windows 10";
+        platformName = "Windows 10";
         return this;
     }
+
     public SauceOptions withWindows8_1() {
-        operatingSystem = "Windows 8.1";
+        platformName = "Windows 8.1";
         return this;
     }
+
     public SauceOptions withWindows8() {
-        operatingSystem = "Windows 8";
+        platformName = "Windows 8";
         return this;
     }
 
     public SauceOptions withWindows7() {
-        operatingSystem = "Windows 7";
+        platformName = "Windows 7";
         return this;
     }
 
@@ -75,11 +79,13 @@ public class SauceOptions {
         browserVersion = "18.17763";
         return this;
     }
+
     public SauceOptions withEdge17() {
         withEdge();
         browserVersion = "17.17134";
         return this;
     }
+
     public SauceOptions withEdge16() {
         withEdge();
         browserVersion = "16.16299";
@@ -105,7 +111,7 @@ public class SauceOptions {
     }
 
     public SauceOptions withFirefox() {
-        browserName = "Firefox";
+        browserName = "firefox";
         return this;
     }
 
@@ -127,7 +133,7 @@ public class SauceOptions {
     }
 
     public SauceOptions withMac(MacVersion macVersion) {
-        operatingSystem = macVersion.label;
+        platformName = macVersion.label;
         browserName = "Safari";
         return this;
     }

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
@@ -96,7 +96,7 @@ public class SauceSession {
     private MutableCapabilities setRemoteDriverCapabilities(MutableCapabilities sauceOptions) {
         currentSessionCapabilities.setCapability(sauceOptionsTag, sauceOptions);
         currentSessionCapabilities.setCapability(CapabilityType.BROWSER_NAME, this.sauceOptions.getBrowserName());
-        currentSessionCapabilities.setCapability(CapabilityType.PLATFORM_NAME, this.sauceOptions.getOperatingSystem());
+        currentSessionCapabilities.setCapability(CapabilityType.PLATFORM_NAME, this.sauceOptions.getPlatformName());
         currentSessionCapabilities.setCapability(CapabilityType.BROWSER_VERSION, this.sauceOptions.getBrowserVersion());
         return currentSessionCapabilities;
     }

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
@@ -6,13 +6,7 @@ import lombok.Setter;
 import org.openqa.selenium.InvalidArgumentException;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.edge.EdgeOptions;
-import org.openqa.selenium.firefox.FirefoxOptions;
-import org.openqa.selenium.ie.InternetExplorerOptions;
-import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.RemoteWebDriver;
-import org.openqa.selenium.safari.SafariOptions;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -20,20 +14,12 @@ import java.net.URL;
 public class SauceSession {
     @Getter @Setter private DataCenter dataCenter = DataCenter.US_WEST;
     @Getter private final SauceOptions sauceOptions;
-    @Getter private final SauceTimeout timeouts = new SauceTimeout();
     @Getter @Setter private String username;
     @Getter @Setter private String accessKey;
     @Setter private URL sauceUrl;
-    private final String sauceOptionsTag = "sauce:options";
 
-    //TODO 2 same variables being used differently
-    private MutableCapabilities mutableCapabilities;
     @Getter private MutableCapabilities currentSessionCapabilities;
-    @Getter private WebDriver driver;
-
-    public MutableCapabilities getSauceOptionsCapability(){
-        return ((MutableCapabilities) currentSessionCapabilities.getCapability(sauceOptionsTag));
-    }
+    @Getter private RemoteWebDriver driver;
 
     public SauceSession() {
         this(new SauceOptions());
@@ -41,65 +27,12 @@ public class SauceSession {
 
     public SauceSession(SauceOptions options) {
         sauceOptions = options;
-        currentSessionCapabilities = new MutableCapabilities();
     }
 
-    public WebDriver start() {
-        mutableCapabilities = appendSauceCapabilities();
-        setBrowserSpecificCapabilities(sauceOptions.getBrowserName());
-        currentSessionCapabilities = setRemoteDriverCapabilities(mutableCapabilities);
-        sauceUrl = getSauceUrl();
-        driver = createRemoteWebDriver();
+    public RemoteWebDriver start() {
+        driver = createRemoteWebDriver(getSauceUrl(), sauceOptions.toCapabilities());
         return driver;
 	}
-
-    private MutableCapabilities appendSauceCapabilities() {
-        mutableCapabilities = new MutableCapabilities();
-        if (timeouts.getCommandTimeout() != 0) {
-            mutableCapabilities.setCapability("commandTimeout", timeouts.getCommandTimeout());
-        }
-        if (timeouts.getIdleTimeout() != 0) {
-            mutableCapabilities.setCapability("idleTimeout", timeouts.getIdleTimeout());
-        }
-        if (timeouts.getMaxTestDurationTimeout() != 0) {
-            mutableCapabilities.setCapability("maxDuration", timeouts.getMaxTestDurationTimeout());
-        }
-        return mutableCapabilities;
-    }
-
-    private void setBrowserSpecificCapabilities(String browserName) {
-        if (browserName.equalsIgnoreCase("Chrome")) {
-            ChromeOptions chromeOptions = new ChromeOptions();
-            currentSessionCapabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
-        }
-        else if (browserName.equalsIgnoreCase("Firefox")) {
-            FirefoxOptions firefoxOptions = new FirefoxOptions();
-            currentSessionCapabilities.setCapability(FirefoxOptions.FIREFOX_OPTIONS, firefoxOptions);
-        }
-        else if(browserName.equalsIgnoreCase("Safari")) {
-            SafariOptions safariOptions = new SafariOptions();
-            currentSessionCapabilities.setCapability(SafariOptions.CAPABILITY, safariOptions);
-        }
-        else if(browserName.equalsIgnoreCase("Edge")) {
-            EdgeOptions edgeOptions = new EdgeOptions();
-            currentSessionCapabilities.setCapability("Edge", edgeOptions);
-        }
-        else if(browserName.equalsIgnoreCase("IE")) {
-            InternetExplorerOptions ieOptions = new InternetExplorerOptions();
-            currentSessionCapabilities.setCapability("se:ieOptions", ieOptions);
-        }
-        else {
-            throw new IllegalArgumentException("The browserName=>" + browserName + " that you passed in is not a valid option.");
-        }
-    }
-
-    private MutableCapabilities setRemoteDriverCapabilities(MutableCapabilities sauceOptions) {
-        currentSessionCapabilities.setCapability(sauceOptionsTag, sauceOptions);
-        currentSessionCapabilities.setCapability(CapabilityType.BROWSER_NAME, this.sauceOptions.getBrowserName());
-        currentSessionCapabilities.setCapability(CapabilityType.PLATFORM_NAME, this.sauceOptions.getPlatformName());
-        currentSessionCapabilities.setCapability(CapabilityType.BROWSER_VERSION, this.sauceOptions.getBrowserVersion());
-        return currentSessionCapabilities;
-    }
 
     public URL getSauceUrl() {
         if (sauceUrl != null) {
@@ -114,12 +47,12 @@ public class SauceSession {
         }
     }
 
-    protected RemoteWebDriver createRemoteWebDriver() {
-        return new RemoteWebDriver(getSauceUrl(), currentSessionCapabilities);
+    protected RemoteWebDriver createRemoteWebDriver(URL url, MutableCapabilities capabilities) {
+        return new RemoteWebDriver(url, capabilities);
     }
 
     protected JavascriptExecutor getJSExecutor() {
-        return (JavascriptExecutor) driver;
+        return driver;
     }
 
     public void stop(Boolean passed) {

--- a/java/src/test/java/com/saucelabs/simplesauce/BaseConfigurationTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/BaseConfigurationTest.java
@@ -3,28 +3,10 @@ package com.saucelabs.simplesauce;
 import org.junit.Rule;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.openqa.selenium.remote.RemoteWebDriver;
-
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 
 public class BaseConfigurationTest {
-    protected SauceSession sauce;
     protected SauceOptions sauceOptions = new SauceOptions();
-    protected RemoteWebDriver dummyRemoteDriver = mock(RemoteWebDriver.class);
 
     @Rule
     public MockitoRule initRule = MockitoJUnit.rule();
-
-    protected SauceSession instantiateSauceSession() {
-        sauce = spy(new SauceSession(sauceOptions));
-        doReturn(dummyRemoteDriver).when(sauce).createRemoteWebDriver();
-        return sauce;
-    }
-
-    protected void startSauceSession() {
-        instantiateSauceSession();
-        sauce.start();
-    }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/EdgeTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/EdgeTest.java
@@ -1,7 +1,6 @@
 package com.saucelabs.simplesauce;
 
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 
@@ -9,9 +8,8 @@ public class EdgeTest extends BaseConfigurationTest {
     @Test
     public void withEdge_default() {
         sauceOptions.withEdge();
-        startSauceSession();
 
-        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
+        String actualBrowserSetInConfig = sauceOptions.getBrowserVersion();
         assertEquals("18.17763", actualBrowserSetInConfig);
     }
 
@@ -19,54 +17,47 @@ public class EdgeTest extends BaseConfigurationTest {
     public void withEdge18_returnsBrowserVersion18_17763() {
         sauceOptions.withEdge18();
 
-        startSauceSession();
-        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
+        String actualBrowserSetInConfig = sauceOptions.getBrowserVersion();
         assertEquals("18.17763", actualBrowserSetInConfig);
     }
 
     @Test
     public void withEdge17_returnsBrowserVersion17_17134() {
         sauceOptions.withEdge17();
-        startSauceSession();
 
-        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
+        String actualBrowserSetInConfig = sauceOptions.getBrowserVersion();
         assertEquals("17.17134", actualBrowserSetInConfig);
     }
 
     @Test
     public void withEdge16_returnsBrowserVersion16_16299() {
         sauceOptions.withEdge16();
-        startSauceSession();
 
-        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
+        String actualBrowserSetInConfig = sauceOptions.getBrowserVersion();
         assertEquals("16.16299", actualBrowserSetInConfig);
     }
 
     @Test
     public void withEdge15_returnsBrowserVersion15_15063() {
         sauceOptions.withEdge15();
-        startSauceSession();
 
-        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
+        String actualBrowserSetInConfig = sauceOptions.getBrowserVersion();
         assertEquals("15.15063", actualBrowserSetInConfig);
     }
 
     @Test
     public void withEdge14_returnsBrowserVersion14_14393() {
         sauceOptions.withEdge14();
-        startSauceSession();
 
-        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
+        String actualBrowserSetInConfig = sauceOptions.getBrowserVersion();
         assertEquals("14.14393", actualBrowserSetInConfig);
     }
 
     @Test
     public void withEdge13_returnsBrowserVersion13_10586() {
         sauceOptions.withEdge13();
-        startSauceSession();
-        Mockito.doReturn(dummyRemoteDriver).when(sauce).createRemoteWebDriver();
 
-        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
+        String actualBrowserSetInConfig = sauceOptions.getBrowserVersion();
         assertEquals("13.10586", actualBrowserSetInConfig);
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/IETest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/IETest.java
@@ -8,27 +8,24 @@ public class IETest extends BaseConfigurationTest {
     @Test
     public void withIE_validIeVersionEnum() {
         sauceOptions.withIE(IEVersion._11);
-        startSauceSession();
 
-        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
+        String actualBrowserSetInConfig = sauceOptions.getBrowserVersion();
         assertEquals("11.285", actualBrowserSetInConfig);
     }
 
     @Test
     public void withIE_validIeVersionString() {
         sauceOptions.withIE(IEVersion._11.getVersion());
-        startSauceSession();
 
-        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
+        String actualBrowserSetInConfig = sauceOptions.getBrowserVersion();
         assertEquals("11.285", actualBrowserSetInConfig);
     }
 
     @Test
     public void withIE_default() {
         sauceOptions.withIE();
-        startSauceSession();
 
-        String actualBrowserSetInConfig = sauce.getCurrentSessionCapabilities().getVersion();
+        String actualBrowserSetInConfig = sauceOptions.getBrowserVersion();
         assertEquals("latest", actualBrowserSetInConfig);
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/LinuxTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/LinuxTest.java
@@ -8,9 +8,8 @@ public class LinuxTest extends BaseConfigurationTest {
     @Test
     public void withLinux_setsPlatformToLinux() {
         sauceOptions.withLinux();
-        startSauceSession();
 
-        String actualOsSetInConfig = sauce.getCurrentSessionCapabilities().getPlatform().toString();
+        String actualOsSetInConfig = sauceOptions.getPlatformName();
         assertEquals("linux", actualOsSetInConfig.toLowerCase());
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/MacOsTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/MacOsTest.java
@@ -26,70 +26,56 @@ public class MacOsTest extends BaseConfigurationTest {
     @UseDataProvider("expectedMacOsVersions")
     public void withMacOs_returnsValidOsConfiguration(MacVersion version, String expectedMacOsVersion) {
         sauceOptions.withMac(version);
-        startSauceSession();
 
-        String actualOsThatWasSet = getSessionPlatformString();
+        String actualOsThatWasSet = sauceOptions.getPlatformName();
         assertEquals(expectedMacOsVersion, actualOsThatWasSet);
-    }
-
-    private String getSessionPlatformString() {
-        return sauce.getCurrentSessionCapabilities().getPlatform().toString();
     }
 
     @Test
     public void defaultSafari_browserVersionIs12_0() {
         sauceOptions.withSafari();
-        startSauceSession();
 
-        //TODO mockSauceSession.sauceSessionCapabilities can be turned into a method, maybe on the session
-        //class that allows easier access to the caps
-        String safariVersionSetThroughSauceSession = sauce.getCurrentSessionCapabilities().getVersion();
-        assertEquals("latest", safariVersionSetThroughSauceSession);
+        String actualBrowserVersionSetInConfig = sauceOptions.getBrowserVersion();
+        assertEquals("latest", actualBrowserVersionSetInConfig);
     }
 
     @Test
     public void defaultSafari_macOsVersionIsMojave() {
         sauceOptions.withSafari();
-        startSauceSession();
 
-        String safariVersionSetThroughSauceSession = getSessionPlatformString();
-        assertEquals(Platforms.MAC_OS.MOJAVE.getPlatform().getOsVersion(), safariVersionSetThroughSauceSession);
+        String actualPlatformSetInConfig = sauceOptions.getPlatformName();
+        assertEquals(Platforms.MAC_OS.MOJAVE.getPlatform().getOsVersion(), actualPlatformSetInConfig);
     }
 
     @Test
     public void withSafari_browserName_setToSafariEnum() {
         sauceOptions.withSafari(SafariVersion._8);
-        startSauceSession();
 
-        String actualBrowserNameSetThroughSauceSession = sauce.getCurrentSessionCapabilities().getBrowserName();
+        String actualBrowserNameSetThroughSauceSession = sauceOptions.getBrowserName();
         assertEquals("safari", actualBrowserNameSetThroughSauceSession);
     }
 
     @Test
     public void withSafari_browserName_setToSafariString() {
         sauceOptions.withSafari(SafariVersion._8.getVersion());
-        startSauceSession();
 
-        String actualBrowserNameSetThroughSauceSession = sauce.getCurrentSessionCapabilities().getBrowserName();
+        String actualBrowserNameSetThroughSauceSession = sauceOptions.getBrowserName();
         assertEquals("safari", actualBrowserNameSetThroughSauceSession);
     }
 
     @Test
     public void withSafari_versionChangedFromDefault_returnsCorrectVersion() {
         sauceOptions.withSafari(SafariVersion._8);
-        startSauceSession();
 
-        String actualBrowserVersionSetThroughSauceSession = sauce.getCurrentSessionCapabilities().getVersion();
+        String actualBrowserVersionSetThroughSauceSession = sauceOptions.getBrowserVersion();
         assertEquals("8.0", actualBrowserVersionSetThroughSauceSession);
     }
 
     @Test
     public void withSafari_versionNotSet_returnsLatest() {
         sauceOptions.withSafari("");
-        startSauceSession();
 
-        String actualBrowserVersionSetThroughSauceSession =
-                sauce.getCurrentSessionCapabilities().getVersion();
+        String actualBrowserVersionSetThroughSauceSession = sauceOptions.getBrowserVersion();
         assertEquals("latest", actualBrowserVersionSetThroughSauceSession);
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
@@ -3,8 +3,13 @@ package com.saucelabs.simplesauce;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.PageLoadStrategy;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.ie.InternetExplorerOptions;
 import org.openqa.selenium.remote.BrowserType;
+import org.openqa.selenium.safari.SafariOptions;
 
 import java.util.HashMap;
 
@@ -43,7 +48,30 @@ public class SauceOptionsTest extends BaseConfigurationTest{
     }
 
     @Test
-    public void acceptsSeleniumBrowserOptionsClass() {
+    public void acceptsChromeOptionsClass() {
+        ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.addArguments("--foo");
+        chromeOptions.setUnhandledPromptBehaviour(DISMISS);
+
+        sauceOptions = new SauceOptions(chromeOptions);
+
+        assertEquals("chrome", sauceOptions.getBrowserName());
+        assertEquals(chromeOptions, sauceOptions.getSeleniumCapabilities());
+    }
+
+    @Test
+    public void acceptsEdgeOptionsClass() {
+        EdgeOptions edgeOptions = new EdgeOptions();
+        edgeOptions.setPageLoadStrategy("eager");
+
+        sauceOptions = new SauceOptions(edgeOptions);
+
+        assertEquals("MicrosoftEdge", sauceOptions.getBrowserName());
+        assertEquals(edgeOptions, sauceOptions.getSeleniumCapabilities());
+    }
+
+    @Test
+    public void acceptsFirefoxOptionsClass() {
         FirefoxOptions firefoxOptions = new FirefoxOptions();
         firefoxOptions.addArguments("--foo");
         firefoxOptions.addPreference("foo", "bar");
@@ -56,14 +84,28 @@ public class SauceOptionsTest extends BaseConfigurationTest{
     }
 
     @Test
-    public void acceptsSeleniumMutableCapabilitiesClass() {
-        MutableCapabilities caps = new MutableCapabilities();
-        caps.setCapability("browserName", "firefox");
-        SauceOptions sauceOptions = new SauceOptions(caps);
-        assertEquals(caps, sauceOptions.getSeleniumCapabilities());
+    public void acceptsInternetExplorerOptionsClass() {
+        InternetExplorerOptions internetExplorerOptions = new InternetExplorerOptions();
+        internetExplorerOptions.requireWindowFocus();
+        internetExplorerOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
+        internetExplorerOptions.setUnhandledPromptBehaviour(DISMISS);
 
-        caps.setCapability("browserName", "chrome");
-        assertEquals("firefox", sauceOptions.getSeleniumCapabilities().getBrowserName());
+        sauceOptions = new SauceOptions(internetExplorerOptions);
+
+        assertEquals("internet explorer", sauceOptions.getBrowserName());
+        assertEquals(internetExplorerOptions, sauceOptions.getSeleniumCapabilities());
+    }
+
+    @Test
+    public void acceptsSafariOptionsClass() {
+        SafariOptions safariOptions = new SafariOptions();
+        safariOptions.setAutomaticInspection(true);
+        safariOptions.setAutomaticProfiling(true);
+
+        sauceOptions = new SauceOptions(safariOptions);
+
+        assertEquals("safari", sauceOptions.getBrowserName());
+        assertEquals(safariOptions, sauceOptions.getSeleniumCapabilities());
     }
 
     @Test

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
@@ -9,6 +9,8 @@ import org.openqa.selenium.remote.BrowserType;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.openqa.selenium.UnexpectedAlertBehaviour.DISMISS;
 
 public class SauceOptionsTest extends BaseConfigurationTest{
@@ -70,13 +72,19 @@ public class SauceOptionsTest extends BaseConfigurationTest{
     }
 
     @Test
-    @Ignore("Not Implemented Yet")
     public void allowsBuildToBeSet() {
+        sauceOptions.setBuild("Manual Build Set");
+        assertEquals("Manual Build Set", sauceOptions.getBuild());
     }
 
     @Test
-    @Ignore("Not Implemented Yet")
     public void createsDefaultBuildName() {
+        SauceOptions sauceOptions = spy(new SauceOptions());
+        doReturn("Not Empty").when(sauceOptions).getEnvironmentVariable("BUILD_TAG");
+        doReturn("TEMP BUILD").when(sauceOptions).getEnvironmentVariable("BUILD_NAME");
+        doReturn("11").when(sauceOptions).getEnvironmentVariable("BUILD_NUMBER");
+
+        assertEquals("TEMP BUILD: 11", sauceOptions.getBuild());
     }
 
     // TODO: This needs to get fleshed out a lot more

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
@@ -20,7 +20,7 @@ public class SauceOptionsTest {
 
     @Test
     public void sauceOptions_defaultOS_setToWindows() {
-        assertEquals("Windows 10", options.getOperatingSystem());
+        assertEquals("Windows 10", options.getPlatformName());
     }
 
     @Test

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
@@ -1,31 +1,108 @@
 package com.saucelabs.simplesauce;
 
+import org.junit.Ignore;
 import org.junit.Test;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.remote.BrowserType;
+
+import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.openqa.selenium.UnexpectedAlertBehaviour.DISMISS;
 
-public class SauceOptionsTest {
-    private SauceOptions options = new SauceOptions();
-
+public class SauceOptionsTest extends BaseConfigurationTest{
     @Test
-    public void sauceOptions_defaultBrowser_setToChrome() {
-        assertEquals("chrome", options.getBrowserName());
+    public void usesLatestChromeWindowsVersions() {
+        assertEquals(BrowserType.CHROME, sauceOptions.getBrowserName());
+        assertEquals("Windows 10", sauceOptions.getPlatformName());
+        assertEquals("latest", sauceOptions.getBrowserVersion());
     }
 
     @Test
-    public void sauceOptions_defaultBrowserVersion_setToLatest() {
-        assertEquals("latest", options.getBrowserVersion());
+    public void updatesBrowserBrowserVersionPlatformVersionValues() {
+        sauceOptions.setBrowserName(BrowserType.FIREFOX);
+        sauceOptions.setPlatformName(Platforms.MAC_OS_HIGH_SIERRA.getOsVersion());
+        sauceOptions.setBrowserVersion("68");
+
+        assertEquals(BrowserType.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals("68", sauceOptions.getBrowserVersion());
+        assertEquals("macOS 10.13", sauceOptions.getPlatformName());
     }
 
     @Test
-    public void sauceOptions_defaultOS_setToWindows() {
-        assertEquals("Windows 10", options.getPlatformName());
+    @Ignore("Not Implemented Yet")
+    public void acceptsOtherW3CValues() {
     }
 
     @Test
-    public void withChrome_browser_setToChrome() {
-        options.withChrome();
-        assertNotNull(options.getChromeOptions());
+    @Ignore("Not Implemented Yet")
+    public void acceptsSauceLabsSettings() {
+    }
+
+    @Test
+    public void acceptsSeleniumBrowserOptionsClass() {
+        FirefoxOptions firefoxOptions = new FirefoxOptions();
+        firefoxOptions.addArguments("--foo");
+        firefoxOptions.addPreference("foo", "bar");
+        firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
+
+        sauceOptions = new SauceOptions(firefoxOptions);
+
+        assertEquals("firefox", sauceOptions.getBrowserName());
+        assertEquals(firefoxOptions, sauceOptions.getSeleniumCapabilities());
+    }
+
+    @Test
+    public void acceptsSeleniumMutableCapabilitiesClass() {
+        MutableCapabilities caps = new MutableCapabilities();
+        caps.setCapability("browserName", "firefox");
+        SauceOptions sauceOptions = new SauceOptions(caps);
+        assertEquals(caps, sauceOptions.getSeleniumCapabilities());
+
+        caps.setCapability("browserName", "chrome");
+        assertEquals("firefox", sauceOptions.getSeleniumCapabilities().getBrowserName());
+    }
+
+    @Test
+    @Ignore("Not Implemented Yet")
+    public void setsCapabilitiesFromMap() {
+    }
+
+    @Test
+    @Ignore("Not Implemented Yet")
+    public void allowsBuildToBeSet() {
+    }
+
+    @Test
+    @Ignore("Not Implemented Yet")
+    public void createsDefaultBuildName() {
+    }
+
+    // TODO: This needs to get fleshed out a lot more
+    @Test
+    public void parsesW3CAndSauceAndSeleniumSettings() {
+        FirefoxOptions firefoxOptions = new FirefoxOptions();
+        firefoxOptions.addArguments("--foo");
+        firefoxOptions.addPreference("foo", "bar");
+        firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
+
+        sauceOptions = new SauceOptions(firefoxOptions);
+
+        sauceOptions.setBrowserName(BrowserType.FIREFOX);
+        sauceOptions.setPlatformName(Platforms.MAC_OS_HIGH_SIERRA.getOsVersion());
+        sauceOptions.setBrowserVersion("68");
+
+        MutableCapabilities expectedCaps = new MutableCapabilities();
+        expectedCaps.setCapability("acceptInsecureCerts", true);
+        expectedCaps.setCapability("browserName", "firefox");
+        expectedCaps.setCapability("browserVersion", "68");
+        expectedCaps.setCapability("platformName", "macOS 10.13");
+        expectedCaps.setCapability("unhandledPromptBehavior", DISMISS);
+        expectedCaps.setCapability("sauce:options", new HashMap<>());
+        expectedCaps.setCapability("moz:firefoxOptions", firefoxOptions.toJson().get("moz:firefoxOptions"));
+
+        MutableCapabilities actualCaps = sauceOptions.toCapabilities();
+        assertEquals(expectedCaps, actualCaps);
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
@@ -7,21 +7,26 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.remote.BrowserType;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class SauceSessionTest {
-    private SauceSession sauce;
+    private SauceSession sauceSession = spy(new SauceSession());
     private RemoteWebDriver dummyRemoteDriver = mock(RemoteWebDriver.class);
-    private SauceOptions options = new SauceOptions();
     private JavascriptExecutor dummyJSExecutor = mock(JavascriptExecutor.class);
 
     @Rule
@@ -29,142 +34,120 @@ public class SauceSessionTest {
 
     @Before
     public void setUp() {
-        sauce = spy(new SauceSession());
-        doReturn(dummyRemoteDriver).when(sauce).createRemoteWebDriver();
+        doReturn(dummyRemoteDriver).when(sauceSession).createRemoteWebDriver(any(URL.class), any(MutableCapabilities.class));
     }
 
     @Test
-    public void sauceSession_defaultSauceOptions_returnsChromeBrowser() {
-        sauce.start();
-        String actualBrowser = sauce.getCurrentSessionCapabilities().getCapability("browserName").toString();
-        assertEquals("chrome", actualBrowser);
+    public void sauceSessionDefaultsToLatestChromeOnWindows() {
+        String actualBrowser = sauceSession.getSauceOptions().getBrowserName();
+        String actualBrowserVersion = sauceSession.getSauceOptions().getBrowserVersion();
+        String actualPlatformName = sauceSession.getSauceOptions().getPlatformName();
+
+        assertEquals(BrowserType.CHROME, actualBrowser);
+        assertEquals("Windows 10", actualPlatformName);
+        assertEquals("latest", actualBrowserVersion);
     }
 
     @Test
-    public void startSession_defaultConfig_usWestDataCenter() {
-        DataCenter expectedDataCenter = DataCenter.US_WEST;
-        assertEquals(expectedDataCenter.getEndpoint(), sauce.getDataCenter().getEndpoint());
+    public void sauceSessionUsesProvidedSauceOptions() {
+        SauceOptions sauceOptions = spy(new SauceOptions());
+        MutableCapabilities caps = sauceOptions.toCapabilities();
+
+        sauceSession = spy(new SauceSession(sauceOptions));
+        doReturn(dummyRemoteDriver).when(sauceSession).createRemoteWebDriver(anyObject(), eq(caps));
+
+        sauceSession.start();
+
+        verify(sauceOptions, times(2)).toCapabilities();
     }
 
     @Test
-    public void allowsChangingDefaultDataCenter() {
-        DataCenter expectedDataCenter = DataCenter.US_EAST;
-        sauce.setDataCenter(DataCenter.US_EAST);
-        assertEquals(expectedDataCenter.getEndpoint(), sauce.getDataCenter().getEndpoint());
+    public void defaultsToUSWestDataCenter() {
+        String expectedDataCenterEndpoint = DataCenter.US_WEST.getEndpoint();
+        assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getEndpoint());
+    }
+
+    @Test
+    public void setsDataCenter() {
+        String expectedDataCenterEndpoint = DataCenter.US_EAST.getEndpoint();
+        sauceSession.setDataCenter(DataCenter.US_EAST);
+        assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getEndpoint());
     }
 
     @Test
     public void defaultSauceURLUsesENVForUsernameAccessKey() {
-        doReturn("test-name").when(sauce).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("accesskey").when(sauce).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        doReturn("test-name").when(sauceSession).getEnvironmentVariable("SAUCE_USERNAME");
+        doReturn("accesskey").when(sauceSession).getEnvironmentVariable("SAUCE_ACCESS_KEY");
 
         String expetedSauceUrl = "https://test-name:accesskey@ondemand.us-west-1.saucelabs.com/wd/hub";
-        assertEquals(expetedSauceUrl, sauce.getSauceUrl().toString());
+        assertEquals(expetedSauceUrl, sauceSession.getSauceUrl().toString());
+    }
+
+    @Test
+    public void setUserNameAndAccessKey() {
+        sauceSession.setUsername("test-username");
+        sauceSession.setAccessKey("test-accesskey");
+
+        String expetedSauceUrl = "https://test-username:test-accesskey@ondemand.us-west-1.saucelabs.com/wd/hub";
+        assertEquals(expetedSauceUrl, sauceSession.getSauceUrl().toString());
     }
 
     @Test
     public void setsSauceURLDirectly() throws MalformedURLException {
-        sauce.setSauceUrl(new URL("http://example.com"));
+        sauceSession.setSauceUrl(new URL("http://example.com"));
         String expetedSauceUrl = "http://example.com";
-        assertEquals(expetedSauceUrl, sauce.getSauceUrl().toString());
-    }
-
-    @Test
-    public void startSession_setsBrowserKey() {
-        sauce.start();
-
-        String expectedBrowserCapabilityKey = "browserName";
-        String actualBrowser = sauce.getCurrentSessionCapabilities().getCapability(expectedBrowserCapabilityKey).toString();
-        assertNotEquals("", actualBrowser);
-    }
-
-    @Test
-    public void start_setsPlatformNameKey() {
-        sauce.start();
-
-        String correctPlatformKey = "platformName";
-        String browserSetInSauceSession = sauce.getCurrentSessionCapabilities().getCapability(correctPlatformKey).toString();
-        assertEquals("Windows 10", browserSetInSauceSession);
-    }
-
-    @Test
-    public void defaultBrowserIsLatest() {
-        sauce.start();
-
-        String correctKey = "browserVersion";
-        String browserSetThroughSauceSession = sauce.getCurrentSessionCapabilities().getCapability(correctKey).toString();
-        assertEquals("latest", browserSetThroughSauceSession);
-    }
-
-    @Test
-    public void defaultIsChrome() {
-        sauce.start();
-
-        String actualBrowser = sauce.getCurrentSessionCapabilities().getBrowserName();
-        assertEquals("chrome", actualBrowser);
-    }
-
-    @Test
-    public void defaultIsWindows10() {
-        sauce.start();
-
-        String actualOs = sauce.getCurrentSessionCapabilities().getPlatform().name();
-        assertEquals("WIN10", actualOs);
-    }
-
-    @Test
-    public void sauceOptions_startWithChrome_startsChrome() {
-        options.withChrome();
-
-        sauce = spy(new SauceSession(options));
-        doReturn(dummyRemoteDriver).when(sauce).createRemoteWebDriver();
-        sauce.start();
-
-        String actualBrowser = sauce.getCurrentSessionCapabilities().getBrowserName();
-        assertEquals("chrome", actualBrowser);
+        assertEquals(expetedSauceUrl, sauceSession.getSauceUrl().toString());
     }
 
     @Test(expected = SauceEnvironmentVariablesNotSetException.class)
     public void startThrowsErrorWithoutUsername() {
-        doReturn(null).when(sauce).getEnvironmentVariable("SAUCE_USERNAME");
-        sauce.start();
+        doReturn(null).when(sauceSession).getEnvironmentVariable("SAUCE_USERNAME");
+        sauceSession.start();
     }
 
     @Test(expected = SauceEnvironmentVariablesNotSetException.class)
     public void startThrowsErrorWithoutAccessKey() {
-        doReturn(null).when(sauce).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-        sauce.start();
+        doReturn(null).when(sauceSession).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        sauceSession.start();
+    }
+
+    @Test
+    public void stopCallsDriverQuitPassing() {
+        sauceSession.start();
+        sauceSession.stop(true);
+
+        verify(dummyRemoteDriver).quit();
     }
 
     @Test
     public void stopWithBooleanTrue() {
-        doReturn(dummyJSExecutor).when(sauce).getJSExecutor();
-        sauce.start();
-        sauce.stop(true);
+        doReturn(dummyJSExecutor).when(sauceSession).getJSExecutor();
+        sauceSession.start();
+        sauceSession.stop(true);
         verify(dummyJSExecutor).executeScript("sauce:job-result=passed");
     }
 
     @Test
     public void stopWithBooleanFalse() {
-        doReturn(dummyJSExecutor).when(sauce).getJSExecutor();
-        sauce.start();
-        sauce.stop(false);
+        doReturn(dummyJSExecutor).when(sauceSession ).getJSExecutor();
+        sauceSession .start();
+        sauceSession .stop(false);
         verify(dummyJSExecutor).executeScript("sauce:job-result=failed");
     }
 
     @Test
     public void stopWithStringPassed() {
-        doReturn(dummyJSExecutor).when(sauce).getJSExecutor();
-        sauce.start();
-        sauce.stop("passed");
+        doReturn(dummyJSExecutor).when(sauceSession ).getJSExecutor();
+        sauceSession .start();
+        sauceSession .stop("passed");
         verify(dummyJSExecutor).executeScript("sauce:job-result=passed");
     }
 
     @Test
     public void stopWithStringFailed() {
-        doReturn(dummyJSExecutor).when(sauce).getJSExecutor();
-        sauce.start();
-        sauce.stop("failed");
+        doReturn(dummyJSExecutor).when(sauceSession ).getJSExecutor();
+        sauceSession .start();
+        sauceSession .stop("failed");
         verify(dummyJSExecutor).executeScript("sauce:job-result=failed");
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/TimeoutTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/TimeoutTest.java
@@ -1,55 +1,37 @@
 package com.saucelabs.simplesauce;
 
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
-import org.openqa.selenium.MutableCapabilities;
 
 import static org.junit.Assert.assertEquals;
 
 public class TimeoutTest extends BaseConfigurationTest {
-    @Before
-    public void mockSession() {
-        sauce = Mockito.spy(new SauceSession(sauceOptions));
-        Mockito.doReturn(dummyRemoteDriver).when(sauce).createRemoteWebDriver();
-    }
+    private SauceTimeout sauceTimeout = sauceOptions.getSauceTimeout();
 
     @Test
     public void commandTimeout_canBeSet() {
-        sauce.getTimeouts().setCommandTimeout(100);
-        sauce.start();
-        assertCorrectCommandSetOnRemoteSession("commandTimeout", 100);
-    }
-
-    private void assertCorrectCommandSetOnRemoteSession(String commandTimeout, int expectedTimeout) {
-        Object sauceOptions = sauce.getCurrentSessionCapabilities().asMap().get("sauce:options");
-        Object commandTimeoutSetInCaps = ((MutableCapabilities) sauceOptions).getCapability(commandTimeout);
-        assertEquals(expectedTimeout, commandTimeoutSetInCaps);
+        sauceTimeout.setCommandTimeout(100);
+        assertEquals(sauceTimeout.getCommandTimeout(), 100);
     }
 
     @Test
     public void idleTimeout_canBeSet() {
-        sauce.getTimeouts().setIdleTimeout(100);
-        sauce.start();
-        assertCorrectCommandSetOnRemoteSession("idleTimeout", 100);
+        int idleTimeout = 100;
+
+        sauceTimeout.setIdleTimeout(idleTimeout);
+        assertEquals(idleTimeout, sauceTimeout.getIdleTimeout());
     }
+
     @Test
     public void maxDuration_canBeSet() throws MaxTestDurationTimeoutExceededException {
         int maxTestDurationInSec = 1800;
-        sauce.getTimeouts().setMaxTestDurationTimeout(maxTestDurationInSec);
-        sauce.start();
-        assertCorrectCommandSetOnRemoteSession("maxDuration", maxTestDurationInSec);
+        sauceTimeout.setMaxTestDurationTimeout(maxTestDurationInSec);
+
+        assertEquals(maxTestDurationInSec, sauceTimeout.getMaxTestDurationTimeout());
     }
+
     @Test(expected = MaxTestDurationTimeoutExceededException.class)
     public void maxDuration_setTo1HigherThanMax_throwsException() throws MaxTestDurationTimeoutExceededException {
         int maxTestDurationInSec = 1801;
-        sauce.getTimeouts().setMaxTestDurationTimeout(maxTestDurationInSec);
-    }
-    @Test()
-    public void maxDuration_setTo1LowerThanMax_noException() throws MaxTestDurationTimeoutExceededException {
-        int maxTestDurationInSec = 1799;
-        sauce.getTimeouts().setMaxTestDurationTimeout(maxTestDurationInSec);
-        sauce.start();
-        assertCorrectCommandSetOnRemoteSession("maxDuration", maxTestDurationInSec);
+        sauceTimeout.setMaxTestDurationTimeout(maxTestDurationInSec);
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/WindowsTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/WindowsTest.java
@@ -8,29 +8,29 @@ public class WindowsTest extends BaseConfigurationTest {
     @Test
     public void withWindows10_setsWindows10Platform() {
         sauceOptions.withWindows10();
-        startSauceSession();
-        String actualOsSetInConfig = sauce.getCurrentSessionCapabilities().getPlatform().toString();
-        assertEquals("WIN10", actualOsSetInConfig);
+
+        String actualOsSetInConfig = sauceOptions.getPlatformName();
+        assertEquals("Windows 10", actualOsSetInConfig);
     }
     @Test
     public void withWindows8_1_setsPlatformToWindows8_1() {
         sauceOptions.withWindows8_1();
-        startSauceSession();
-        String actualOsSetInConfig = sauce.getCurrentSessionCapabilities().getPlatform().toString();
-        assertEquals("WIN8_1", actualOsSetInConfig);
+
+        String actualOsSetInConfig = sauceOptions.getPlatformName();
+        assertEquals("Windows 8.1", actualOsSetInConfig);
     }
     @Test
     public void withWindows8_setsPlatformToWindows8() {
         sauceOptions.withWindows8();
-        startSauceSession();
-        String actualOsSetInConfig = sauce.getCurrentSessionCapabilities().getPlatform().toString();
-        assertEquals("WIN8", actualOsSetInConfig);
+
+        String actualOsSetInConfig = sauceOptions.getPlatformName();
+        assertEquals("Windows 8", actualOsSetInConfig);
     }
     @Test
     public void withWindows7_setsPlatformToWindows7() {
         sauceOptions.withWindows7();
-        startSauceSession();
-        String actualOsSetInConfig = sauce.getCurrentSessionCapabilities().getPlatform().toString();
-        assertEquals("VISTA", actualOsSetInConfig);
+
+        String actualOsSetInConfig = sauceOptions.getPlatformName();
+        assertEquals("Windows 7", actualOsSetInConfig);
     }
 }


### PR DESCRIPTION
EDIT:
This is now based solely on: #98 getting merged, so there will still need to be some rebasing before it is merged, but... I think this includes all the changes to make sure everything is in place.

Note the second `SauceOptions` constructor that takes an instance of a `MutableCapabilities` / browser Options class.

Session only cares about calling `toCapabilities()` on the `SauceOptions` instance. 

I've written out the tests passing in Python & Ruby that we still need to implement.

__________________
So this won't be able to be merged in directly, yet... It is based off of all other open Java PRs (#95 #97 #98). It separates concerns and implements default build name support.

It's pretty much everything except for figuring out the accessors.
I added placeholder specs for the tests we still need to get to pass before we are beta ready.

Note that I'm comparing this to java_merge_prs branch (#99)