### PR TITLE
[py] add capabilities and a lot more tests

### DIFF
--- a/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
@@ -215,7 +215,7 @@ public class SauceOptions {
 
     // Use Case is pulling serialized information from JSON/YAML, converting it to a HashMap and passing it in
     // This is a preferred pattern as it avoids conditionals in code
-    public void setCapabilities(Map<String, Object> capabilities) {
+    public void mergeCapabilities(Map<String, Object> capabilities) {
         capabilities.forEach(this::setCapability);
     }
 

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceOptionsTest.java
@@ -237,7 +237,7 @@ public class SauceOptionsTest {
         tags.add("Foobar");
         map.put("tags", tags);
 
-        sauceOptions.setCapabilities(map);
+        sauceOptions.mergeCapabilities(map);
 
         assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
         assertEquals("68", sauceOptions.getBrowserVersion());

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
 selenium==3.141.0
 pytest
 flake8
+pyyaml

--- a/python/simplesauce/options.py
+++ b/python/simplesauce/options.py
@@ -127,6 +127,10 @@ class SauceOptions:
         except KeyError:
             return None
 
+    def merge_capabilities(self, capabilities):
+        for key, value in capabilities.items():
+            self.set_capability(key, value)
+
     # Sets with camelCase
     def set_capability(self, key, value):
         if key in sauce_configs.values():

--- a/python/tests/options.yml
+++ b/python/tests/options.yml
@@ -1,0 +1,56 @@
+exampleValues:
+  browserName: 'firefox'
+  browserVersion: '68'
+  platformName: 'macOS 10.13'
+  acceptInsecureCerts: true
+  pageLoadStrategy: 'eager'
+  setWindowRect: true
+  unhandledPromptBehavior: "accept"
+  strictFileInteractability: true
+  timeouts:
+    implicit: 1
+    pageLoad: 59
+    script: 29
+  avoidProxy: true
+  build: 'Sample Build Name'
+  capturePerformance: true
+  chromedriverVersion: '71'
+  commandTimeout: 2
+  customData:
+    foo: 'foo'
+    bar: 'bar'
+  extendedDebugging: true
+  idleTimeout: 3
+  iedriverVersion: '3.141.0'
+  maxDuration: 300
+  name: 'Sample Test Name'
+  parentTunnel: 'Mommy'
+  prerun:
+    executable: "http://url.to/your/executable.exe"
+    args:
+      - --silent
+      - -a
+      - -q
+    background: false
+    timeout: 120
+  priority: 0
+  public: 'team'
+  recordLogs: false
+  recordScreenshots: false
+  recordVideo: false
+  screenResolution: '10x10'
+  seleniumVersion: '3.141.59'
+  tags:
+    - foo
+    - bar
+    - foobar
+  timeZone: 'San Francisco'
+  tunnelIdentifier: 'tunnelname'
+  videoUploadOnPass: false
+
+invalidOption:
+  foo: "bar"
+  browser_Nme: "firefox"
+  browserVersion: "70"
+  platformName: "MacOS 10.12"
+  recordScreenshots: false

--- a/python/tests/test_options.py
+++ b/python/tests/test_options.py
@@ -30,53 +30,166 @@ class TestInit(object):
         assert sauce.browser_version == '75.0'
         assert sauce.platform_name == 'macOS 10.13'
 
-    def test_accepts_w3c_values(self):
-        sauce = SauceOptions(acceptInsecureCerts=True, pageLoadStrategy='eager')
-
-        assert sauce.accept_insecure_certs is True
-        assert sauce.page_load_strategy == 'eager'
-
-    def test_accepts_sauce_values_with_dict(self):
-        options = {'maxDuration': 1,
-                   'commandTimeout': 2,
-                   'idleTimeout': 3,
-                   'name': 'foo',
-                   'build': 'bar',
-                   'tags': ['foo', 'bar'],
-                   'parentTunnel': 'bar',
-                   'tunnelIdentifier': 'foobar',
-                   'screenResolution': '10x10',
-                   'timeZone': 'Foo',
-                   'extendedDebugging': True,
-                   'capturePerformance': True,
-                   'recordVideo': False,
-                   'videoUploadOnPass': False,
-                   'recordScreenshots': False,
-                   'recordLogs': False}
+    def test_accepts_w3c_values_with_dict(self):
+        timeouts = {'implicit': 1,
+                    'pageLoad': 59,
+                    'script': 29}
+        options = {'acceptInsecureCerts': True,
+                   'pageLoadStrategy': 'eager',
+                   'setWindowRect': True,
+                   'unhandledPromptBehavior': 'accept',
+                   'strictFileInteractability': True,
+                   'timeouts': timeouts}
 
         sauce = SauceOptions(**options)
 
-        assert sauce.max_duration == 1
-        assert sauce.command_timeout == 2
-        assert sauce.idle_timeout == 3
-        assert sauce.name == 'foo'
+        assert sauce.accept_insecure_certs is True
+        assert sauce.page_load_strategy == 'eager'
+        assert sauce.set_window_rect is True
+        assert sauce.unhandled_prompt_behavior == 'accept'
+        assert sauce.strict_file_interactability is True
+        assert sauce.timeouts == timeouts
+
+    def test_accepts_w3c_values_as_params(self):
+        timeouts = {'implicit': 1,
+                    'pageLoad': 59,
+                    'script': 29}
+
+        sauce = SauceOptions(acceptInsecureCerts=True,
+                             pageLoadStrategy='eager',
+                             setWindowRect=True,
+                             unhandledPromptBehavior='accept',
+                             strictFileInteractability=True,
+                             timeouts=timeouts)
+
+        assert sauce.accept_insecure_certs is True
+        assert sauce.page_load_strategy == 'eager'
+        assert sauce.set_window_rect is True
+        assert sauce.unhandled_prompt_behavior == 'accept'
+        assert sauce.strict_file_interactability is True
+        assert sauce.timeouts == timeouts
+
+    def test_accepts_sauce_values_with_dict(self):
+        options = {'avoidProxy': True,
+                   'build': 'bar',
+                   'capturePerformance': True,
+                   'chromedriverVersion': "71",
+                   'commandTimeout': 2,
+                   'customData': {'foo': 'foo',
+                                  'bar': 'bar'},
+                   'extendedDebugging': True,
+                   'idleTimeout': 3,
+                   'iedriverVersion': '3.141.0',
+                   'maxDuration': 1,
+                   'name': 'foo',
+                   'parentTunnel': 'bar',
+                   'prerun': {'executable': 'http://url.to/your/executable.exe',
+                              'args': ['--silent', '-a', '-q'],
+                              'background': False,
+                              'timeout': 120},
+                   'priority': 0,
+                   'public': 'team',
+                   'recordLogs': False,
+                   'recordScreenshots': False,
+                   'recordVideo': False,
+                   'screenResolution': '10x10',
+                   'seleniumVersion': '3.141.59',
+                   'tags': ['foo', 'bar'],
+                   'timeZone': 'Foo',
+                   'tunnelIdentifier': 'foobar',
+                   'videoUploadOnPass': False}
+
+        sauce = SauceOptions(**options)
+
+        assert sauce.avoid_proxy is True
         assert sauce.build == 'bar'
-        assert sauce.tags == ['foo', 'bar']
-        assert sauce.parent_tunnel == 'bar'
-        assert sauce.tunnel_identifier == 'foobar'
-        assert sauce.screen_resolution == '10x10'
-        assert sauce.time_zone == 'Foo'
-        assert sauce.extended_debugging is True
         assert sauce.capture_performance is True
-        assert sauce.record_video is False
-        assert sauce.video_upload_on_pass is False
-        assert sauce.record_screenshots is False
+        assert sauce.chromedriver_version == '71'
+        assert sauce.command_timeout == 2
+        assert sauce.custom_data == {'foo': 'foo',
+                                     'bar': 'bar'}
+        assert sauce.extended_debugging is True
+        assert sauce.idle_timeout == 3
+        assert sauce.iedriver_version == '3.141.0'
+        assert sauce.max_duration == 1
+        assert sauce.name == 'foo'
+        assert sauce.parent_tunnel == 'bar'
+        assert sauce.prerun == {'executable': 'http://url.to/your/executable.exe',
+                                'args': ['--silent', '-a', '-q'],
+                                'background': False,
+                                'timeout': 120}
+        assert sauce.priority == 0
+        assert sauce.public == 'team'
         assert sauce.record_logs is False
+        assert sauce.record_screenshots is False
+        assert sauce.record_video is False
+        assert sauce.screen_resolution == '10x10'
+        assert sauce.selenium_version == '3.141.59'
+        assert sauce.tags == ['foo', 'bar']
+        assert sauce.time_zone == 'Foo'
+        assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.video_upload_on_pass is False
 
     def test_accepts_sauce_values_as_params(self):
-        sauce = SauceOptions(maxDuration=1, commandTimeout=2)
-        assert sauce.max_duration == 1
+        custom_data = {'foo': 'foo',
+                       'bar': 'bar'}
+        prerun = {'executable': 'http://url.to/your/executable.exe',
+                   'args': ['--silent', '-a', '-q'],
+                   'background': False,
+                   'timeout': 120}
+        sauce = SauceOptions(avoidProxy=True,
+                             build='bar',
+                             capturePerformance=True,
+                             chromedriverVersion='71',
+                             commandTimeout=2,
+                             customData=custom_data,
+                             extendedDebugging=True,
+                             idleTimeout=3,
+                             iedriverVersion='3.141.0',
+                             maxDuration=1,
+                             name='foo',
+                             parentTunnel='bar',
+                             prerun=prerun,
+                             priority=0,
+                             public='team',
+                             recordLogs=False,
+                             recordScreenshots=False,
+                             recordVideo=False,
+                             screenResolution='10x10',
+                             seleniumVersion='3.141.59',
+                             tags=['foo', 'bar'],
+                             timeZone='Foo',
+                             tunnelIdentifier='foobar',
+                             videoUploadOnPass=False)
+
+        assert sauce.avoid_proxy is True
+        assert sauce.build == 'bar'
+        assert sauce.capture_performance is True
+        assert sauce.chromedriver_version == '71'
         assert sauce.command_timeout == 2
+        assert sauce.custom_data == {'foo': 'foo',
+                                     'bar': 'bar'}
+        assert sauce.extended_debugging is True
+        assert sauce.idle_timeout == 3
+        assert sauce.iedriver_version == '3.141.0'
+        assert sauce.max_duration == 1
+        assert sauce.name == 'foo'
+        assert sauce.parent_tunnel == 'bar'
+        assert sauce.prerun == {'executable': 'http://url.to/your/executable.exe',
+                                'args': ['--silent', '-a', '-q'],
+                                'background': False,
+                                'timeout': 120}
+        assert sauce.priority == 0
+        assert sauce.public == 'team'
+        assert sauce.record_logs is False
+        assert sauce.record_screenshots is False
+        assert sauce.record_video is False
+        assert sauce.screen_resolution == '10x10'
+        assert sauce.selenium_version == '3.141.59'
+        assert sauce.tags == ['foo', 'bar']
+        assert sauce.time_zone == 'Foo'
+        assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.video_upload_on_pass is False
 
     def test_accepts_selenium_browser_options_instance(self):
         options = FirefoxOptions()
@@ -135,58 +248,207 @@ class TestInit(object):
 class TestSauceSpecificOptions(object):
 
     def test_w3c_options(self):
-        sauce = SauceOptions()
-        sauce.browser_name = 'safari'
-        sauce.platform_name = 'macOS 10.14'
+        timeouts = {'implicit': 1,
+                    'pageLoad': 59,
+                    'script': 29}
 
-        sauce.accept_insecure_certs = True
+        options = SauceOptions()
+        options.browser_name = 'firefox'
+        options.browser_version = '7'
+        options.platform_name = 'macOS 10.14'
+        options.accept_insecure_certs = True
+        options.page_load_strategy = 'eager'
+        options.set_window_rect = True
+        options.unhandled_prompt_behavior = 'accept'
+        options.strict_file_interactability = True
+        options.timeouts = timeouts
 
-        assert sauce.browser_name == 'safari'
-        assert sauce.accept_insecure_certs is True
-        assert sauce.platform_name == 'macOS 10.14'
+        assert options.browser_name == 'firefox'
+        assert options.browser_version == '7'
+        assert options.platform_name == 'macOS 10.14'
+        assert options.accept_insecure_certs is True
+        assert options.page_load_strategy == 'eager'
+        assert options.set_window_rect is True
+        assert options.unhandled_prompt_behavior == 'accept'
+        assert options.strict_file_interactability is True
+        assert options.timeouts == timeouts
 
     def test_sauce_options(self):
-        sauce = SauceOptions()
-        sauce.name = 'my-test'
-        sauce.record_screenshots = False
+        prerun = {'executable': 'http://url.to/your/executable.exe',
+                  'args': ['--silent', '-a', '-q'],
+                  'background': False,
+                  'timeout': 120}
+        custom_data = {'foo': 'foo',
+                       'bar': 'bar'}
+        tags = ['foo', 'bar']
 
-        assert sauce.name == 'my-test'
-        assert sauce.record_screenshots is False
+        options = SauceOptions()
+
+        options.avoid_proxy = True
+        options.build = 'Sample Build Name'
+        options.capture_performance = True
+        options.chromedriver_version = '71'
+        options.command_timeout = 2
+        options.custom_data = custom_data
+        options.extended_debugging = True
+        options.idle_timeout = 3
+        options.iedriver_version = '3.141.0'
+        options.max_duration = 300
+        options.name = 'Sample Test Name'
+        options.parent_tunnel = 'Mommy'
+        options.prerun = prerun
+        options.priority = 0
+        options.public = 'team'
+        options.record_logs = False
+        options.record_screenshots = False
+        options.record_video = False
+        options.screen_resolution = '10x10'
+        options.selenium_version = '3.141.59'
+        options.tags = tags
+        options.time_zone = 'San Francisco'
+        options.tunnel_identifier = 'tunnelname'
+        options.video_upload_on_pass = False
+
+        assert options.avoid_proxy is True
+        assert options.build == 'Sample Build Name'
+        assert options.capture_performance is True
+        assert options.chromedriver_version == '71'
+        assert options.command_timeout == 2
+        assert options.custom_data == custom_data
+        assert options.extended_debugging is True
+        assert options.idle_timeout == 3
+        assert options.iedriver_version == '3.141.0'
+        assert options.max_duration == 300
+        assert options.name == 'Sample Test Name'
+        assert options.parent_tunnel == 'Mommy'
+        assert options.prerun == prerun
+        assert options.priority == 0
+        assert options.public == 'team'
+        assert options.record_logs is False
+        assert options.record_screenshots is False
+        assert options.record_video is False
+        assert options.screen_resolution == '10x10'
+        assert options.selenium_version == '3.141.59'
+        assert options.tags == tags
+        assert options.time_zone == 'San Francisco'
+        assert options.tunnel_identifier == 'tunnelname'
+        assert options.video_upload_on_pass is False
 
 
 class TestCapabilitiesCreation(object):
 
     def test_capabilities_for_w3c(self):
-        sauce = SauceOptions()
-        sauce.browser_name = 'safari'
-        sauce.platform_name = 'macOS 10.14'
-        sauce.accept_insecure_certs = True
+        options = SauceOptions()
 
-        capabilities = sauce.to_capabilities()
+        options.browser_name = 'firefox'
+        options.browser_version = '7'
+        options.platform_name = 'macOS 10.14'
+        options.accept_insecure_certs = True
+        options.page_load_strategy = 'eager'
+        options.set_window_rect = True
+        options.unhandled_prompt_behavior = 'accept'
+        options.strict_file_interactability = True
+        options.timeouts = {'implicit': 1,
+                            'pageLoad': 59,
+                            'script': 29}
+        options.build = "Build Name"
 
-        assert capabilities['acceptInsecureCerts'] is True
-        assert capabilities['browserName'] == 'safari'
-        assert capabilities['browserVersion'] == 'latest'
-        assert capabilities['sauce:options']['build'] is not None
+        expected_capabilities = {'browserName': 'firefox',
+                                 'browserVersion': '7',
+                                 'platformName': 'macOS 10.14',
+                                 'acceptInsecureCerts': True,
+                                 'pageLoadStrategy': 'eager',
+                                 'setWindowRect': True,
+                                 'unhandledPromptBehavior': 'accept',
+                                 'strictFileInteractability': True,
+                                 'timeouts': {'implicit': 1,
+                                              'pageLoad': 59,
+                                              'script': 29},
+                                 'sauce:options': {'build': 'Build Name'}}
+
+        assert options.to_capabilities() == expected_capabilities
 
     def test_capabilities_for_sauce(self):
-        sauce = SauceOptions()
-        sauce.name = 'my-test'
-        sauce.record_screenshots = False
+        prerun = {'executable': 'http://url.to/your/executable.exe',
+                  'args': ['--silent', '-a', '-q'],
+                  'background': False,
+                  'timeout': 120}
+        custom_data = {'foo': 'foo',
+                       'bar': 'bar'}
+        tags = ['foo', 'bar']
 
-        capabilities = sauce.to_capabilities()
+        options = SauceOptions()
 
-        assert capabilities['sauce:options']['recordScreenshots'] is False
-        assert capabilities['sauce:options']['name'] == 'my-test'
+        options.avoid_proxy = True
+        options.build = 'Sample Build Name'
+        options.capture_performance = True
+        options.chromedriver_version = '71'
+        options.command_timeout = 2
+        options.custom_data = custom_data
+        options.extended_debugging = True
+        options.idle_timeout = 3
+        options.iedriver_version = '3.141.0'
+        options.max_duration = 300
+        options.name = 'Sample Test Name'
+        options.parent_tunnel = 'Mommy'
+        options.prerun = prerun
+        options.priority = 0
+        options.public = 'team'
+        options.record_logs = False
+        options.record_screenshots = False
+        options.record_video = False
+        options.screen_resolution = '10x10'
+        options.selenium_version = '3.141.59'
+        options.tags = tags
+        options.time_zone = 'San Francisco'
+        options.tunnel_identifier = 'tunnelname'
+        options.video_upload_on_pass = False
+
+        expected_capabilities = {'browserName': 'chrome',
+                                 'browserVersion': 'latest',
+                                 'platformName': 'Windows 10',
+                                 'sauce:options': {'build': 'Sample Build Name',
+                                                   'avoidProxy': True,
+                                                   'capturePerformance': True,
+                                                   'chromedriverVersion': '71',
+                                                   'commandTimeout': 2,
+                                                   'customData': {'foo': 'foo',
+                                                                  'bar': 'bar'},
+                                                   'extendedDebugging': True,
+                                                   'idleTimeout': 3,
+                                                   'iedriverVersion': '3.141.0',
+                                                   'maxDuration': 300,
+                                                   'name': 'Sample Test Name',
+                                                   'parentTunnel': 'Mommy',
+                                                   'prerun': prerun,
+                                                   'priority': 0,
+                                                   'public': 'team',
+                                                   'recordLogs': False,
+                                                   'recordScreenshots': False,
+                                                   'recordVideo': False,
+                                                   'screenResolution': '10x10',
+                                                   'seleniumVersion': '3.141.59',
+                                                   'tags': ['foo', 'bar'],
+                                                   'timeZone': 'San Francisco',
+                                                   'tunnelIdentifier': 'tunnelname',
+                                                   'videoUploadOnPass': False}}
+
+        assert options.to_capabilities() == expected_capabilities
 
     def test_capabilities_for_selenium(self):
         browser_options = FirefoxOptions()
         browser_options.add_argument('--foo')
         browser_options.set_preference('foo', 'bar')
 
-        sauce = SauceOptions(seleniumOptions=browser_options)
+        options = SauceOptions(seleniumOptions=browser_options)
+        options.build = 'Sample Build Name'
 
-        capabilities = sauce.to_capabilities()
+        expected_capabilities = {'acceptInsecureCerts': True,
+                                 'browserName': 'firefox',
+                                 'browserVersion': 'latest',
+                                 'platformName': 'Windows 10',
+                                 'marionette': True,
+                                 'moz:firefoxOptions': {'args': ['--foo'], 'prefs': {'foo': 'bar'}},
+                                 'sauce:options': {'build': 'Sample Build Name'}}
 
-        assert capabilities['moz:firefoxOptions']['args'] == ['--foo']
-        assert capabilities['moz:firefoxOptions']['prefs'] == {'foo': 'bar'}
+        assert options.to_capabilities() == expected_capabilities

--- a/python/tests/test_options.py
+++ b/python/tests/test_options.py
@@ -1,10 +1,10 @@
 import os
 
 import pytest
+import yaml
 
 from simplesauce.options import SauceOptions
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
-from selenium.webdriver import DesiredCapabilities
 
 
 class TestInit(object):
@@ -134,9 +134,9 @@ class TestInit(object):
         custom_data = {'foo': 'foo',
                        'bar': 'bar'}
         prerun = {'executable': 'http://url.to/your/executable.exe',
-                   'args': ['--silent', '-a', '-q'],
-                   'background': False,
-                   'timeout': 120}
+                  'args': ['--silent', '-a', '-q'],
+                  'background': False,
+                  'timeout': 120}
         sauce = SauceOptions(avoidProxy=True,
                              build='bar',
                              capturePerformance=True,
@@ -245,7 +245,7 @@ class TestInit(object):
             SauceOptions(**options)
 
 
-class TestSauceSpecificOptions(object):
+class TestSettingSpecificOptions(object):
 
     def test_w3c_options(self):
         timeouts = {'implicit': 1,
@@ -309,6 +309,65 @@ class TestSauceSpecificOptions(object):
         options.tunnel_identifier = 'tunnelname'
         options.video_upload_on_pass = False
 
+        assert options.avoid_proxy is True
+        assert options.build == 'Sample Build Name'
+        assert options.capture_performance is True
+        assert options.chromedriver_version == '71'
+        assert options.command_timeout == 2
+        assert options.custom_data == custom_data
+        assert options.extended_debugging is True
+        assert options.idle_timeout == 3
+        assert options.iedriver_version == '3.141.0'
+        assert options.max_duration == 300
+        assert options.name == 'Sample Test Name'
+        assert options.parent_tunnel == 'Mommy'
+        assert options.prerun == prerun
+        assert options.priority == 0
+        assert options.public == 'team'
+        assert options.record_logs is False
+        assert options.record_screenshots is False
+        assert options.record_video is False
+        assert options.screen_resolution == '10x10'
+        assert options.selenium_version == '3.141.59'
+        assert options.tags == tags
+        assert options.time_zone == 'San Francisco'
+        assert options.tunnel_identifier == 'tunnelname'
+        assert options.video_upload_on_pass is False
+
+
+class TestAddingCapabilities(object):
+
+    def test_setting_capabilities(self):
+        #  TODO create a conditional for this:
+        file_location = r'./tests/options.yml'  # if running on CI
+        #  file_location = r'options.yml'  # If running locally
+        with open(file_location) as file:
+            yml = yaml.safe_load(file)
+
+        prerun = {'executable': 'http://url.to/your/executable.exe',
+                  'args': ['--silent', '-a', '-q'],
+                  'background': False,
+                  'timeout': 120}
+        custom_data = {'foo': 'foo',
+                       'bar': 'bar'}
+        tags = ['foo', 'bar', 'foobar']
+
+        timeouts = {'implicit': 1,
+                    'pageLoad': 59,
+                    'script': 29}
+
+        options = SauceOptions()
+        options.merge_capabilities(yml.get("exampleValues"))
+
+        assert options.browser_name == 'firefox'
+        assert options.browser_version == '68'
+        assert options.platform_name == 'macOS 10.13'
+        assert options.accept_insecure_certs is True
+        assert options.page_load_strategy == 'eager'
+        assert options.set_window_rect is True
+        assert options.unhandled_prompt_behavior == 'accept'
+        assert options.strict_file_interactability is True
+        assert options.timeouts == timeouts
         assert options.avoid_proxy is True
         assert options.build == 'Sample Build Name'
         assert options.capture_performance is True

--- a/ruby/lib/simple_sauce/options.rb
+++ b/ruby/lib/simple_sauce/options.rb
@@ -61,7 +61,7 @@ module SimpleSauce
     end
     alias as_json capabilities
 
-    def add_capabilities(opts)
+    def merge_capabilities(opts)
       opts.each do |key, value|
         raise ArgumentError, "#{key} is not a valid parameter for Options class" unless respond_to?("#{key}=")
 

--- a/ruby/spec/options_spec.rb
+++ b/ruby/spec/options_spec.rb
@@ -202,7 +202,6 @@ module SimpleSauce
         options.unhandled_prompt_behavior = 'accept'
         options.strict_file_interactability = true
         options.timeouts = timeouts
-        options.platform_name
 
         expect(options.browser_name).to eq 'firefox'
         expect(options.browser_version).to eq '7'
@@ -279,7 +278,7 @@ module SimpleSauce
       end
     end
 
-    describe '#add_capabilities' do
+    describe '#merge_capabilities' do
       it 'loads options from configuration' do
         timeouts = {implicit: 1,
                     page_load: 59,
@@ -294,7 +293,7 @@ module SimpleSauce
 
         options = Options.new
         yaml = YAML.load_file('spec/options.yml')
-        options.add_capabilities(yaml['example_values'])
+        options.merge_capabilities(yaml['example_values'])
 
         expect(options.browser_name).to eq 'firefox'
         expect(options.browser_version).to eq '123'
@@ -336,7 +335,7 @@ module SimpleSauce
         yaml = YAML.load_file('spec/options.yml')
 
         msg = 'foo is not a valid parameter for Options class'
-        expect { options.add_capabilities(yaml['invalid_option']) }.to raise_exception(ArgumentError, msg)
+        expect { options.merge_capabilities(yaml['invalid_option']) }.to raise_exception(ArgumentError, msg)
       end
     end
 
@@ -375,7 +374,7 @@ module SimpleSauce
       it 'correctly generates capabilities for sauce values' do
         custom_data = {foo: 'foo',
                        bar: 'bar'}
-        prerun = {'executable': 'http://url.to/your/executable.exe',
+        prerun = {executable: 'http://url.to/your/executable.exe',
                   args: ['--silent', '-a', '-q'],
                   background: false,
                   timeout: 120}


### PR DESCRIPTION
This expand all of the tests to cover all of the capabilities. Except Proxy, I skipped that one because proxies are hard, and it's Python. Do we need to add it in to all of the w3c tests? I did add it to the Ruby ones.

Also added the `add_capabilities` method. I'm wondering if it should be named `merge` or `set_capabilities` or `merge_capabilities`.

The one weird thing with Python bindings is how `pageLoad` is handled. The current implementation gets weird if you pass it in as `page_load` instead of `pageLoad` and I'm not sure what the right answer is here.