### PR TITLE
[java] allow user to pass through Command Executor code

### DIFF
--- a/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/simplesauce/SauceSession.java
@@ -5,10 +5,15 @@ import org.openqa.selenium.JavascriptExecutor;
 import lombok.Setter;
 import org.openqa.selenium.InvalidArgumentException;
 import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.remote.CommandExecutor;
+import org.openqa.selenium.remote.CommandInfo;
+import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.http.HttpClient;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Map;
 
 public class SauceSession {
 
@@ -21,6 +26,7 @@ public class SauceSession {
 
     @Getter @Setter private DataCenter dataCenter = DataCenter.US_WEST;
     @Getter private final SauceOptions sauceOptions;
+    @Getter private CommandExecutor commandExecutor;
     @Setter private URL sauceUrl;
 
     @Getter private RemoteWebDriver driver;
@@ -51,8 +57,20 @@ public class SauceSession {
         }
     }
 
+    public void setCommandExecutor(Map<String, CommandInfo> commandInfoMap) {
+        commandExecutor = new HttpCommandExecutor(commandInfoMap, getSauceUrl());
+    }
+
+    public void setCommandExecutor(Map<String, CommandInfo> commandInfoMap, HttpClient.Factory factory) {
+        commandExecutor = new HttpCommandExecutor(commandInfoMap, getSauceUrl(), factory);
+    }
+
     protected RemoteWebDriver createRemoteWebDriver(URL url, MutableCapabilities capabilities) {
-        return new RemoteWebDriver(url, capabilities);
+        if (commandExecutor != null) {
+            return new RemoteWebDriver(commandExecutor, capabilities);
+        } else {
+            return new RemoteWebDriver(url, capabilities);
+        }
     }
 
     protected JavascriptExecutor getJSExecutor() {

--- a/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/simplesauce/SauceSessionTest.java
@@ -8,10 +8,14 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.http.HttpClient;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -158,5 +162,35 @@ public class SauceSessionTest {
         sauceSession.start();
         sauceSession.stop("failed");
         verify(dummyJSExecutor).executeScript("sauce:job-result=failed");
+    }
+
+    @Test
+    public void setsCommandExecutorWithMap(){
+        Map<String, CommandInfo> commandInfoMap = new HashMap<>();
+        sauceSession.setCommandExecutor(commandInfoMap);
+        RemoteWebDriver driver = sauceSession.start();
+
+        // TODO: Verify something
+    }
+    @Test
+    public void setsCommandExecutorWithFactory(){
+        Map<String, CommandInfo> commandInfoMap = new HashMap<>();
+
+        HttpClient.Factory factory = new HttpClient.Factory() {
+            @Override
+            public HttpClient.Builder builder() {
+                return null;
+            }
+
+            @Override
+            public void cleanupIdleClients() {
+
+            }
+        };
+
+        sauceSession.setCommandExecutor(commandInfoMap, factory);
+        RemoteWebDriver driver = sauceSession.start();
+
+        // TODO: Verify something
     }
 }


### PR DESCRIPTION
I'm not sure this is the right way to do it.

The complication is that command executor constructor requires the URL, which Session wants to generate for the user.

Another option I think would be to make the user set it with `start()`
I think this is the best implementation wise, but not sure it is the best user-wise
```java
SauceSession session = new SauceSession(options);
CommandExecutor executor = new HttpCommandExecutor(commandInfoMap, session.getSauceUrl)
RemoteWebDriver driver = session.start(executor);
```

The main issue is that I don't know how to test these things. This code is one big rabbit hole to me.
can anyone help?