### PR TITLE
Java Beans Approach to Accessors

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.2</version>
+            <version>1.18.10</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
@@ -135,6 +135,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-scm-plugin</artifactId>
                 <version>1.9.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/java/src/main/java/com/saucelabs/simplesauce/DataCenter.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/DataCenter.java
@@ -2,14 +2,18 @@ package com.saucelabs.simplesauce;
 
 import lombok.Getter;
 
-enum DataCenter {
+public enum DataCenter {
     US_WEST("ondemand.us-west-1.saucelabs.com"),
     US_EAST("ondemand.us-east-1.saucelabs.com"),
     EU_CENTRAL("ondemand.eu-central-1.saucelabs.com");
 
-    @Getter private final String endpoint;
+    @Getter private final String value;
 
-    DataCenter(String endpoint) {
-        this.endpoint = endpoint;
+    DataCenter(String value) {
+        this.value = value;
+    }
+
+    public String toString() {
+        return value;
     }
 }

--- a/java/src/main/java/com/saucelabs/simplesauce/Options.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/Options.java
@@ -1,0 +1,274 @@
+package com.saucelabs.simplesauce;
+
+import lombok.Getter;
+
+import java.util.*;
+
+public class Options {
+    private static final class BrowserLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    private static final class PlatformLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    private static final class PageLoadStrategyLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    private static final class TimeoutsLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    private static final class UnhandledPromptBehaviorLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    private static final class JobVisibilityLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    private static final class PreRunLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    public enum PageLoadStrategy {
+        NONE("none"),
+        EAGER("eager"),
+        NORMAL("normal");
+
+        @Getter private String value;
+
+        public static Set keys() {
+            return PageLoadStrategyLookup.lookup.keySet();
+        }
+
+        PageLoadStrategy(String value) {
+            this.value = value;
+            PageLoadStrategyLookup.lookup.put(value.toString(), this.name());
+        }
+
+        public static String fromString(String value) {
+            return PageLoadStrategyLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value.toString();
+        }
+    }
+
+    public enum UnhandledPromptBehavior {
+        DISMISS("dismiss"),
+        ACCEPT("accept"),
+        DISMISS_AND_NOTIFY("dismiss and notify"),
+        ACCEPT_AND_NOTIFY("accept and notify"),
+        IGNORE("ignore");
+
+        @Getter private String value;
+
+        public static Set keys() {
+            return UnhandledPromptBehaviorLookup.lookup.keySet();
+        }
+
+        UnhandledPromptBehavior(String value) {
+            this.value = value;
+            UnhandledPromptBehaviorLookup.lookup.put(value.toString(), this.name());
+        }
+
+        public static String fromString(String value) {
+            return UnhandledPromptBehaviorLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value.toString();
+        }
+    }
+
+    public enum PreRun {
+        EXECUTABLE("executable"),
+        ARGS("args"),
+        BACKGROUND("background"),
+        TIMEOUT("timeout");
+
+        @Getter private String value;
+
+        public static Set keys() {
+            return PreRunLookup.lookup.keySet();
+        }
+
+        PreRun(String value) {
+            this.value = value;
+            PreRunLookup.lookup.put(value, this.name());
+        }
+
+        public static String fromString(String value) {
+            return PreRunLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value.toString();
+        }
+    }
+
+    public enum JobVisibility {
+        PUBLIC("public"),
+        PUBLIC_RESTRICTED("public restricted"),
+        SHARE("share"),
+        TEAM("team"),
+        PRIVATE("private");
+
+        @Getter private String value;
+
+        public static Set keys() {
+            return JobVisibilityLookup.lookup.keySet();
+        }
+
+        JobVisibility(String value) {
+            this.value = value;
+            JobVisibilityLookup.lookup.put(value.toString(), this.name());
+        }
+
+        public static String fromString(String value) {
+            return JobVisibilityLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value.toString();
+        }
+    }
+
+    public enum Browser {
+        CHROME("chrome"),
+        INTERNET_EXPLORER("internet explorer"),
+        EDGE("MicrosoftEdge"),
+        SAFARI("safari"),
+        FIREFOX("firefox");
+
+        @Getter private final String value;
+
+        public static Set keys() {
+            return BrowserLookup.lookup.keySet();
+        }
+
+        Browser(String value) {
+            this.value = value;
+            BrowserLookup.lookup.put(value, this.name());
+        }
+
+        public static String fromString(String value) {
+            return BrowserLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value;
+        }
+    }
+
+    public enum Timeouts {
+        IMPLICIT("implicit"),
+        PAGE_LOAD("pageLoad"),
+        SCRIPT("script");
+
+        @Getter private final String value;
+
+        public static Set keys() {
+            return TimeoutsLookup.lookup.keySet();
+        }
+
+        Timeouts(String value) {
+            this.value = value;
+            TimeoutsLookup.lookup.put(value, this.name());
+        }
+
+        public static String fromString(String value) {
+            return TimeoutsLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value;
+        }
+    }
+
+    public enum Platform {
+        WINDOWS_10("Windows 10"),
+        WINDOWS_8_1("Windows 8.1"),
+        WINDOWS_8("Windows 8"),
+        MAC_MOJAVE("macOS 10.14"),
+        MAC_HIGH_SIERRA("macOS 10.13"),
+        MAC_SIERRA("macOS 10.12"),
+        MAC_EL_CAPITAN("OS X 10.11"),
+        MAC_YOSEMITE("OS X 10.10");
+
+        @Getter
+        private final String value;
+
+        public static Set keys() {
+            return PlatformLookup.lookup.keySet();
+        }
+
+        Platform(String value) {
+            this.value = value;
+            PlatformLookup.lookup.put(value, this.name());
+        }
+
+        public static String fromString(String value) {
+            return PlatformLookup.lookup.get(value);
+        }
+
+        public String toString() {
+            return this.value;
+        }
+    }
+
+    public static final List<String> primaryEnum = List.of(
+            "browserName",
+            "jobVisibility",
+            "pageLoadStrategy",
+            "platformName",
+            "timeouts",
+            "unhandledPromptBehavior"
+    );
+
+    public static final List<String> secondaryEnum = List.of(
+            "timeouts",
+            "prerun"
+    );
+
+    public static final List<String> w3c = List.of(
+            "browserName",
+            "browserVersion",
+            "platformName",
+            "pageLoadStrategy",
+            "acceptInsecureCerts",
+            "proxy",
+            "setWindowRect",
+            "timeouts",
+            "strictFileInteractability",
+            "unhandledPromptBehavior");
+
+    public static final List<String> sauce = List.of(
+            "avoidProxy",
+            "build",
+            "capturePerformance",
+            "chromedriverVersion",
+            "commandTimeout",
+            "customData",
+            "extendedDebugging",
+            "idleTimeout",
+            "iedriverVersion",
+            "maxDuration",
+            "name",
+            "parentTunnel",
+            "prerun",
+            "priority",
+            "recordLogs",
+            "recordScreenshots",
+            "recordVideo",
+            "screenResolution",
+            "seleniumVersion",
+            "tags",
+            "timeZone",
+            "tunnelIdentifier",
+            "videoUploadOnPass");
+}

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
@@ -1,21 +1,64 @@
 package com.saucelabs.simplesauce;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.MutableCapabilities;
-import org.openqa.selenium.remote.BrowserType;
-import org.openqa.selenium.remote.CapabilityType;
+import org.openqa.selenium.Proxy;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+@Accessors(chain = true)
+@Setter @Getter
 public class SauceOptions {
-    @Getter private MutableCapabilities seleniumCapabilities;
+    @Setter(AccessLevel.NONE) private MutableCapabilities seleniumCapabilities;
 
-    @Getter @Setter private String browserName = BrowserType.CHROME;
-    @Getter @Setter private String browserVersion = "latest";
-    @Getter @Setter private String platformName = "Windows 10";
-    @Setter private String build;
+    // w3c Settings
+    private Options.Browser browserName = Options.Browser.CHROME;
+    private String browserVersion = "latest";
+    private Options.Platform platformName = Options.Platform.WINDOWS_10;
+    private Options.PageLoadStrategy pageLoadStrategy;
+    private Boolean acceptInsecureCerts = null;
+    private Proxy proxy;
+    private Boolean setWindowRect = null;
+    private Map<Options.Timeouts, Integer> timeouts;
+    private Boolean strictFileInteractability = null;
+    private Options.UnhandledPromptBehavior unhandledPromptBehavior;
+
+    // Sauce Settings
+    private Boolean avoidProxy = null;
+    private String build;
+    private Boolean capturePerformance = null;
+    private String chromedriverVersion;
+    private Integer commandTimeout = null;
+    private Map<String, Object> customData = null;
+    private Boolean extendedDebugging = null;
+    private Integer idleTimeout = null;
+    private String iedriverVersion;
+    private Integer maxDuration = null;
+    private String name;
+    private String parentTunnel;
+    private Map<Options.PreRun, Object> prerun;
+    private URL prerunUrl;
+    private Integer priority = null;
+    private Options.JobVisibility jobVisibility; // the actual key for this is a Java reserved keyword "public"
+    private Boolean recordLogs = null;
+    private Boolean recordScreenshots = null;
+    private Boolean recordVideo = null;
+    private String screenResolution;
+    private String seleniumVersion;
+    private List<String> tags = null;
+    private String timeZone;
+    private String tunnelIdentifier;
+    private Boolean videoUploadOnPass = null;
 
     public SauceOptions() {
         this(new MutableCapabilities());
@@ -24,16 +67,37 @@ public class SauceOptions {
     public SauceOptions(Capabilities capabilities) {
         seleniumCapabilities = new MutableCapabilities(capabilities);
         if (capabilities.getCapability("browserName") != null) {
-            browserName = (String) capabilities.getCapability("browserName");
+            setCapability("browserName", capabilities.getCapability("browserName"));
         }
     }
 
     public MutableCapabilities toCapabilities() {
-        seleniumCapabilities.setCapability(CapabilityType.BROWSER_NAME, browserName);
-        seleniumCapabilities.setCapability(CapabilityType.PLATFORM_NAME, platformName);
-        seleniumCapabilities.setCapability(CapabilityType.BROWSER_VERSION, browserVersion);
-        seleniumCapabilities.setCapability("sauce:options", new HashMap<>());
-        return seleniumCapabilities;
+        MutableCapabilities w3cCapabilities = getSeleniumCapabilities();
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+
+        for (Field field : this.getClass().getDeclaredFields()) {
+            try {
+                String fieldName = field.getName();
+                if (!"seleniumCapabilities".equals(fieldName)) {
+                    Object value = getCapability(fieldName);
+                    String key = "prerunUrl".equals(fieldName) ? "prerun" : fieldName;
+                    if (value == null) {
+                        continue;
+                    } else if (Options.w3c.contains(key)) {
+                        w3cCapabilities.setCapability(fieldName, value);
+                    } else if (Options.sauce.contains(key)) {
+                        sauceCapabilities.setCapability(fieldName, value);
+                    } else if ("jobVisibility".equals(key)) {
+                        sauceCapabilities.setCapability("public", value);
+                    }
+                }
+            } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                e.printStackTrace();
+            }
+        }
+
+        w3cCapabilities.setCapability("sauce:options", sauceCapabilities);
+        return w3cCapabilities;
     }
 
     public String getBuild() {
@@ -63,8 +127,104 @@ public class SauceOptions {
         }
     }
 
+    // Use Case is pulling serialized information from JSON/YAML, converting it to a HashMap and passing it in
+    // This is a preferred pattern as it avoids conditionals in code
+    public void setCapabilities(Map<String, Object> capabilities) {
+        capabilities.forEach(this::setCapability);
+    }
+
+    // This might be made public in future version; For now, no good reason to prefer it over direct accessor
+    private Object getCapability(String capability) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        String getter = "get" + capability.substring(0, 1).toUpperCase() + capability.substring(1);
+        Method declaredMethod = SauceOptions.class.getDeclaredMethod(getter);
+        return declaredMethod.invoke(this);
+    }
+
+    // This might be made public in future version; For now, no good reason to prefer it over direct accessor
+    public void setCapability(String key, Object value) {
+        if (Options.primaryEnum.contains(key) && value.getClass().equals(String.class)) {
+            setPrimaryEnumCapability(key, (String) value);
+        } else if (Options.secondaryEnum.contains(key) && ((HashMap) value).keySet().toArray()[0].getClass().equals(String.class)) {
+            setSecondaryEnumCapability(key, (HashMap) value);
+        } else {
+            try {
+                Class<?> type = SauceOptions.class.getDeclaredField(key).getType();
+                String setter = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
+                Method method = SauceOptions.class.getDeclaredMethod(setter, type);
+                method.invoke(this, value);
+            } catch (NoSuchFieldException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private void setPrimaryEnumCapability(String key, String value) {
+        switch (key) {
+            case "browserName":
+                if (!Options.Browser.keys().contains(value)) {
+                    String message = value + " is not a valid Browser, please choose from: " + Options.Browser.keys();
+                    throw new InvalidSauceOptionsArguementException(message);
+                } else {
+                    this.browserName = Options.Browser.valueOf(Options.Browser.fromString(value));
+                }
+                break;
+            case "platformName":
+                if (!Options.Platform.keys().contains(value)) {
+                    String message = value + " is not a valid Platform, please choose from: " + Options.Platform.keys();
+                    throw new InvalidSauceOptionsArguementException(message);
+                } else {
+                    this.platformName = Options.Platform.valueOf(Options.Platform.fromString(value));
+                }
+                break;
+            case "jobVisibility":
+                if (!Options.JobVisibility.keys().contains(value)) {
+                    String message = value + " is not a valid Job Visibility, please choose from: " + Options.JobVisibility.keys();
+                    throw new InvalidSauceOptionsArguementException(message);
+                } else {
+                    this.jobVisibility = Options.JobVisibility.valueOf(Options.JobVisibility.fromString(value));
+                }
+                break;
+            case "pageLoadStrategy":
+                if (!Options.PageLoadStrategy.keys().contains(value)) {
+                    String message = value + " is not a valid Job Visibility, please choose from: " + Options.PageLoadStrategy.keys();
+                    throw new InvalidSauceOptionsArguementException(message);
+                } else {
+                    this.pageLoadStrategy = Options.PageLoadStrategy.valueOf(Options.PageLoadStrategy.fromString(value));
+                }
+                break;
+            case "unhandledPromptBehavior":
+                if (!Options.UnhandledPromptBehavior.keys().contains(value)) {
+                    String message = value + " is not a valid Job Visibility, please choose from: " + Options.UnhandledPromptBehavior.keys();
+                    throw new InvalidSauceOptionsArguementException(message);
+                } else {
+                    this.unhandledPromptBehavior = Options.UnhandledPromptBehavior.valueOf(Options.UnhandledPromptBehavior.fromString(value));
+                }
+                break;
+        }
+    }
+
+    private void setSecondaryEnumCapability(String key, Map<String, Object> value) {
+        switch (key) {
+            case "prerun":
+                Map<Options.PreRun, Object> prerunMap = new HashMap<>();
+                value.forEach((oldKey, val) -> {
+                    String keyString = Options.PreRun.fromString((String) oldKey);
+                    prerunMap.put(Options.PreRun.valueOf(keyString), val);
+                });
+                this.prerun = prerunMap;
+                break;
+            case "timeouts":
+                Map<Options.Timeouts, Integer> timeoutsMap = new HashMap<>();
+                value.forEach((oldKey, val) -> {
+                    String keyString = Options.Timeouts.fromString((String) oldKey);
+                    timeoutsMap.put(Options.Timeouts.valueOf(keyString), (Integer) val);
+                });
+                this.timeouts = timeoutsMap;
+                break;
+        }
+    }
+
     protected String getEnvironmentVariable(String key) {
         return System.getenv(key);
     }
-
 }

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
@@ -5,7 +5,6 @@ import org.openqa.selenium.JavascriptExecutor;
 import lombok.Setter;
 import org.openqa.selenium.InvalidArgumentException;
 import org.openqa.selenium.MutableCapabilities;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
@@ -40,7 +39,7 @@ public class SauceSession {
         if (sauceUrl != null) {
             return sauceUrl;
         } else {
-            String url = "https://" + getSauceUsername() + ":" + getSauceAccessKey() + "@" + dataCenter.getEndpoint() + "/wd/hub";
+            String url = "https://" + getSauceUsername() + ":" + getSauceAccessKey() + "@" + dataCenter + "/wd/hub";
             try {
                 return new URL(url);
             } catch (MalformedURLException e) {

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
@@ -4,7 +4,11 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.firefox.FirefoxOptions;
-import org.openqa.selenium.remote.BrowserType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
@@ -13,31 +17,79 @@ import static org.openqa.selenium.UnexpectedAlertBehaviour.DISMISS;
 
 public class SauceOptionsTest extends BaseConfigurationTest{
     @Test
-    public void usesLatestChromeWindowsVersions() {
-        assertEquals(BrowserType.CHROME, sauceOptions.getBrowserName());
-        assertEquals("Windows 10", sauceOptions.getPlatformName());
+    public void usesLatestChromeWindowsVersionsByDefault() {
+        assertEquals(Options.Browser.CHROME, sauceOptions.getBrowserName());
+        assertEquals(Options.Platform.WINDOWS_10, sauceOptions.getPlatformName());
         assertEquals("latest", sauceOptions.getBrowserVersion());
     }
 
     @Test
     public void updatesBrowserBrowserVersionPlatformVersionValues() {
-        sauceOptions.setBrowserName(BrowserType.FIREFOX);
-        sauceOptions.setPlatformName("macOS 10.13");
+        sauceOptions.setBrowserName(Options.Browser.FIREFOX);
+        sauceOptions.setPlatformName(Options.Platform.MAC_HIGH_SIERRA);
         sauceOptions.setBrowserVersion("68");
 
-        assertEquals(BrowserType.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals(Options.Browser.FIREFOX, sauceOptions.getBrowserName());
         assertEquals("68", sauceOptions.getBrowserVersion());
-        assertEquals("macOS 10.13", sauceOptions.getPlatformName());
+        assertEquals(Options.Platform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
     }
 
     @Test
-    @Ignore("Not Implemented Yet")
+    public void fluentPatternWorks() {
+        sauceOptions.setBrowserName(Options.Browser.FIREFOX)
+                .setBrowserVersion("68")
+                .setPlatformName(Options.Platform.MAC_HIGH_SIERRA);
+
+        assertEquals(Options.Browser.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals("68", sauceOptions.getBrowserVersion());
+        assertEquals(Options.Platform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
+    }
+
+    @Test
     public void acceptsOtherW3CValues() {
+        sauceOptions.setPageLoadStrategy(Options.PageLoadStrategy.EAGER);
+        sauceOptions.setAcceptInsecureCerts(true);
+        Map<Options.Timeouts, Integer> timeouts = new HashMap<>();
+        timeouts.put(Options.Timeouts.IMPLICIT, 1);
+        timeouts.put(Options.Timeouts.PAGE_LOAD, 100);
+        timeouts.put(Options.Timeouts.SCRIPT, 10);
+        sauceOptions.setTimeouts(timeouts);
+        sauceOptions.setUnhandledPromptBehavior(Options.UnhandledPromptBehavior.IGNORE);
+
+        assertEquals(Options.PageLoadStrategy.EAGER, sauceOptions.getPageLoadStrategy());
+        assertEquals(true, sauceOptions.getAcceptInsecureCerts());
+        assertEquals(timeouts, sauceOptions.getTimeouts());
+        assertEquals(Options.UnhandledPromptBehavior.IGNORE, sauceOptions.getUnhandledPromptBehavior());
     }
 
     @Test
-    @Ignore("Not Implemented Yet")
     public void acceptsSauceLabsSettings() {
+        sauceOptions.setExtendedDebugging(true);
+        sauceOptions.setName("Test name");
+        sauceOptions.setParentTunnel("Mommy");
+        sauceOptions.setJobVisibility(Options.JobVisibility.SHARE);
+        Map<Options.PreRun, Object> prerun = new HashMap<>();
+        prerun.put(Options.PreRun.EXECUTABLE, "http://example.com");
+        List<String> args = new ArrayList<>();
+        args.add("--silent");
+        args.add("-a");
+        args.add("-q");
+        prerun.put(Options.PreRun.ARGS, args);
+        prerun.put(Options.PreRun.BACKGROUND, true);
+        prerun.put(Options.PreRun.TIMEOUT, 40);
+        sauceOptions.setPrerun(prerun);
+        List<String> tags = new ArrayList<>();
+        tags.add("Foo");
+        tags.add("Bar");
+        tags.add("Foobar");
+        sauceOptions.setTags(tags);
+
+        assertEquals(true, sauceOptions.getExtendedDebugging());
+        assertEquals("Test name", sauceOptions.getName());
+        assertEquals("Mommy", sauceOptions.getParentTunnel());
+        assertEquals(Options.JobVisibility.SHARE, sauceOptions.getJobVisibility());
+        assertEquals(prerun, sauceOptions.getPrerun());
+        assertEquals(tags, sauceOptions.getTags());
     }
 
     @Test
@@ -49,7 +101,7 @@ public class SauceOptionsTest extends BaseConfigurationTest{
 
         sauceOptions = new SauceOptions(firefoxOptions);
 
-        assertEquals("firefox", sauceOptions.getBrowserName());
+        assertEquals(Options.Browser.FIREFOX, sauceOptions.getBrowserName());
         assertEquals(firefoxOptions, sauceOptions.getSeleniumCapabilities());
     }
 
@@ -65,8 +117,65 @@ public class SauceOptionsTest extends BaseConfigurationTest{
     }
 
     @Test
-    @Ignore("Not Implemented Yet")
     public void setsCapabilitiesFromMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("browserName", "firefox");
+        map.put("platformName", "macOS 10.13");
+        map.put("browserVersion", "68");
+        map.put("pageLoadStrategy", "eager");
+        map.put("acceptInsecureCerts", true);
+        Map<String, Integer> timeouts = new HashMap<>();
+        timeouts.put("implicit", 1);
+        timeouts.put("pageLoad", 100);
+        timeouts.put("script", 10);
+
+        Map<Options.Timeouts, Integer> expectedTimeouts = new HashMap<>();
+        expectedTimeouts.put(Options.Timeouts.IMPLICIT, 1);
+        expectedTimeouts.put(Options.Timeouts.PAGE_LOAD, 100);
+        expectedTimeouts.put(Options.Timeouts.SCRIPT, 10);
+
+        map.put("timeouts", timeouts);
+        map.put("unhandledPromptBehavior", "ignore");
+        map.put("extendedDebugging", true);
+        map.put("parentTunnel", "Mommy");
+        map.put("jobVisibility", "share");
+        Map<String, Object> prerun = new HashMap<>();
+        prerun.put("executable", "http://example.com");
+        List<String> args = new ArrayList<>();
+        args.add("--silent");
+        args.add("-a");
+        args.add("-q");
+        prerun.put("args", args);
+        prerun.put("background", true);
+        prerun.put("timeout", 40);
+        map.put("prerun", prerun);
+
+        Map<Options.PreRun, Object> expectedPrerun = new HashMap<>();
+        expectedPrerun.put(Options.PreRun.ARGS, args);
+        expectedPrerun.put(Options.PreRun.BACKGROUND, true);
+        expectedPrerun.put(Options.PreRun.EXECUTABLE, "http://example.com");
+        expectedPrerun.put(Options.PreRun.TIMEOUT, 40);
+
+        List<String> tags = new ArrayList<>();
+        tags.add("Foo");
+        tags.add("Bar");
+        tags.add("Foobar");
+        map.put("tags", tags);
+
+        sauceOptions.setCapabilities(map);
+
+        assertEquals(Options.Browser.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals("68", sauceOptions.getBrowserVersion());
+        assertEquals(Options.Platform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
+        assertEquals(Options.PageLoadStrategy.EAGER, sauceOptions.getPageLoadStrategy());
+        assertEquals(true, sauceOptions.getAcceptInsecureCerts());
+        assertEquals(expectedTimeouts, sauceOptions.getTimeouts());
+        assertEquals(Options.UnhandledPromptBehavior.IGNORE, sauceOptions.getUnhandledPromptBehavior());
+        assertEquals(true, sauceOptions.getExtendedDebugging());
+        assertEquals("Mommy", sauceOptions.getParentTunnel());
+        assertEquals(Options.JobVisibility.SHARE, sauceOptions.getJobVisibility());
+        assertEquals(expectedPrerun, sauceOptions.getPrerun());
+        assertEquals(tags, sauceOptions.getTags());
     }
 
     @Test
@@ -86,7 +195,68 @@ public class SauceOptionsTest extends BaseConfigurationTest{
     }
 
     @Test
-    @Ignore("Not Implemented Yet")
     public void parsesW3CAndSauceAndSeleniumSettings() {
+        MutableCapabilities expectedCapabilities = new MutableCapabilities();
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+
+        FirefoxOptions firefoxOptions = new FirefoxOptions();
+        firefoxOptions.addArguments("--foo");
+        firefoxOptions.addPreference("foo", "bar");
+        firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
+
+        sauceOptions = new SauceOptions(firefoxOptions);
+
+        expectedCapabilities.merge(firefoxOptions);
+        expectedCapabilities.setCapability("browserVersion", "latest");
+        expectedCapabilities.setCapability("platformName", "Windows 10");
+        expectedCapabilities.setCapability("acceptInsecureCerts", true);
+
+        sauceOptions.setBuild("CUSTOM BUILD: 12");
+        sauceCapabilities.setCapability("build", "CUSTOM BUILD: 12");
+
+        sauceOptions.setPageLoadStrategy(Options.PageLoadStrategy.EAGER);
+        expectedCapabilities.setCapability("pageLoadStrategy", Options.PageLoadStrategy.EAGER);
+        sauceOptions.setAcceptInsecureCerts(true);
+        expectedCapabilities.setCapability("acceptInsecureCerts", true);
+        Map<Options.Timeouts, Integer> timeouts = new HashMap<>();
+        timeouts.put(Options.Timeouts.IMPLICIT, 1);
+        timeouts.put(Options.Timeouts.PAGE_LOAD, 100);
+        timeouts.put(Options.Timeouts.SCRIPT, 10);
+        sauceOptions.setTimeouts(timeouts);
+        expectedCapabilities.setCapability("timeouts", timeouts);
+        sauceOptions.setUnhandledPromptBehavior(Options.UnhandledPromptBehavior.IGNORE);
+        expectedCapabilities.setCapability("unhandledPromptBehavior", Options.UnhandledPromptBehavior.IGNORE);
+
+        sauceOptions.setExtendedDebugging(true);
+        sauceCapabilities.setCapability("extendedDebugging", true);
+        sauceOptions.setName("Test name");
+        sauceCapabilities.setCapability("name", "Test name");
+        sauceOptions.setParentTunnel("Mommy");
+        sauceCapabilities.setCapability("parentTunnel", "Mommy");
+
+        sauceOptions.setJobVisibility(Options.JobVisibility.SHARE);
+        sauceCapabilities.setCapability("public", Options.JobVisibility.SHARE);
+        Map<Options.PreRun, Object> prerun = new HashMap<>();
+        prerun.put(Options.PreRun.EXECUTABLE, "http://example.com");
+        List<String> args = new ArrayList<>();
+        args.add("--silent");
+        args.add("-a");
+        args.add("-q");
+        prerun.put(Options.PreRun.ARGS, args);
+        prerun.put(Options.PreRun.BACKGROUND, true);
+        prerun.put(Options.PreRun.TIMEOUT, 40);
+        sauceOptions.setPrerun(prerun);
+        sauceCapabilities.setCapability("prerun", prerun);
+        List<String> tags = new ArrayList<>();
+        tags.add("Foo");
+        tags.add("Bar");
+        tags.add("Foobar");
+        sauceOptions.setTags(tags);
+        sauceCapabilities.setCapability("tags", tags);
+
+        expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
+
+        // Firefox Options ImmutableSortedMap gets weird when comparing, so using toString
+        assertEquals(expectedCapabilities.toString(), sauceOptions.toCapabilities().toString());
     }
 }

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
@@ -7,7 +7,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.remote.BrowserType;
+import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
@@ -17,9 +17,11 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class SauceSessionTest {
+    private SauceOptions sauceOptions = spy(new SauceOptions());
     private SauceSession sauceSession = spy(new SauceSession());
     private RemoteWebDriver dummyRemoteDriver = mock(RemoteWebDriver.class);
     private JavascriptExecutor dummyJSExecutor = mock(JavascriptExecutor.class);
+    private MutableCapabilities dummyMutableCapabilities = mock(MutableCapabilities.class);
 
     @Rule
     public MockitoRule initRule = MockitoJUnit.rule();
@@ -31,21 +33,20 @@ public class SauceSessionTest {
 
     @Test
     public void sauceSessionDefaultsToLatestChromeOnWindows() {
-        String actualBrowser = sauceSession.getSauceOptions().getBrowserName();
+        Options.Browser actualBrowser = sauceSession.getSauceOptions().getBrowserName();
         String actualBrowserVersion = sauceSession.getSauceOptions().getBrowserVersion();
-        String actualPlatformName = sauceSession.getSauceOptions().getPlatformName();
+        Options.Platform actualPlatformName = sauceSession.getSauceOptions().getPlatformName();
 
-        assertEquals(BrowserType.CHROME, actualBrowser);
-        assertEquals("Windows 10", actualPlatformName);
+        assertEquals(Options.Browser.CHROME, actualBrowser);
+        assertEquals(Options.Platform.WINDOWS_10, actualPlatformName);
         assertEquals("latest", actualBrowserVersion);
     }
 
     @Test
     public void sauceSessionUsesProvidedSauceOptions() {
-        SauceOptions sauceOptions = spy(new SauceOptions());
-
         sauceSession = spy(new SauceSession(sauceOptions));
         doReturn(dummyRemoteDriver).when(sauceSession).createRemoteWebDriver();
+        doReturn(dummyMutableCapabilities).when(sauceOptions).toCapabilities();
 
         sauceSession.start();
 
@@ -54,15 +55,15 @@ public class SauceSessionTest {
 
     @Test
     public void defaultsToUSWestDataCenter() {
-        String expectedDataCenterEndpoint = DataCenter.US_WEST.getEndpoint();
-        assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getEndpoint());
+        String expectedDataCenterEndpoint = DataCenter.US_WEST.getValue();
+        assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getValue());
     }
 
     @Test
     public void setsDataCenter() {
-        String expectedDataCenterEndpoint = DataCenter.US_EAST.getEndpoint();
+        String expectedDataCenterEndpoint = DataCenter.US_EAST.getValue();
         sauceSession.setDataCenter(DataCenter.US_EAST);
-        assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getEndpoint());
+        assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getValue());
     }
 
     @Test
@@ -120,33 +121,33 @@ public class SauceSessionTest {
 
     @Test
     public void stopWithBooleanFalse() {
-        doReturn(dummyJSExecutor).when(sauceSession ).getJSExecutor();
-        sauceSession .start();
-        sauceSession .stop(false);
+        doReturn(dummyJSExecutor).when(sauceSession).getJSExecutor();
+        sauceSession.start();
+        sauceSession.stop(false);
         verify(dummyJSExecutor).executeScript("sauce:job-result=failed");
     }
 
     @Test
     public void stopWithStringPassed() {
-        doReturn(dummyJSExecutor).when(sauceSession ).getJSExecutor();
-        sauceSession .start();
-        sauceSession .stop("passed");
+        doReturn(dummyJSExecutor).when(sauceSession).getJSExecutor();
+        sauceSession.start();
+        sauceSession.stop("passed");
         verify(dummyJSExecutor).executeScript("sauce:job-result=passed");
     }
 
     @Test
     public void stopWithStringFailed() {
-        doReturn(dummyJSExecutor).when(sauceSession ).getJSExecutor();
-        sauceSession .start();
-        sauceSession .stop("failed");
+        doReturn(dummyJSExecutor).when(sauceSession).getJSExecutor();
+        sauceSession.start();
+        sauceSession.stop("failed");
         verify(dummyJSExecutor).executeScript("sauce:job-result=failed");
     }
 
     @Test
     public void stopWithNoParameters() {
-        doReturn(dummyJSExecutor).when(sauceSession ).getJSExecutor();
-        sauceSession .start();
-        sauceSession .stop();
+        doReturn(dummyJSExecutor).when(sauceSession).getJSExecutor();
+        sauceSession.start();
+        sauceSession.stop();
 
         verify(dummyJSExecutor, never()).executeScript(anyString());
     }


### PR DESCRIPTION
Regardless of the With Statements, we need a baseline approach to setting values.
We should either follow the NetBeans Approach or the Selenium Approach (#105). This is the Java Beans Approach.

(This is getting compared to a branch with no accessors just to see an apples-to-apples comparison)

Pro: 
* Enums protect users from incorrect values
* Explicit Fields allow us to ensure types for the various capabilities (and let users see)
* Explicit getter/setters allow the user to know exactly what is available from IDE
* Easy to toggle fluent support

Con:
* Reflection is complicated, then lots of brute force coding for the edge cases
* Converting Strings to enums is complicated

This is what it looks like. Note that we can have these be fluent or not. You know my preference, but it's not the hill I want to die on. :)

```java
FirefoxOptions firefoxOptions = new FirefoxOptions();
firefoxOptions.addArguments("--foo");
firefoxOptions.addPreference("foo", "bar");
sauceOptions = new SauceOptions(firefoxOptions);

// Setting Values
sauceOptions.setBuild("CUSTOM BUILD: 12")
            .setPageLoadStrategy(Options.PageLoadStrategy.EAGER)
            .setUnhandledPromptBehavior(Options.UnhandledPromptBehavior.ACCEPT)
            .setAcceptInsecureCerts(true);

Map<Options.Timeouts, Integer> timeouts = new HashMap<>();
timeouts.put(Options.Timeouts.IMPLICIT, 1);
timeouts.put(Options.Timeouts.PAGE_LOAD, 100);
timeouts.put(Options.Timeouts.SCRIPT, 10);
sauceOptions.setTimeouts(timeouts);

// Getting Values --> Values set as Strings return as 
assertEquals(Options.PageLoadStrategy.EAGER, sauceOptions.getPageLoadStrategy());
assertEquals(Options.UnhandledPromptBehavior.IGNORE, sauceOptions.getUnhandledPromptBehavior());
```

I'm not sure it is the best way to do it, but I namespaced all of the enums under `Options` which I think should make it easier to see what is available? Let me know if that's dumb, I can change it.

* This implementation uses reflection to generate the capabilities (`toCapabilities()`)
* The setters can only accept enums if one is defined for it, (no Strings!).
* `setCapability()` is not public, so users are required to use the named methods, or to pass in a `HashMap` instance to `setCapabilities()`. 
* The use case for `setCapabilities()` is to be able to convert serialized data into a HashMap with a lookup instead of a conditional, then pass it into the `SauceOptions` instance. Since the values have to be from serialized data, they can't be enums. There are a number of ugly conditionals here to auto-translate the String value into an appropriate enum value.
* Overall this implementation is less straightforward, but much more helpful to the end user.