### PR TITLE
move authentication handling into the Options class

### DIFF
--- a/java/src/main/java/com/saucelabs/saucebindings/DataCenter.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/DataCenter.java
@@ -3,9 +3,9 @@ package com.saucelabs.saucebindings;
 import lombok.Getter;
 
 public enum DataCenter {
-    US_WEST("ondemand.us-west-1.saucelabs.com"),
-    US_EAST("ondemand.us-east-1.saucelabs.com"),
-    EU_CENTRAL("ondemand.eu-central-1.saucelabs.com");
+    US_WEST("https://ondemand.us-west-1.saucelabs.com/wd/hub"),
+    US_EAST("https://ondemand.us-east-1.saucelabs.com/wd/hub"),
+    EU_CENTRAL("https://ondemand.eu-central-1.saucelabs.com/wd/hub");
 
     @Getter private final String value;
 

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -167,7 +167,7 @@ public class SauceOptions {
     }
 
     public MutableCapabilities toCapabilities() {
-        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+        MutableCapabilities sauceCapabilities = addAuthentication();
 
         if (getCapability("jobVisibility") != null) {
             sauceCapabilities.setCapability("public", getCapability("jobVisibility"));
@@ -324,6 +324,37 @@ public class SauceOptions {
             default:
                 break;
         }
+    }
+
+    private MutableCapabilities addAuthentication() {
+        MutableCapabilities caps = new MutableCapabilities();
+        caps.setCapability("username", getSauceUsername());
+        caps.setCapability("accessKey", getSauceAccessKey());
+        return caps;
+    }
+
+    protected String getSauceUsername() {
+        if (getSystemProperty("SAUCE_USERNAME") != null) {
+            return getSystemProperty("SAUCE_USERNAME");
+        } else if (getEnvironmentVariable("SAUCE_USERNAME") != null) {
+            return getEnvironmentVariable("SAUCE_USERNAME");
+        } else {
+            throw new SauceEnvironmentVariablesNotSetException("Sauce Username was not provided");
+        }
+    }
+
+    protected String getSauceAccessKey() {
+        if (getSystemProperty("SAUCE_ACCESS_KEY") != null) {
+            return getSystemProperty("SAUCE_ACCESS_KEY");
+        } else if (getEnvironmentVariable("SAUCE_ACCESS_KEY") != null) {
+            return getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        } else {
+            throw new SauceEnvironmentVariablesNotSetException("Sauce Access Key was not provided");
+        }
+    }
+
+    protected String getSystemProperty(String key) {
+        return System.getProperty(key);
     }
 
     protected String getEnvironmentVariable(String key) {

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -34,9 +34,8 @@ public class SauceSession {
         if (sauceUrl != null) {
             return sauceUrl;
         } else {
-            String url = "https://" + getSauceUsername() + ":" + getSauceAccessKey() + "@" + dataCenter + "/wd/hub";
             try {
-                return new URL(url);
+                return new URL(dataCenter.getValue());
             } catch (MalformedURLException e) {
                 throw new InvalidArgumentException("Invalid URL");
             }
@@ -69,33 +68,5 @@ public class SauceSession {
         if(driver !=null) {
             driver.quit();
         }
-    }
-
-    private String getSauceUsername() {
-        if (getSystemProperty("SAUCE_USERNAME") != null) {
-            return getSystemProperty("SAUCE_USERNAME");
-        } else if (getEnvironmentVariable("SAUCE_USERNAME") != null) {
-            return getEnvironmentVariable("SAUCE_USERNAME");
-        } else {
-            throw new SauceEnvironmentVariablesNotSetException("Sauce Username was not provided");
-        }
-    }
-
-    private String getSauceAccessKey() {
-        if (getSystemProperty("SAUCE_ACCESS_KEY") != null) {
-            return getSystemProperty("SAUCE_ACCESS_KEY");
-        } else if (getEnvironmentVariable("SAUCE_ACCESS_KEY") != null) {
-            return getEnvironmentVariable("SAUCE_ACCESS_KEY");
-        } else {
-            throw new SauceEnvironmentVariablesNotSetException("Sauce Access Key was not provided");
-        }
-    }
-
-    protected String getSystemProperty(String key) {
-        return System.getProperty(key);
-    }
-
-    protected String getEnvironmentVariable(String key) {
-        return System.getenv(key);
     }
 }

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.spy;
 import static org.openqa.selenium.UnexpectedAlertBehaviour.DISMISS;
 
 public class SauceOptionsTest {
-    protected SauceOptions sauceOptions = new SauceOptions();
+    private SauceOptions sauceOptions = spy(new SauceOptions());
 
     @Rule
     public MockitoRule initRule = MockitoJUnit.rule();
@@ -222,7 +222,6 @@ public class SauceOptionsTest {
 
     @Test
     public void createsDefaultBuildName() {
-        SauceOptions sauceOptions = spy(new SauceOptions());
         doReturn("Not Empty").when(sauceOptions).getEnvironmentVariable("BUILD_TAG");
         doReturn("TEMP BUILD").when(sauceOptions).getEnvironmentVariable("BUILD_NAME");
         doReturn("11").when(sauceOptions).getEnvironmentVariable("BUILD_NUMBER");
@@ -301,6 +300,9 @@ public class SauceOptionsTest {
 
     @Test
     public void parsesCapabilitiesFromW3CValues() {
+        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
+        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+
         sauceOptions.setBrowserName(Browser.FIREFOX);
         sauceOptions.setPlatformName(SaucePlatform.MAC_HIGH_SIERRA);
         sauceOptions.setBrowserVersion("77");
@@ -316,8 +318,8 @@ public class SauceOptionsTest {
 
         Map<Timeouts, Integer> timeouts = new HashMap<>();
         timeouts.put(Timeouts.IMPLICIT, 1);
-        timeouts.put(Timeouts.PAGE_LOAD, 100);
         timeouts.put(Timeouts.SCRIPT, 10);
+        timeouts.put(Timeouts.PAGE_LOAD, 100);
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
         expectedCapabilities.setCapability("browserName", "firefox");
@@ -332,6 +334,8 @@ public class SauceOptionsTest {
 
         MutableCapabilities sauceCapabilities = new MutableCapabilities();
         sauceCapabilities.setCapability("build", "Build Name");
+        sauceCapabilities.setCapability("username", "test-name");
+        sauceCapabilities.setCapability("accessKey", "test-accesskey");
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
         MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
 
@@ -340,6 +344,9 @@ public class SauceOptionsTest {
 
     @Test
     public void parsesCapabilitiesFromSauceValues() {
+        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
+        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+
         Map<String, Object> customData = new HashMap<>();
         customData.put("foo", "foo");
         customData.put("bar", "bar");
@@ -410,6 +417,8 @@ public class SauceOptionsTest {
         sauceCapabilities.setCapability("timeZone", "San Francisco");
         sauceCapabilities.setCapability("tunnelIdentifier", "tunnelname");
         sauceCapabilities.setCapability("videoUploadOnPass", false);
+        sauceCapabilities.setCapability("username", "test-name");
+        sauceCapabilities.setCapability("accessKey", "test-accesskey");
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
         expectedCapabilities.setCapability("browserName", "chrome");
@@ -429,7 +438,11 @@ public class SauceOptionsTest {
         firefoxOptions.addArguments("--foo");
         firefoxOptions.addPreference("foo", "bar");
         firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
-        sauceOptions = new SauceOptions(firefoxOptions);
+
+        sauceOptions = spy(new SauceOptions(firefoxOptions));
+        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
+        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+
         sauceOptions.setBuild("Build Name");
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
@@ -440,12 +453,15 @@ public class SauceOptionsTest {
 
         MutableCapabilities sauceCapabilities = new MutableCapabilities();
         sauceCapabilities.setCapability("build", "Build Name");
+        sauceCapabilities.setCapability("username", "test-name");
+        sauceCapabilities.setCapability("accessKey", "test-accesskey");
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
         MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
 
         assertEquals(expectedCapabilities.asMap().toString(), actualCapabilities.asMap().toString());
     }
-        @Test
+
+    @Test
     public void parsesW3CAndSauceAndSeleniumSettings() {
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
         MutableCapabilities sauceCapabilities = new MutableCapabilities();
@@ -454,7 +470,10 @@ public class SauceOptionsTest {
         firefoxOptions.addArguments("--foo");
         firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
 
-        sauceOptions = new SauceOptions(firefoxOptions);
+        sauceOptions = spy(new SauceOptions(firefoxOptions));
+
+        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
+        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
 
         expectedCapabilities.merge(firefoxOptions);
         expectedCapabilities.setCapability("browserVersion", "latest");
@@ -473,8 +492,8 @@ public class SauceOptionsTest {
                 .setScript(10);
         Map<Timeouts, Integer> timeouts = new HashMap<>();
         timeouts.put(Timeouts.IMPLICIT, 1);
-        timeouts.put(Timeouts.PAGE_LOAD, 100);
         timeouts.put(Timeouts.SCRIPT, 10);
+        timeouts.put(Timeouts.PAGE_LOAD, 100);
         expectedCapabilities.setCapability("timeouts", timeouts);
         sauceOptions.setUnhandledPromptBehavior(UnhandledPromptBehavior.IGNORE);
         expectedCapabilities.setCapability("unhandledPromptBehavior", UnhandledPromptBehavior.IGNORE);
@@ -488,10 +507,12 @@ public class SauceOptionsTest {
 
         sauceOptions.setJobVisibility(JobVisibility.SHARE);
         sauceCapabilities.setCapability("public", JobVisibility.SHARE);
+        sauceCapabilities.setCapability("username", "test-name");
+        sauceCapabilities.setCapability("accessKey", "test-accesskey");
 
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
         MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
 
         assertEquals(expectedCapabilities.asMap().toString(), actualCapabilities.asMap().toString());
-        }
+    }
 }

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 public class SauceSessionTest {
     private SauceOptions sauceOptions = spy(new SauceOptions());
     private SauceSession sauceSession = spy(new SauceSession());
+    private SauceSession sauceOptsSession = spy(new SauceSession(sauceOptions));
     private RemoteWebDriver dummyRemoteDriver = mock(RemoteWebDriver.class);
     private JavascriptExecutor dummyJSExecutor = mock(JavascriptExecutor.class);
     private MutableCapabilities dummyMutableCapabilities = mock(MutableCapabilities.class);
@@ -48,11 +49,10 @@ public class SauceSessionTest {
 
     @Test
     public void sauceSessionUsesProvidedSauceOptions() {
-        sauceSession = spy(new SauceSession(sauceOptions));
         doReturn(dummyMutableCapabilities).when(sauceOptions).toCapabilities();
-        doReturn(dummyRemoteDriver).when(sauceSession).createRemoteWebDriver(any(URL.class), eq(dummyMutableCapabilities));
+        doReturn(dummyRemoteDriver).when(sauceOptsSession).createRemoteWebDriver(any(URL.class), eq(dummyMutableCapabilities));
 
-        sauceSession.start();
+        sauceOptsSession.start();
 
         verify(sauceOptions).toCapabilities();
     }
@@ -71,24 +71,6 @@ public class SauceSessionTest {
     }
 
     @Test
-    public void defaultSauceURLUsesENVForUsernameAccessKey() {
-        doReturn("test-name").when(sauceSession).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceSession).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-
-        String expetedSauceUrl = "https://test-name:test-accesskey@ondemand.us-west-1.saucelabs.com/wd/hub";
-        assertEquals(expetedSauceUrl, sauceSession.getSauceUrl().toString());
-    }
-
-    @Test
-    public void setUserNameAndAccessKeyWithSystemProperties() {
-        doReturn("test-name").when(sauceSession).getSystemProperty("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceSession).getSystemProperty("SAUCE_ACCESS_KEY");
-
-        String expetedSauceUrl = "https://test-name:test-accesskey@ondemand.us-west-1.saucelabs.com/wd/hub";
-        assertEquals(expetedSauceUrl, sauceSession.getSauceUrl().toString());
-    }
-
-    @Test
     public void setsSauceURLDirectly() throws MalformedURLException {
         sauceSession.setSauceUrl(new URL("http://example.com"));
         String expetedSauceUrl = "http://example.com";
@@ -97,14 +79,14 @@ public class SauceSessionTest {
 
     @Test(expected = SauceEnvironmentVariablesNotSetException.class)
     public void startThrowsErrorWithoutUsername() {
-        doReturn(null).when(sauceSession).getEnvironmentVariable("SAUCE_USERNAME");
-        sauceSession.start();
+        doReturn(null).when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
+        sauceOptsSession.start();
     }
 
     @Test(expected = SauceEnvironmentVariablesNotSetException.class)
     public void startThrowsErrorWithoutAccessKey() {
-        doReturn(null).when(sauceSession).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-        sauceSession.start();
+        doReturn(null).when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        sauceOptsSession.start();
     }
 
     @Test


### PR DESCRIPTION
(Don't merge until after 1.0 release)

Access Key has been removed from metadata view on Sauce Labs, so we should move authentication into the payload where it is most appropriate.

This has the added benefit of making it easier to manage both Sauce Labs and Test Object authentication approaches.