### PR TITLE
Selenium Approach to Accessors

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.2</version>
+            <version>1.18.10</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
@@ -135,6 +135,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-scm-plugin</artifactId>
                 <version>1.9.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/java/src/main/java/com/saucelabs/simplesauce/DataCenter.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/DataCenter.java
@@ -2,14 +2,18 @@ package com.saucelabs.simplesauce;
 
 import lombok.Getter;
 
-enum DataCenter {
+public enum DataCenter {
     US_WEST("ondemand.us-west-1.saucelabs.com"),
     US_EAST("ondemand.us-east-1.saucelabs.com"),
     EU_CENTRAL("ondemand.eu-central-1.saucelabs.com");
 
-    @Getter private final String endpoint;
+    @Getter private final String value;
 
-    DataCenter(String endpoint) {
-        this.endpoint = endpoint;
+    DataCenter(String value) {
+        this.value = value;
+    }
+
+    public String toString() {
+        return value;
     }
 }

--- a/java/src/main/java/com/saucelabs/simplesauce/Options.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/Options.java
@@ -1,0 +1,261 @@
+package com.saucelabs.simplesauce;
+
+import lombok.Getter;
+
+import java.util.*;
+
+public class Options {
+    private static final class BrowserLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    private static final class PlatformLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    private static final class PageLoadStrategyLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    private static final class TimeoutsLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    private static final class UnhandledPromptBehaviorLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    private static final class PublicLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    private static final class PreRunLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    public enum PageLoadStrategy {
+        NONE("none"),
+        EAGER("eager"),
+        NORMAL("normal");
+
+        @Getter private String value;
+
+        public static Set keys() {
+            return PageLoadStrategyLookup.lookup.keySet();
+        }
+
+        PageLoadStrategy(String value) {
+            this.value = value;
+            PageLoadStrategyLookup.lookup.put(value.toString(), this.name());
+        }
+
+        public static String fromString(String value) {
+            return PageLoadStrategyLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value.toString();
+        }
+    }
+
+    public enum UnhandledPromptBehavior {
+        DISMISS("dismiss"),
+        ACCEPT("accept"),
+        DISMISS_AND_NOTIFY("dismiss and notify"),
+        ACCEPT_AND_NOTIFY("accept and notify"),
+        IGNORE("ignore");
+
+        @Getter private String value;
+
+        public static Set keys() {
+            return UnhandledPromptBehaviorLookup.lookup.keySet();
+        }
+
+        UnhandledPromptBehavior(String value) {
+            this.value = value;
+            UnhandledPromptBehaviorLookup.lookup.put(value.toString(), this.name());
+        }
+
+        public static String fromString(String value) {
+            return UnhandledPromptBehaviorLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value.toString();
+        }
+    }
+
+    public enum PreRun {
+        EXECUTABLE("executable"),
+        ARGS("args"),
+        BACKGROUND("background"),
+        TIMEOUT("timeout");
+
+        @Getter private String value;
+
+        public static Set keys() {
+            return PreRunLookup.lookup.keySet();
+        }
+
+        PreRun(String value) {
+            this.value = value;
+            PreRunLookup.lookup.put(value, this.name());
+        }
+
+        public static String fromString(String value) {
+            return PreRunLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value.toString();
+        }
+    }
+
+    public enum Public {
+        PUBLIC("public"),
+        PUBLIC_RESTRICTED("public restricted"),
+        SHARE("share"),
+        TEAM("team"),
+        PRIVATE("private");
+
+        @Getter private String value;
+
+        public static Set keys() {
+            return PublicLookup.lookup.keySet();
+        }
+
+        Public(String value) {
+            this.value = value;
+            PublicLookup.lookup.put(value.toString(), this.name());
+        }
+
+        public static String fromString(String value) {
+            return PublicLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value.toString();
+        }
+    }
+
+    public enum Browser {
+        CHROME("chrome"),
+        INTERNET_EXPLORER("internet explorer"),
+        EDGE("MicrosoftEdge"),
+        SAFARI("safari"),
+        FIREFOX("firefox");
+
+        @Getter private final String value;
+
+        public static Set keys() {
+            return BrowserLookup.lookup.keySet();
+        }
+
+        Browser(String value) {
+            this.value = value;
+            BrowserLookup.lookup.put(value, this.name());
+        }
+
+        public static String fromString(String value) {
+            return BrowserLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value;
+        }
+    }
+
+    public enum Timeouts {
+        IMPLICIT("implicit"),
+        PAGE_LOAD("pageLoad"),
+        SCRIPT("script");
+
+        @Getter private final String value;
+
+        public static Set keys() {
+            return TimeoutsLookup.lookup.keySet();
+        }
+
+        Timeouts(String value) {
+            this.value = value;
+            TimeoutsLookup.lookup.put(value, this.name());
+        }
+
+        public static String fromString(String value) {
+            return TimeoutsLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value;
+        }
+    }
+
+    public enum Platform {
+        WINDOWS_10("Windows 10"),
+        WINDOWS_8_1("Windows 8.1"),
+        WINDOWS_8("Windows 8"),
+        MAC_MOJAVE("macOS 10.14"),
+        MAC_HIGH_SIERRA("macOS 10.13"),
+        MAC_SIERRA("macOS 10.12"),
+        MAC_EL_CAPITAN("OS X 10.11"),
+        MAC_YOSEMITE("OS X 10.10");
+
+        @Getter
+        private final String value;
+
+        public static Set keys() {
+            return PlatformLookup.lookup.keySet();
+        }
+
+        Platform(String value) {
+            this.value = value;
+            PlatformLookup.lookup.put(value, this.name());
+        }
+
+        public static String fromString(String value) {
+            return PlatformLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value;
+        }
+    }
+
+    public static final List<String> w3c = List.of(
+            "browserName",
+            "browserVersion",
+            "platformName",
+            "pageLoadStrategy",
+            "acceptInsecureCerts",
+            "proxy",
+            "setWindowRect",
+            "timeouts",
+            "strictFileInteractability",
+            "unhandledPromptBehavior");
+
+    public static final List<String> sauce = List.of(
+            "avoidProxy",
+            "build",
+            "capturePerformance",
+            "chromedriverVersion",
+            "commandTimeout",
+            "customData",
+            "extendedDebugging",
+            "idleTimeout",
+            "iedriverVersion",
+            "maxDuration",
+            "name",
+            "parentTunnel",
+            "prerun",
+            "priority",
+            "public",
+            "recordLogs",
+            "recordScreenshots",
+            "recordVideo",
+            "screenResolution",
+            "seleniumVersion",
+            "tags",
+            "timeZone",
+            "tunnelIdentifier",
+            "videoUploadOnPass");
+}

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
@@ -2,19 +2,23 @@ package com.saucelabs.simplesauce;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.InvalidArgumentException;
 import org.openqa.selenium.MutableCapabilities;
-import org.openqa.selenium.remote.BrowserType;
 import org.openqa.selenium.remote.CapabilityType;
 
 import java.util.HashMap;
+import java.util.Map;
 
+@Accessors(chain = true)
 public class SauceOptions {
     @Getter private MutableCapabilities seleniumCapabilities;
+    private MutableCapabilities sauceCapabilities = new MutableCapabilities();
 
-    @Getter @Setter private String browserName = BrowserType.CHROME;
+    @Getter @Setter private Options.Browser browserName = Options.Browser.CHROME;
     @Getter @Setter private String browserVersion = "latest";
-    @Getter @Setter private String platformName = "Windows 10";
+    @Getter @Setter private Options.Platform platformName = Options.Platform.WINDOWS_10;
     @Setter private String build;
 
     public SauceOptions() {
@@ -24,7 +28,7 @@ public class SauceOptions {
     public SauceOptions(Capabilities capabilities) {
         seleniumCapabilities = new MutableCapabilities(capabilities);
         if (capabilities.getCapability("browserName") != null) {
-            browserName = (String) capabilities.getCapability("browserName");
+           setCapability("browserName", capabilities.getCapability("browserName"));
         }
     }
 
@@ -32,7 +36,10 @@ public class SauceOptions {
         seleniumCapabilities.setCapability(CapabilityType.BROWSER_NAME, browserName);
         seleniumCapabilities.setCapability(CapabilityType.PLATFORM_NAME, platformName);
         seleniumCapabilities.setCapability(CapabilityType.BROWSER_VERSION, browserVersion);
-        seleniumCapabilities.setCapability("sauce:options", new HashMap<>());
+
+        sauceCapabilities.setCapability("build", getBuild());
+        seleniumCapabilities.setCapability("sauce:options", sauceCapabilities);
+
         return seleniumCapabilities;
     }
 
@@ -63,8 +70,65 @@ public class SauceOptions {
         }
     }
 
+    // Use Case is pulling serialized information from JSON/YAML, converting it to a HashMap and passing it in
+    // This is a preferred pattern as it avoids conditionals in code
+    public void setCapabilities(Map<String, Object> capabilities) {
+        capabilities.forEach(this::setCapability);
+    }
+
+    public SauceOptions setCapability(String key, Object value) {
+        if ("browserName".equals(key) && value.getClass().equals(String.class)) {
+            this.browserName = Options.Browser.valueOf(Options.Browser.fromString((String) value));
+        } else if ("browserVersion".equals(key)) {
+            this.browserVersion = (String) value;
+        } else if ("platformName".equals(key) && value.getClass().equals(String.class)) {
+            this.platformName = Options.Platform.valueOf(Options.Platform.fromString((String) value));
+        } else if ("build".equals(key)) {
+            this.build = (String) value;
+        } else if ("pageLoadStrategy".equals(key) && value.getClass().equals(String.class)) {
+            Options.PageLoadStrategy strategy = Options.PageLoadStrategy.valueOf(Options.PageLoadStrategy.fromString((String) value));
+            seleniumCapabilities.setCapability("pageLoadStrategy", strategy);
+        } else if ("unhandledPromptBehavior".equals(key) && value.getClass().equals(String.class)) {
+            Options.UnhandledPromptBehavior behavior = Options.UnhandledPromptBehavior.valueOf(Options.UnhandledPromptBehavior.fromString((String) value));
+            seleniumCapabilities.setCapability("unhandledPromptBehavior", behavior);
+        } else if ("public".equals(key) && value.getClass().equals(String.class)) {
+            Options.Public visiblity = Options.Public.valueOf(Options.Public.fromString((String) value));
+            sauceCapabilities.setCapability("public", visiblity);
+        } else if ("prerun".equals(key) && ((HashMap) value).keySet().toArray()[0].getClass().equals(String.class)) {
+            Map<Options.PreRun, Object> prerunMap = new HashMap<>();
+            ((HashMap) value).forEach((oldKey, val) -> {
+                String keyString = Options.PreRun.fromString((String) oldKey);
+                prerunMap.put(Options.PreRun.valueOf(keyString), val);
+            });
+            sauceCapabilities.setCapability("prerun", prerunMap);
+        } else if ("timeouts".equals(key) && ((HashMap) value).keySet().toArray()[0].getClass().equals(String.class)) {
+            Map<Options.Timeouts, Integer> timeoutMap = new HashMap<>();
+            ((HashMap) value).forEach((oldKey, val) -> {
+                String keyString = Options.Timeouts.fromString((String) oldKey);
+                timeoutMap.put(Options.Timeouts.valueOf(keyString), (Integer) val);
+            });
+            seleniumCapabilities.setCapability("timeouts", timeoutMap);
+        } else if (Options.w3c.contains(key)) {
+            seleniumCapabilities.setCapability(key, value);
+        } else if (Options.sauce.contains(key)) {
+            sauceCapabilities.setCapability(key, value);
+        } else {
+            throw new InvalidArgumentException(key + " is not a known capability");
+        }
+        return this;
+    }
+
+    public Object getCapability(String key) {
+        if (Options.w3c.contains(key)) {
+            return seleniumCapabilities.getCapability(key);
+        } else if (Options.sauce.contains(key)) {
+            return sauceCapabilities.getCapability(key);
+        } else {
+            throw new InvalidArgumentException(key + " is not a known capability");
+        }
+    }
+
     protected String getEnvironmentVariable(String key) {
         return System.getenv(key);
     }
-
 }

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
@@ -40,7 +40,7 @@ public class SauceSession {
         if (sauceUrl != null) {
             return sauceUrl;
         } else {
-            String url = "https://" + getSauceUsername() + ":" + getSauceAccessKey() + "@" + dataCenter.getEndpoint() + "/wd/hub";
+            String url = "https://" + getSauceUsername() + ":" + getSauceAccessKey() + "@" + dataCenter + "/wd/hub";
             try {
                 return new URL(url);
             } catch (MalformedURLException e) {

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
@@ -4,7 +4,11 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.firefox.FirefoxOptions;
-import org.openqa.selenium.remote.BrowserType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
@@ -13,31 +17,80 @@ import static org.openqa.selenium.UnexpectedAlertBehaviour.DISMISS;
 
 public class SauceOptionsTest extends BaseConfigurationTest{
     @Test
-    public void usesLatestChromeWindowsVersions() {
-        assertEquals(BrowserType.CHROME, sauceOptions.getBrowserName());
-        assertEquals("Windows 10", sauceOptions.getPlatformName());
+    public void usesLatestChromeWindowsVersionsByDefault() {
+        assertEquals(Options.Browser.CHROME, sauceOptions.getBrowserName());
+        assertEquals(Options.Platform.WINDOWS_10, sauceOptions.getPlatformName());
         assertEquals("latest", sauceOptions.getBrowserVersion());
     }
 
     @Test
     public void updatesBrowserBrowserVersionPlatformVersionValues() {
-        sauceOptions.setBrowserName(BrowserType.FIREFOX);
-        sauceOptions.setPlatformName("macOS 10.13");
+        sauceOptions.setBrowserName(Options.Browser.FIREFOX);
+        sauceOptions.setPlatformName(Options.Platform.MAC_HIGH_SIERRA);
         sauceOptions.setBrowserVersion("68");
 
-        assertEquals(BrowserType.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals(Options.Browser.FIREFOX, sauceOptions.getBrowserName());
         assertEquals("68", sauceOptions.getBrowserVersion());
-        assertEquals("macOS 10.13", sauceOptions.getPlatformName());
+        assertEquals(Options.Platform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
     }
 
     @Test
-    @Ignore("Not Implemented Yet")
+    public void fluentPatternWorks() {
+        sauceOptions.setBrowserName(Options.Browser.FIREFOX)
+                .setBrowserVersion("68")
+                .setPlatformName(Options.Platform.MAC_HIGH_SIERRA);
+
+        assertEquals(Options.Browser.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals("68", sauceOptions.getBrowserVersion());
+        assertEquals(Options.Platform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
+    }
+
+    @Test
     public void acceptsOtherW3CValues() {
+        sauceOptions.setCapability("pageLoadStrategy", Options.PageLoadStrategy.EAGER);
+        sauceOptions.setCapability("acceptInsecureCerts", true);
+
+        Map<Options.Timeouts, Integer> timeouts = new HashMap<>();
+        timeouts.put(Options.Timeouts.IMPLICIT, 1);
+        timeouts.put(Options.Timeouts.PAGE_LOAD, 100);
+        timeouts.put(Options.Timeouts.SCRIPT, 10);
+
+        sauceOptions.setCapability("timeouts", timeouts);
+        sauceOptions.setCapability("unhandledPromptBehavior", Options.UnhandledPromptBehavior.IGNORE);
+
+        assertEquals(Options.PageLoadStrategy.EAGER, sauceOptions.getCapability("pageLoadStrategy"));
+        assertEquals(true, sauceOptions.getCapability("acceptInsecureCerts"));
+        assertEquals(timeouts, sauceOptions.getCapability("timeouts"));
+        assertEquals(Options.UnhandledPromptBehavior.IGNORE, sauceOptions.getCapability("unhandledPromptBehavior"));
     }
 
     @Test
-    @Ignore("Not Implemented Yet")
     public void acceptsSauceLabsSettings() {
+        sauceOptions.setCapability("extendedDebugging", true);
+        sauceOptions.setCapability("name", "Test name");
+        sauceOptions.setCapability("parentTunnel", "Mommy");
+        sauceOptions.setCapability("public", Options.Public.SHARE);
+        Map<Options.PreRun, Object> prerun = new HashMap<>();
+        prerun.put(Options.PreRun.EXECUTABLE, "http://example.com");
+        List<String> args = new ArrayList<>();
+        args.add("--silent");
+        args.add("-a");
+        args.add("-q");
+        prerun.put(Options.PreRun.ARGS, args);
+        prerun.put(Options.PreRun.BACKGROUND, true);
+        prerun.put(Options.PreRun.TIMEOUT, 40);
+        sauceOptions.setCapability("prerun", prerun);
+        List<String> tags = new ArrayList<>();
+        tags.add("Foo");
+        tags.add("Bar");
+        tags.add("Foobar");
+        sauceOptions.setCapability("tags", tags);
+
+        assertEquals(true, sauceOptions.getCapability("extendedDebugging"));
+        assertEquals("Mommy", sauceOptions.getCapability("parentTunnel"));
+        assertEquals(Options.Public.SHARE, sauceOptions.getCapability("public"));
+        assertEquals(prerun, sauceOptions.getCapability("prerun"));
+        assertEquals(tags, sauceOptions.getCapability("tags"));
     }
 
     @Test
@@ -49,7 +102,7 @@ public class SauceOptionsTest extends BaseConfigurationTest{
 
         sauceOptions = new SauceOptions(firefoxOptions);
 
-        assertEquals("firefox", sauceOptions.getBrowserName());
+        assertEquals(Options.Browser.FIREFOX, sauceOptions.getBrowserName());
         assertEquals(firefoxOptions, sauceOptions.getSeleniumCapabilities());
     }
 
@@ -65,8 +118,67 @@ public class SauceOptionsTest extends BaseConfigurationTest{
     }
 
     @Test
-    @Ignore("Not Implemented Yet")
     public void setsCapabilitiesFromMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("browserName", "firefox");
+        map.put("platformName", "macOS 10.13");
+        map.put("browserVersion", "68");
+        map.put("pageLoadStrategy", "eager");
+        map.put("acceptInsecureCerts", true);
+        Map<String, Integer> timeouts = new HashMap<>();
+        timeouts.put("implicit", 1);
+        timeouts.put("pageLoad", 100);
+        timeouts.put("script", 10);
+
+        Map<Options.Timeouts, Integer> expectedTimeouts = new HashMap<>();
+        expectedTimeouts.put(Options.Timeouts.IMPLICIT, 1);
+        expectedTimeouts.put(Options.Timeouts.PAGE_LOAD, 100);
+        expectedTimeouts.put(Options.Timeouts.SCRIPT, 10);
+
+        map.put("timeouts", timeouts);
+        map.put("unhandledPromptBehavior", "ignore");
+        map.put("extendedDebugging", true);
+        map.put("parentTunnel", "Mommy");
+        map.put("public", "share");
+        Map<String, Object> prerun = new HashMap<>();
+        prerun.put("executable", "http://example.com");
+        List<String> args = new ArrayList<>();
+        args.add("--silent");
+        args.add("-a");
+        args.add("-q");
+        prerun.put("args", args);
+        prerun.put("background", true);
+        prerun.put("timeout", 40);
+        map.put("prerun", prerun);
+
+        Map<Options.PreRun, Object> expectedPrerun = new HashMap<>();
+        expectedPrerun.put(Options.PreRun.ARGS, args);
+        expectedPrerun.put(Options.PreRun.BACKGROUND, true);
+        expectedPrerun.put(Options.PreRun.EXECUTABLE, "http://example.com");
+        expectedPrerun.put(Options.PreRun.TIMEOUT, 40);
+
+        List<String> tags = new ArrayList<>();
+        tags.add("Foo");
+        tags.add("Bar");
+        tags.add("Foobar");
+        map.put("tags", tags);
+
+        sauceOptions.setCapabilities(map);
+
+        assertEquals(Options.Browser.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals("68", sauceOptions.getBrowserVersion());
+        assertEquals(Options.Platform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
+
+        assertEquals(Options.PageLoadStrategy.EAGER, sauceOptions.getCapability("pageLoadStrategy"));
+        assertEquals(true, sauceOptions.getCapability("acceptInsecureCerts"));
+        assertEquals(expectedTimeouts, sauceOptions.getCapability("timeouts"));
+        assertEquals(Options.UnhandledPromptBehavior.IGNORE, sauceOptions.getCapability("unhandledPromptBehavior"));
+
+        assertEquals(true, sauceOptions.getCapability("extendedDebugging"));
+        assertEquals("Mommy", sauceOptions.getCapability("parentTunnel"));
+        assertEquals(Options.Public.SHARE, sauceOptions.getCapability("public"));
+        assertEquals(expectedPrerun, sauceOptions.getCapability("prerun"));
+        assertEquals(tags, sauceOptions.getCapability("tags"));
     }
 
     @Test
@@ -86,7 +198,70 @@ public class SauceOptionsTest extends BaseConfigurationTest{
     }
 
     @Test
-    @Ignore("Not Implemented Yet")
     public void parsesW3CAndSauceAndSeleniumSettings() {
+        MutableCapabilities expectedCapabilities = new MutableCapabilities();
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+
+        FirefoxOptions firefoxOptions = new FirefoxOptions();
+        firefoxOptions.addArguments("--foo");
+        firefoxOptions.addPreference("foo", "bar");
+        firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
+
+        sauceOptions = new SauceOptions(firefoxOptions);
+
+        expectedCapabilities.merge(firefoxOptions);
+        expectedCapabilities.setCapability("browserName", Options.Browser.FIREFOX);
+        expectedCapabilities.setCapability("browserVersion", "latest");
+        expectedCapabilities.setCapability("platformName", Options.Platform.WINDOWS_10);
+        expectedCapabilities.setCapability("acceptInsecureCerts", true);
+
+        sauceOptions.setCapability("build", "CUSTOM BUILD: 12");
+        sauceCapabilities.setCapability("build", "CUSTOM BUILD: 12");
+
+        sauceOptions.setCapability("pageLoadStrategy", Options.PageLoadStrategy.EAGER);
+        expectedCapabilities.setCapability("pageLoadStrategy", Options.PageLoadStrategy.EAGER);
+        sauceOptions.setCapability("acceptInsecureCerts", true);
+        expectedCapabilities.setCapability("acceptInsecureCerts", true);
+        Map<Options.Timeouts, Integer> timeouts = new HashMap<>();
+        timeouts.put(Options.Timeouts.IMPLICIT, 1);
+        timeouts.put(Options.Timeouts.PAGE_LOAD, 100);
+        timeouts.put(Options.Timeouts.SCRIPT, 10);
+        sauceOptions.setCapability("timeouts", timeouts);
+        expectedCapabilities.setCapability("timeouts", timeouts);
+        sauceOptions.setCapability("unhandledPromptBehavior", Options.UnhandledPromptBehavior.IGNORE);
+        expectedCapabilities.setCapability("unhandledPromptBehavior", Options.UnhandledPromptBehavior.IGNORE);
+
+        sauceOptions.setCapability("extendedDebugging", true);
+        sauceCapabilities.setCapability("extendedDebugging", true);
+        sauceOptions.setCapability("name", "Test name");
+        sauceCapabilities.setCapability("name", "Test name");
+        sauceOptions.setCapability("parentTunnel", "Mommy");
+        sauceCapabilities.setCapability("parentTunnel", "Mommy");
+
+        sauceOptions.setCapability("public", Options.Public.SHARE);
+        sauceCapabilities.setCapability("public", Options.Public.SHARE);
+        Map<Options.PreRun, Object> prerun = new HashMap<>();
+        prerun.put(Options.PreRun.EXECUTABLE, "http://example.com");
+        List<String> args = new ArrayList<>();
+        args.add("--silent");
+        args.add("-a");
+        args.add("-q");
+        prerun.put(Options.PreRun.ARGS, args);
+        prerun.put(Options.PreRun.BACKGROUND, true);
+        prerun.put(Options.PreRun.TIMEOUT, 40);
+        sauceOptions.setCapability("prerun", prerun);
+        sauceCapabilities.setCapability("prerun", prerun);
+        List<String> tags = new ArrayList<>();
+        tags.add("Foo");
+        tags.add("Bar");
+        tags.add("Foobar");
+        sauceOptions.setCapability("tags", tags);
+        sauceCapabilities.setCapability("tags", tags);
+
+        expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
+        MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
+
+        // Firefox Options ImmutableSortedMap gets weird when comparing, so using toString which is the important part anyway
+        assertEquals(expectedCapabilities.toString(), actualCapabilities.toString());
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
@@ -7,7 +7,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.remote.BrowserType;
+import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
@@ -17,9 +17,11 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class SauceSessionTest {
+    private SauceOptions sauceOptions = spy(new SauceOptions());
     private SauceSession sauceSession = spy(new SauceSession());
     private RemoteWebDriver dummyRemoteDriver = mock(RemoteWebDriver.class);
     private JavascriptExecutor dummyJSExecutor = mock(JavascriptExecutor.class);
+    private MutableCapabilities dummyMutableCapabilities = mock(MutableCapabilities.class);
 
     @Rule
     public MockitoRule initRule = MockitoJUnit.rule();
@@ -31,21 +33,20 @@ public class SauceSessionTest {
 
     @Test
     public void sauceSessionDefaultsToLatestChromeOnWindows() {
-        String actualBrowser = sauceSession.getSauceOptions().getBrowserName();
+        Options.Browser actualBrowser = sauceSession.getSauceOptions().getBrowserName();
         String actualBrowserVersion = sauceSession.getSauceOptions().getBrowserVersion();
-        String actualPlatformName = sauceSession.getSauceOptions().getPlatformName();
+        Options.Platform actualPlatformName = sauceSession.getSauceOptions().getPlatformName();
 
-        assertEquals(BrowserType.CHROME, actualBrowser);
-        assertEquals("Windows 10", actualPlatformName);
+        assertEquals(Options.Browser.CHROME, actualBrowser);
+        assertEquals(Options.Platform.WINDOWS_10, actualPlatformName);
         assertEquals("latest", actualBrowserVersion);
     }
 
     @Test
     public void sauceSessionUsesProvidedSauceOptions() {
-        SauceOptions sauceOptions = spy(new SauceOptions());
-
         sauceSession = spy(new SauceSession(sauceOptions));
         doReturn(dummyRemoteDriver).when(sauceSession).createRemoteWebDriver();
+        doReturn(dummyMutableCapabilities).when(sauceOptions).toCapabilities();
 
         sauceSession.start();
 
@@ -54,15 +55,15 @@ public class SauceSessionTest {
 
     @Test
     public void defaultsToUSWestDataCenter() {
-        String expectedDataCenterEndpoint = DataCenter.US_WEST.getEndpoint();
-        assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getEndpoint());
+        String expectedDataCenterEndpoint = DataCenter.US_WEST.getValue();
+        assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getValue());
     }
 
     @Test
     public void setsDataCenter() {
-        String expectedDataCenterEndpoint = DataCenter.US_EAST.getEndpoint();
+        String expectedDataCenterEndpoint = DataCenter.US_EAST.getValue();
         sauceSession.setDataCenter(DataCenter.US_EAST);
-        assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getEndpoint());
+        assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getValue());
     }
 
     @Test
@@ -120,33 +121,33 @@ public class SauceSessionTest {
 
     @Test
     public void stopWithBooleanFalse() {
-        doReturn(dummyJSExecutor).when(sauceSession ).getJSExecutor();
-        sauceSession .start();
-        sauceSession .stop(false);
+        doReturn(dummyJSExecutor).when(sauceSession).getJSExecutor();
+        sauceSession.start();
+        sauceSession.stop(false);
         verify(dummyJSExecutor).executeScript("sauce:job-result=failed");
     }
 
     @Test
     public void stopWithStringPassed() {
-        doReturn(dummyJSExecutor).when(sauceSession ).getJSExecutor();
-        sauceSession .start();
-        sauceSession .stop("passed");
+        doReturn(dummyJSExecutor).when(sauceSession).getJSExecutor();
+        sauceSession.start();
+        sauceSession.stop("passed");
         verify(dummyJSExecutor).executeScript("sauce:job-result=passed");
     }
 
     @Test
     public void stopWithStringFailed() {
-        doReturn(dummyJSExecutor).when(sauceSession ).getJSExecutor();
-        sauceSession .start();
-        sauceSession .stop("failed");
+        doReturn(dummyJSExecutor).when(sauceSession).getJSExecutor();
+        sauceSession.start();
+        sauceSession.stop("failed");
         verify(dummyJSExecutor).executeScript("sauce:job-result=failed");
     }
 
     @Test
     public void stopWithNoParameters() {
-        doReturn(dummyJSExecutor).when(sauceSession ).getJSExecutor();
-        sauceSession .start();
-        sauceSession .stop();
+        doReturn(dummyJSExecutor).when(sauceSession).getJSExecutor();
+        sauceSession.start();
+        sauceSession.stop();
 
         verify(dummyJSExecutor, never()).executeScript(anyString());
     }


### PR DESCRIPTION
Regardless of the With Statements, we need a baseline approach to setting values.
We should either follow the NetBeans Approach (#106) or the Selenium Approach. This is the Selenium Approach.

(This is getting compared to a branch with no accessors just to see an apples-to-apples comparison)

Pro: 
* Enums (when used) protect users from incorrect values
* List of allowed capabilities allows us to throw an exception if something is not recognized
* Easy to toggle fluent support
* More Straightforward implementation 

Con:
* No Type checks on capabilities; no way to enforce usage of enums
* Values set as Strings get returned as enums
* No easy to see list of what capabilities are allowed

This is what it looks like. Note that we can have these be fluent or not. You know my preference, but it's not the hill I want to die on. :)

```java
// Setting values
FirefoxOptions firefoxOptions = new FirefoxOptions();
firefoxOptions.addArguments("--foo");
firefoxOptions.addPreference("foo", "bar");

sauceOptions = new SauceOptions(firefoxOptions);

// setCapability() takes String / Object / Enum values as necessary
sauceOptions.setCapability("pageLoadStrategy", Options.PageLoadStrategy.EAGER)
            .setCapability("acceptInsecureCerts", true)
            .setCapability("unhandledPromptBehavior", "ignore);

Map<Options.Timeouts, Integer> timeouts = new HashMap<>();
timeouts.put(Options.Timeouts.IMPLICIT, 1);
timeouts.put(Options.Timeouts.PAGE_LOAD, 100);
timeouts.put(Options.Timeouts.SCRIPT, 10);
sauceOptions.setCapability("timeouts", timeouts);

// Getting Values --> Values set as Strings return as 
assertEquals(Options.PageLoadStrategy.EAGER, sauceOptions.getCapability("pageLoadStrategy"));
assertEquals(Options.UnhandledPromptBehavior.IGNORE, sauceOptions.getCapability("unhandledPromptBehavior"));
```

I'm not sure it is the best way to do it, but I namespaced all of the enums under `Options` which I think should make it easier to see what is available? Let me know if that's dumb, I can change it.

* An exception is thrown if the capability is not recognized
* This converts String values to Enum values where possible, though that might be confusing since we aren't type checking anything, and users may want to get/set compare and this will prevent that
* Overall this implementation is more straightforward, but the user-facing API is not as helpful.