### PR TITLE
remove accessors from Session username and accessKey

### DIFF
--- a/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceOptions.java
@@ -117,6 +117,17 @@ public class SauceOptions {
             "tunnelIdentifier",
             "videoUploadOnPass");
 
+    public static final Map<String, String> knownCITools;
+    static {
+        knownCITools = new HashMap<>();
+        knownCITools.put("Jenkins", "BUILD_TAG");
+        knownCITools.put("Bamboo", "bamboo_agentId");
+        knownCITools.put("Travis", "TRAVIS_JOB_ID");
+        knownCITools.put("Circle", "CIRCLE_JOB");
+        knownCITools.put("GitLab", "CI");
+        knownCITools.put("TeamCity", "TEAMCITY_PROJECT_NAME");
+    }
+
     public SauceOptions() {
         this(new MutableCapabilities());
     }
@@ -189,28 +200,25 @@ public class SauceOptions {
     public String getBuild() {
         if (build != null) {
             return build;
-            // Jenkins
-        } else if (getEnvironmentVariable("BUILD_TAG") != null) {
+        } else if (getEnvironmentVariable(knownCITools.get("Jenkins")) != null) {
             return getEnvironmentVariable("BUILD_NAME") + ": " + getEnvironmentVariable("BUILD_NUMBER");
-            // Bamboo
-        } else if (getEnvironmentVariable("bamboo_agentId") != null) {
+        } else if (getEnvironmentVariable(knownCITools.get("Bamboo")) != null) {
             return getEnvironmentVariable("bamboo_shortJobName") + ": " + getEnvironmentVariable("bamboo_buildNumber");
-            // Travis
-        } else if (getEnvironmentVariable("TRAVIS_JOB_ID") != null) {
+        } else if (getEnvironmentVariable(knownCITools.get("Travis")) != null) {
             return getEnvironmentVariable("TRAVIS_JOB_NAME") + ": " + getEnvironmentVariable("TRAVIS_JOB_NUMBER");
-            // CircleCI
-        } else if (getEnvironmentVariable("CIRCLE_JOB") != null) {
+        } else if (getEnvironmentVariable(knownCITools.get("Circle")) != null) {
             return getEnvironmentVariable("CIRCLE_JOB") + ": " + getEnvironmentVariable("CIRCLE_BUILD_NUM");
-            // Gitlab
-        } else if (getEnvironmentVariable("CI") != null) {
+        } else if (getEnvironmentVariable(knownCITools.get("GitLab")) != null) {
             return getEnvironmentVariable("CI_JOB_NAME") + ": " + getEnvironmentVariable("CI_JOB_ID");
-            // Team City
-        } else if (getEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null) {
+        } else if (getEnvironmentVariable(knownCITools.get("TeamCity")) != null) {
             return getEnvironmentVariable("TEAMCITY_PROJECT_NAME") + ": " + getEnvironmentVariable("BUILD_NUMBER");
-            // Default
         } else {
             return "Build Time: " + System.currentTimeMillis();
         }
+    }
+
+    public boolean isKnownCI() {
+        return !knownCITools.keySet().stream().allMatch((key) -> getEnvironmentVariable(key) == null);
     }
 
     // Use Case is pulling serialized information from JSON/YAML, converting it to a HashMap and passing it in

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
@@ -82,7 +82,7 @@ public class SauceSession {
     private String getUsername() {
         if (username != null) {
             return username;
-        } else if (!sauceOptions.isKnownCI() && System.getProperty("SAUCE_USERNAME") != null) {
+        } else if (System.getProperty("SAUCE_USERNAME") != null) {
             return System.getProperty("SAUCE_USERNAME");
         } else {
             throw new SauceEnvironmentVariablesNotSetException("Sauce Username was not provided");
@@ -92,7 +92,7 @@ public class SauceSession {
     private String getAccessKey() {
         if (accessKey != null) {
             return accessKey;
-        } else if (!sauceOptions.isKnownCI() && System.getProperty("SAUCE_ACCESS_KEY") != null) {
+        } else if (System.getProperty("SAUCE_ACCESS_KEY") != null) {
             return System.getProperty("SAUCE_ACCESS_KEY");
         } else {
             throw new SauceEnvironmentVariablesNotSetException("Sauce Access Key was not provided");

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
@@ -11,13 +11,18 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 public class SauceSession {
-    private String username;
-    private String accessKey;
+
+    /**
+     * Defaults for username and access key are environment variables
+     */
+    private String username = System.getenv("SAUCE_USERNAME");
+    private String accessKey = System.getenv("SAUCE_ACCESS_KEY");
+
+
     @Getter @Setter private DataCenter dataCenter = DataCenter.US_WEST;
     @Getter private final SauceOptions sauceOptions;
     @Setter private URL sauceUrl;
 
-    @Getter private MutableCapabilities currentSessionCapabilities;
     @Getter private RemoteWebDriver driver;
 
     public SauceSession() {
@@ -74,21 +79,11 @@ public class SauceSession {
         }
     }
 
-    protected String getEnvironmentVariable(String key) {
-        return System.getenv(key);
-    }
-
-    protected String getSystemProperty(String key) {
-        return System.getProperty(key);
-    }
-
     private String getUsername() {
         if (username != null) {
             return username;
-        } else if (!sauceOptions.isKnownCI() && getSystemProperty("SAUCE_USERNAME") != null) {
-            return getSystemProperty("SAUCE_USERNAME");
-        } else if (getEnvironmentVariable("SAUCE_USERNAME") != null) {
-            return getEnvironmentVariable("SAUCE_USERNAME");
+        } else if (!sauceOptions.isKnownCI() && System.getProperty("SAUCE_USERNAME") != null) {
+            return System.getProperty("SAUCE_USERNAME");
         } else {
             throw new SauceEnvironmentVariablesNotSetException("Sauce Username was not provided");
         }
@@ -97,10 +92,8 @@ public class SauceSession {
     private String getAccessKey() {
         if (accessKey != null) {
             return accessKey;
-        } else if (!sauceOptions.isKnownCI() && getSystemProperty("SAUCE_ACCESS_KEY") != null) {
-            return getSystemProperty("SAUCE_ACCESS_KEY");
-        } else if (getEnvironmentVariable("SAUCE_ACCESS_KEY") != null) {
-            return getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        } else if (!sauceOptions.isKnownCI() && System.getProperty("SAUCE_ACCESS_KEY") != null) {
+            return System.getProperty("SAUCE_ACCESS_KEY");
         } else {
             throw new SauceEnvironmentVariablesNotSetException("Sauce Access Key was not provided");
         }

--- a/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
@@ -11,10 +11,10 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 public class SauceSession {
+    private String username;
+    private String accessKey;
     @Getter @Setter private DataCenter dataCenter = DataCenter.US_WEST;
     @Getter private final SauceOptions sauceOptions;
-    @Getter @Setter private String username;
-    @Getter @Setter private String accessKey;
     @Setter private URL sauceUrl;
 
     @Getter private MutableCapabilities currentSessionCapabilities;
@@ -37,7 +37,7 @@ public class SauceSession {
         if (sauceUrl != null) {
             return sauceUrl;
         } else {
-            String url = "https://" + getSauceUsername() + ":" + getSauceAccessKey() + "@" + dataCenter + "/wd/hub";
+            String url = "https://" + getUsername() + ":" + getAccessKey() + "@" + dataCenter + "/wd/hub";
             try {
                 return new URL(url);
             } catch (MalformedURLException e) {
@@ -78,9 +78,15 @@ public class SauceSession {
         return System.getenv(key);
     }
 
-    private String getSauceUsername() {
+    protected String getSystemProperty(String key) {
+        return System.getProperty(key);
+    }
+
+    private String getUsername() {
         if (username != null) {
             return username;
+        } else if (!sauceOptions.isKnownCI() && getSystemProperty("SAUCE_USERNAME") != null) {
+            return getSystemProperty("SAUCE_USERNAME");
         } else if (getEnvironmentVariable("SAUCE_USERNAME") != null) {
             return getEnvironmentVariable("SAUCE_USERNAME");
         } else {
@@ -88,9 +94,11 @@ public class SauceSession {
         }
     }
 
-    private String getSauceAccessKey() {
+    private String getAccessKey() {
         if (accessKey != null) {
             return accessKey;
+        } else if (!sauceOptions.isKnownCI() && getSystemProperty("SAUCE_ACCESS_KEY") != null) {
+            return getSystemProperty("SAUCE_ACCESS_KEY");
         } else if (getEnvironmentVariable("SAUCE_ACCESS_KEY") != null) {
             return getEnvironmentVariable("SAUCE_ACCESS_KEY");
         } else {

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
@@ -78,7 +78,6 @@ public class SauceSessionTest {
 
     @Test
     public void sauceURLUsersSystemPropertiesForUsernameAccessKey() {
-        SauceSession sauceSession = new SauceSession();
         Whitebox.setInternalState(sauceSession, "username", null);
         Whitebox.setInternalState(sauceSession, "accessKey", null);
 
@@ -98,6 +97,7 @@ public class SauceSessionTest {
 
     @Test(expected = SauceEnvironmentVariablesNotSetException.class)
     public void startThrowsErrorWithoutUsername() {
+        SauceSession sauceSession = new SauceSession();
         System.clearProperty("SAUCE_USERNAME");
         System.clearProperty("SAUCE_ACCESS_KEY");
 
@@ -107,6 +107,7 @@ public class SauceSessionTest {
 
     @Test(expected = SauceEnvironmentVariablesNotSetException.class)
     public void startThrowsErrorWithoutAccessKey() {
+        SauceSession sauceSession = new SauceSession();
         System.clearProperty("SAUCE_USERNAME");
         System.clearProperty("SAUCE_ACCESS_KEY");
 

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
@@ -82,8 +82,8 @@ public class SauceSessionTest {
 
     @Test
     public void setUserNameAndAccessKey() {
-        sauceSession.setUsername("test-username");
-        sauceSession.setAccessKey("test-accesskey");
+        doReturn("test-username").when(sauceSession).getSystemProperty("SAUCE_USERNAME");
+        doReturn("test-accesskey").when(sauceSession).getSystemProperty("SAUCE_ACCESS_KEY");
 
         String expetedSauceUrl = "https://test-username:test-accesskey@ondemand.us-west-1.saucelabs.com/wd/hub";
         assertEquals(expetedSauceUrl, sauceSession.getSauceUrl().toString());

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
@@ -78,6 +78,7 @@ public class SauceSessionTest {
 
     @Test
     public void sauceURLUsersSystemPropertiesForUsernameAccessKey() {
+        SauceSession sauceSession = new SauceSession();
         Whitebox.setInternalState(sauceSession, "username", null);
         Whitebox.setInternalState(sauceSession, "accessKey", null);
 

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
@@ -15,7 +15,11 @@ import java.net.URL;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class SauceSessionTest {
     private SauceOptions sauceOptions = spy(new SauceOptions());

--- a/python/simplesauce/options.py
+++ b/python/simplesauce/options.py
@@ -4,7 +4,7 @@ from selenium.webdriver.edge.options import Options as EdgeOptions
 from selenium.webdriver.ie.options import Options as IEOptions
 from datetime import datetime
 import os
-import re
+
 
 w3c_configs = {
     'browser_name': 'browserName',
@@ -85,7 +85,7 @@ class SauceOptions:
         super(SauceOptions, self).__setattr__('seleniumOptions', {})
 
         for key, value in kwargs.items():
-            if key is 'seleniumOptions':
+            if key == 'seleniumOptions':
                 if isinstance(value, tuple(browser_names)):
                     self.set_capability('browserName', browser_names[type(value)])
 
@@ -112,7 +112,7 @@ class SauceOptions:
         self.set_option(key, value)
 
     def __getattr__(self, key):
-        if key is 'selenium_options':
+        if key == 'selenium_options':
             if 'caps' in self.seleniumOptions.keys():
                 return self.seleniumOptions['caps']
             else:

--- a/python/simplesauce/session.py
+++ b/python/simplesauce/session.py
@@ -15,29 +15,13 @@ data_centers = {
 
 class SauceSession():
 
-    def __init__(self, options=None, data_center='us-west', username=None, access_key=None):
+    def __init__(self, options=None, data_center='us-west'):
         self.options = options if options else SauceOptions()
-        self._username = username if username else SAUCE_USERNAME
-        self._access_key = access_key if access_key else SAUCE_ACCESS_KEY
+        self._username = SAUCE_USERNAME
+        self._access_key = SAUCE_ACCESS_KEY
         self.data_center = data_center if data_center else 'us-west'
         self._remote_url = None
         self.driver = None
-
-    @property
-    def username(self):
-        return self._username
-
-    @username.setter
-    def username(self, username):
-        self._username = username
-
-    @property
-    def access_key(self):
-        return self._access_key
-
-    @access_key.setter
-    def access_key(self, access_key):
-        self._access_key = access_key
 
     @property
     def data_center(self):

--- a/python/simplesauce/session.py
+++ b/python/simplesauce/session.py
@@ -4,21 +4,19 @@ from selenium.webdriver.remote.remote_connection import RemoteConnection
 from simplesauce.options import SauceOptions
 
 
-SAUCE_USERNAME = os.getenv('SAUCE_USERNAME', None)
-SAUCE_ACCESS_KEY = os.getenv('SAUCE_ACCESS_KEY', None)
-
 data_centers = {
     'us-west': 'ondemand.us-west-1.saucelabs.com',
     'us-east': 'ondemand.us-east-1.saucelabs.com',
     'eu': 'ondemand.eu-central-1.saucelabs.com'
 }
 
+
 class SauceSession():
 
     def __init__(self, options=None, data_center='us-west'):
         self.options = options if options else SauceOptions()
-        self._username = SAUCE_USERNAME
-        self._access_key = SAUCE_ACCESS_KEY
+        self._username = os.getenv('SAUCE_USERNAME', None)
+        self._access_key = os.getenv('SAUCE_ACCESS_KEY', None)
         self.data_center = data_center if data_center else 'us-west'
         self._remote_url = None
         self.driver = None

--- a/python/tests/test_session.py
+++ b/python/tests/test_session.py
@@ -39,6 +39,7 @@ class TestInit(object):
         assert session.options.browser_version == 'latest'
         assert session.options.platform_name == 'Windows 10'
 
+
 class TestDataCenter(object):
 
     def test_overrides_default_value_for_data_center(self):
@@ -53,7 +54,6 @@ class TestDataCenter(object):
 
         with pytest.raises(ValueError):
             session.data_center = 'invalid'
-
 
 
 class TestStart(object):

--- a/python/tests/test_session.py
+++ b/python/tests/test_session.py
@@ -3,6 +3,9 @@ import os
 from simplesauce.options import SauceOptions
 from simplesauce.session import SauceSession
 
+SAUCE_USERNAME_HOLDER = os.getenv('SAUCE_USERNAME', None)
+SAUCE_ACCESS_KEY_HOLDER = os.getenv('SAUCE_ACCESS_KEY', None)
+
 
 class TestInit(object):
 
@@ -69,12 +72,16 @@ class TestStart(object):
         with pytest.raises(KeyError):
             session.start()
 
+        os.environ['SAUCE_USERNAME'] = SAUCE_USERNAME_HOLDER
+
     def test_raises_exception_if_no_access_key_set(self):
         del os.environ['SAUCE_ACCESS_KEY']
         session = SauceSession()
 
         with pytest.raises(KeyError):
             session.start()
+
+        os.environ['SAUCE_ACCESS_KEY'] = SAUCE_ACCESS_KEY_HOLDER
 
 
 class TestURL(object):

--- a/python/tests/test_session.py
+++ b/python/tests/test_session.py
@@ -36,22 +36,6 @@ class TestInit(object):
         assert session.options.browser_version == 'latest'
         assert session.options.platform_name == 'Windows 10'
 
-    def test_uses_username_and_access_key_if_environment_variables_are_defined(self):
-        session = SauceSession()
-
-        assert session.username == os.environ['SAUCE_USERNAME']
-        assert session.access_key == os.environ['SAUCE_ACCESS_KEY']
-
-    def test_accepts_provided_username_and_access_key(self):
-        user = 'alice.smith'
-        access_key = 'abce-defg-hijk'
-
-        session = SauceSession(username=user, access_key=access_key)
-
-        assert session.username == user
-        assert session.access_key == access_key
-
-
 class TestDataCenter(object):
 
     def test_overrides_default_value_for_data_center(self):
@@ -67,26 +51,6 @@ class TestDataCenter(object):
         with pytest.raises(ValueError):
             session.data_center = 'invalid'
 
-class TestUsername(object):
-
-    def test_accepts_provided_username(self):
-        user = 'bob.smith'
-        session = SauceSession()
-
-        session.username = user
-
-        assert session.username == user
-
-
-class TestAccessKey(object):
-
-    def test_accepts_provided_access_key(self):
-        key = 'abcd-1234-5678'
-        session = SauceSession()
-
-        session.access_key = key
-
-        assert session.access_key == key
 
 
 class TestStart(object):
@@ -99,17 +63,15 @@ class TestStart(object):
         assert session.driver.session_id
 
     def test_raises_exception_if_no_username_set(self):
+        del os.environ['SAUCE_USERNAME']
         session = SauceSession()
-
-        session.username = None
 
         with pytest.raises(KeyError):
             session.start()
 
     def test_raises_exception_if_no_access_key_set(self):
+        del os.environ['SAUCE_ACCESS_KEY']
         session = SauceSession()
-
-        session.access_key = None
 
         with pytest.raises(KeyError):
             session.start()

--- a/ruby/lib/simple_sauce/session.rb
+++ b/ruby/lib/simple_sauce/session.rb
@@ -9,20 +9,20 @@ module SimpleSauce
                     US_EAST: 'ondemand.us-east-1.saucelabs.com',
                     EU_VDC: 'ondemand.eu-central-1.saucelabs.com'}.freeze
 
-    attr_writer :username, :access_key, :url
+    attr_writer :url
     attr_reader :driver, :options, :data_center
 
-    def initialize(options = nil, username: nil, access_key: nil, data_center: nil)
+    def initialize(options = nil, data_center: nil)
       @options = options || Options.new
 
-      @username = username || ENV['SAUCE_USERNAME']
-      @access_key = access_key || ENV['SAUCE_ACCESS_KEY']
+      @username = ENV['SAUCE_USERNAME']
+      @access_key = ENV['SAUCE_ACCESS_KEY']
       self.data_center = data_center || :US_WEST
     end
 
     def start
-      raise ArgumentError, "needs username; use `ENV['SAUCE_USERNAME']` or `Session#username=`" unless @username
-      raise ArgumentError, "needs access_key; use `ENV['SAUCE_ACCESS_KEY']` or `Session#access_key=`" unless @access_key
+      raise ArgumentError, "needs username; use `ENV['SAUCE_USERNAME']`" unless @username
+      raise ArgumentError, "needs access_key; use `ENV['SAUCE_ACCESS_KEY']`" unless @access_key
 
       @driver = Selenium::WebDriver.for :remote, to_selenium
     end

--- a/ruby/spec/session_spec.rb
+++ b/ruby/spec/session_spec.rb
@@ -72,12 +72,10 @@ module SimpleSauce
         expect(session.data_center).to eq :US_WEST
       end
 
-      it 'uses provided Data Center, Username, Access Key' do
-        session = Session.new(data_center: :EU_VDC,
-                              username: 'bar',
-                              access_key: '321')
+      it 'uses provided Data Center' do
+        session = Session.new(data_center: :EU_VDC,)
 
-        expected_results = {url: 'https://bar:321@ondemand.eu-central-1.saucelabs.com:443/wd/hub',
+        expected_results = {url: 'https://foo:123@ondemand.eu-central-1.saucelabs.com:443/wd/hub',
                             desired_capabilities: {'browserName' => 'chrome',
                                                    'browserVersion' => 'latest',
                                                    'platformName' => 'Windows 10',
@@ -96,6 +94,12 @@ module SimpleSauce
 
         driver = Session.new.start
         expect(driver).to be_a Selenium::WebDriver::Driver
+      end
+
+      it 'uses username and access key from ENV' do
+        session = Session.new
+
+        expect(session.url).to include('foo:123')
       end
 
       it 'raises exception if no username set' do
@@ -139,24 +143,6 @@ module SimpleSauce
         session = Session.new
 
         expect { session.data_center = :FOO }.to raise_exception(ArgumentError)
-      end
-    end
-
-    describe '#username=' do
-      it 'accepts provided username' do
-        session = Session.new
-        session.username = 'name'
-
-        expect(session.url).to eq('https://name:123@ondemand.us-west-1.saucelabs.com:443/wd/hub')
-      end
-    end
-
-    describe '#access_key=' do
-      it 'accepts provided access key' do
-        session = Session.new
-        session.access_key = '456'
-
-        expect(session.url).to eq('https://foo:456@ondemand.us-west-1.saucelabs.com:443/wd/hub')
       end
     end
 

--- a/ruby/spec/session_spec.rb
+++ b/ruby/spec/session_spec.rb
@@ -73,7 +73,7 @@ module SimpleSauce
       end
 
       it 'uses provided Data Center' do
-        session = Session.new(data_center: :EU_VDC,)
+        session = Session.new(data_center: :EU_VDC)
 
         expected_results = {url: 'https://foo:123@ondemand.eu-central-1.saucelabs.com:443/wd/hub',
                             desired_capabilities: {'browserName' => 'chrome',


### PR DESCRIPTION
Ok, here's my suggested solution for #19 

1. Force ENV usage on CI tool
2. Allow setting property on local run

I think number 1 accomplishes the goal we have of keeping people from storing credentials in version control
Where number 2 gives users some flexibility to both use the bindings and have ability to do various useful things, without us having to do a new release to support it.

We'll want to update the other languages to remove accessor support for username/access key as well.