### PR TITLE
[dotnet] renamed to sauce bindings

### DIFF
--- a/dotnet/DotnetCore.Test/DotnetCore.Test.csproj
+++ b/dotnet/DotnetCore.Test/DotnetCore.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/Simple.Sauce/Browser.cs
+++ b/dotnet/Simple.Sauce/Browser.cs
@@ -1,4 +1,4 @@
-﻿namespace Simple.Sauce
+﻿namespace Sauce.Bindings
 {
     public class Browser
     {

--- a/dotnet/Simple.Sauce/DataCenter.cs
+++ b/dotnet/Simple.Sauce/DataCenter.cs
@@ -1,4 +1,4 @@
-﻿namespace Simple.Sauce
+﻿namespace Sauce.Bindings
 {
     public class DataCenter
     {

--- a/dotnet/Simple.Sauce/EdgeVersion.cs
+++ b/dotnet/Simple.Sauce/EdgeVersion.cs
@@ -1,4 +1,4 @@
-﻿namespace Simple.Sauce
+﻿namespace Sauce.Bindings
 {
     public class EdgeVersion
     {

--- a/dotnet/Simple.Sauce/ISauceRemoteDriver.cs
+++ b/dotnet/Simple.Sauce/ISauceRemoteDriver.cs
@@ -1,6 +1,6 @@
 ﻿using OpenQA.Selenium;
 
-namespace Simple.Sauce
+namespace Sauce.Bindings
 {
     public interface ISauceRemoteDriver : IJavaScriptExecutor, IWebDriver
     {

--- a/dotnet/Simple.Sauce/IncorrectSafariVersionException.cs
+++ b/dotnet/Simple.Sauce/IncorrectSafariVersionException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Simple.Sauce
+namespace Sauce.Bindings
 {
     public class IncorrectSafariVersionException : Exception
     {

--- a/dotnet/Simple.Sauce/Platforms.cs
+++ b/dotnet/Simple.Sauce/Platforms.cs
@@ -1,6 +1,4 @@
-using System;
-
-namespace Simple.Sauce
+namespace Sauce.Bindings
 {
     public class Platforms
     {

--- a/dotnet/Simple.Sauce/Sauce.Bindings.csproj
+++ b/dotnet/Simple.Sauce/Sauce.Bindings.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageId>Simple.Sauce</PackageId>
+    <PackageId>Sauce.Bindings</PackageId>
     <description>An API wrapper arounds the Sauce Labs API to make test automation extremely easy</description>
     <PackageTags>Sauce Labs, Simple Sauce, Selenium</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/dotnet/Simple.Sauce/Sauce.sln
+++ b/dotnet/Simple.Sauce/Sauce.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29230.47
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleSauce.Test", "..\SimpleSauce.Test\SimpleSauce.Test.csproj", "{DBD7C90F-9514-4EDD-AAB2-63F699CA0BED}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SauceBindings.Test", "..\SimpleSauce.Test\SauceBindings.Test.csproj", "{DBD7C90F-9514-4EDD-AAB2-63F699CA0BED}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D7946C31-90AC-4E17-B663-66C057BD0201}"
 	ProjectSection(SolutionItems) = preProject
@@ -18,7 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A87FACF6-AEF
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{8D1592F6-2723-4AD2-A792-3FEC4408BDC2}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Simple.Sauce", "Simple.Sauce.csproj", "{14CDEF4F-FE78-4FA7-AD7C-A535C555BED9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sauce.Bindings", "Sauce.Bindings.csproj", "{14CDEF4F-FE78-4FA7-AD7C-A535C555BED9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotnetCore.Test", "..\DotnetCore.Test\DotnetCore.Test.csproj", "{EAEF175B-778D-4207-8E0A-F04D4F0A10F8}"
 EndProject
@@ -47,6 +47,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{DBD7C90F-9514-4EDD-AAB2-63F699CA0BED} = {8D1592F6-2723-4AD2-A792-3FEC4408BDC2}
 		{14CDEF4F-FE78-4FA7-AD7C-A535C555BED9} = {A87FACF6-AEFA-45FB-B73C-56378772CE57}
+		{EAEF175B-778D-4207-8E0A-F04D4F0A10F8} = {8D1592F6-2723-4AD2-A792-3FEC4408BDC2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B63DCFB9-E2DF-4886-AF33-8280A869A7F5}

--- a/dotnet/Simple.Sauce/SauceDriver.cs
+++ b/dotnet/Simple.Sauce/SauceDriver.cs
@@ -3,7 +3,7 @@ using System.Collections.ObjectModel;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Remote;
 
-namespace Simple.Sauce
+namespace Sauce.Bindings
 {
     public class SauceDriver : ISauceRemoteDriver
     {

--- a/dotnet/Simple.Sauce/SauceOptions.cs
+++ b/dotnet/Simple.Sauce/SauceOptions.cs
@@ -5,9 +5,10 @@ using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Edge;
 using OpenQA.Selenium.Firefox;
 using OpenQA.Selenium.Safari;
+
 // ReSharper disable InconsistentNaming
 
-namespace Simple.Sauce
+namespace Sauce.Bindings
 {
     public class SauceOptions
     {

--- a/dotnet/Simple.Sauce/SauceSession.cs
+++ b/dotnet/Simple.Sauce/SauceSession.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 
-namespace Simple.Sauce
+namespace Sauce.Bindings
 {
     public class SauceSession
     {

--- a/dotnet/Simple.Sauce/TestVisibility.cs
+++ b/dotnet/Simple.Sauce/TestVisibility.cs
@@ -1,4 +1,4 @@
-﻿namespace Simple.Sauce
+﻿namespace Sauce.Bindings
 {
     public enum TestVisibility
     {

--- a/dotnet/Simple.Sauce/Timeout.cs
+++ b/dotnet/Simple.Sauce/Timeout.cs
@@ -1,8 +1,7 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
-namespace Simple.Sauce
+namespace Sauce.Bindings
 {
     public class Timeout
     {

--- a/dotnet/SimpleSauce.Test/AcceptanceTests.cs
+++ b/dotnet/SimpleSauce.Test/AcceptanceTests.cs
@@ -1,17 +1,14 @@
-using System;
-using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
-using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Remote;
-using Simple.Sauce;
+using Sauce.Bindings;
 
-namespace SimpleSauce.Test
+namespace SauceBindings.Test
 {
     [TestClass]
     [TestCategory("Acceptance")]
-    public class SimpleSauceAcceptanceTests
+    public class AcceptanceTests
     {
         private SauceOptions _sauceOptions;
         private IWebDriver _driver;
@@ -40,7 +37,7 @@ namespace SimpleSauce.Test
             _session = new SauceSession(_sauceOptions);
             _driver = _session.Start();
             var capabilities = ((RemoteWebDriver)_driver).Capabilities;
-            capabilities.GetCapability("browserName").Should().Be("MicrosoftEdge");
+            capabilities.GetCapability("browserName").Should().Be("msedge");
         }
         [TestMethod]
         [Ignore("Getting an infrastructure error")]

--- a/dotnet/SimpleSauce.Test/BaseTest.cs
+++ b/dotnet/SimpleSauce.Test/BaseTest.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Simple.Sauce;
+using Sauce.Bindings;
 
 [assembly: Parallelize(Workers = 100, Scope = ExecutionScope.MethodLevel)]
 
-namespace SimpleSauce.Test
+namespace SauceBindings.Test
 {
     public class BaseTest
     {

--- a/dotnet/SimpleSauce.Test/BaselineSeleniumAcceptanceTests.cs
+++ b/dotnet/SimpleSauce.Test/BaselineSeleniumAcceptanceTests.cs
@@ -5,9 +5,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Remote;
-using Simple.Sauce;
 
-namespace SimpleSauce.Test
+namespace SauceBindings.Test
 {
     [TestClass]
     [TestCategory("Acceptance")]

--- a/dotnet/SimpleSauce.Test/Browsers/ChromeTests.cs
+++ b/dotnet/SimpleSauce.Test/Browsers/ChromeTests.cs
@@ -1,9 +1,9 @@
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Chrome;
-using Simple.Sauce;
+using Sauce.Bindings;
 
-namespace SimpleSauce.Test.Browsers
+namespace SauceBindings.Test.Browsers
 {
     [TestClass]
     public class ChromeTests : BaseTest

--- a/dotnet/SimpleSauce.Test/Browsers/EdgeTests.cs
+++ b/dotnet/SimpleSauce.Test/Browsers/EdgeTests.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Simple.Sauce;
+using Sauce.Bindings;
 
-namespace SimpleSauce.Test.Browsers
+namespace SauceBindings.Test.Browsers
 {
     [TestClass]
     public class EdgeTests : BaseTest

--- a/dotnet/SimpleSauce.Test/Browsers/FirefoxTests.cs
+++ b/dotnet/SimpleSauce.Test/Browsers/FirefoxTests.cs
@@ -1,10 +1,9 @@
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Firefox;
-using Simple.Sauce;
+using Sauce.Bindings;
 
-namespace SimpleSauce.Test.Browsers
+namespace SauceBindings.Test.Browsers
 {
     [TestClass]
     public class FirefoxTests : BaseTest

--- a/dotnet/SimpleSauce.Test/Browsers/SafariTests.cs
+++ b/dotnet/SimpleSauce.Test/Browsers/SafariTests.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Simple.Sauce;
+using Sauce.Bindings;
 
-namespace SimpleSauce.Test.Browsers
+namespace SauceBindings.Test.Browsers
 {
     [TestClass]
     public class SafariTests : BaseTest

--- a/dotnet/SimpleSauce.Test/DataCenterTests.cs
+++ b/dotnet/SimpleSauce.Test/DataCenterTests.cs
@@ -1,8 +1,8 @@
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Simple.Sauce;
+using Sauce.Bindings;
 
-namespace SimpleSauce.Test
+namespace SauceBindings.Test
 {
     [TestClass]
     public class DataCenterTests

--- a/dotnet/SimpleSauce.Test/SauceBindings.Test.csproj
+++ b/dotnet/SimpleSauce.Test/SauceBindings.Test.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -35,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Simple.Sauce\Simple.Sauce.csproj" />
+    <ProjectReference Include="..\Simple.Sauce\Sauce.Bindings.csproj" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/SimpleSauce.Test/SauceDriverTests.cs
+++ b/dotnet/SimpleSauce.Test/SauceDriverTests.cs
@@ -1,9 +1,9 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
-using Simple.Sauce;
+using Sauce.Bindings;
 
-namespace SimpleSauce.Test
+namespace SauceBindings.Test
 {
     [TestClass]
     public class SauceDriverTests : BaseTest

--- a/dotnet/SimpleSauce.Test/SauceOptionsTests.cs
+++ b/dotnet/SimpleSauce.Test/SauceOptionsTests.cs
@@ -1,14 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices.ComTypes;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
-using OpenQA.Selenium.Chrome;
-using OpenQA.Selenium.Edge;
-using Simple.Sauce;
+using Sauce.Bindings;
 
-namespace SimpleSauce.Test
+namespace SauceBindings.Test
 {
     [TestClass]
     public class SauceOptionsTests : BaseTest

--- a/dotnet/SimpleSauce.Test/SauceSessionTests.cs
+++ b/dotnet/SimpleSauce.Test/SauceSessionTests.cs
@@ -1,12 +1,10 @@
-using System;
-using System.Reflection;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Newtonsoft.Json;
-using Simple.Sauce;
+using Sauce.Bindings;
 
-namespace SimpleSauce.Test
+namespace SauceBindings.Test
 {
     [TestClass]
     public class SauceSessionTests : BaseTest


### PR DESCRIPTION
- Renamed everything to Sauce.Bindings
- Fixed issue with old version of .NET Core and moved it to 3.0

