### PR TITLE
updated defaults for safari

### DIFF
--- a/python/saucebindings/options.py
+++ b/python/saucebindings/options.py
@@ -104,7 +104,12 @@ class SauceOptions:
             self.set_capability('browserName', 'chrome')
 
         if self.platform_name is None:
-            self.set_capability('platformName', 'Windows 10')
+            # Special Case: Safari is selected as the browserName
+            # In this case, default to MacOS 10.14
+            if browserName and browserName.lower() == 'safari':
+                self.set_capability('platformName', 'MacOS 10.14')
+            else:
+                self.set_capability('platformName', 'Windows 10')
 
         self._set_default_build_name()
 

--- a/python/tests/test_safari.py
+++ b/python/tests/test_safari.py
@@ -4,6 +4,13 @@ from saucebindings.options import SauceOptions
 class TestSafari(object):
 
     def test_defaults(self):
+        sauce = SauceOptions('safari')
+
+        assert sauce.browser_name == 'safari'
+        assert sauce.browser_version == 'latest'
+        assert sauce.platform_name == 'MacOS 10.14'
+
+    def test_with_platformName(self):
         sauce = SauceOptions('safari', platformName='macOS 10.14')
 
         assert sauce.browser_name == 'safari'


### PR DESCRIPTION
In response to issue #28, the changes here are to default nicely to Safari 12 on Mojave. 