### PR TITLE
added output for Jenkins OnDemand results publisher

### DIFF
--- a/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -63,6 +63,11 @@ public class SauceSession {
 
     private void updateResult(String result) {
         getJSExecutor().executeScript("sauce:job-result=" + result);
+
+        if (this.driver != null) {
+            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", this.driver.getSessionId(), this.sauceOptions.getName());
+            System.out.print("SauceOnDemandSessionID={} job-name={}");
+        }
     }
 
     private void stop() {

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -64,9 +64,14 @@ public class SauceSession {
     private void updateResult(String result) {
         getJSExecutor().executeScript("sauce:job-result=" + result);
 
+        // Add output for the Sauce OnDemand Jenkins plugin
+        // The first print statement will automatically populate links on Jenkins to Sauce
+        // The second print statement will output the job link to logging/console
         if (this.driver != null) {
             String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", this.driver.getSessionId(), this.sauceOptions.getName());
-            System.out.print("SauceOnDemandSessionID={} job-name={}");
+            String sauceTestLink = String.format("Test Job Link: https://app.saucelabs.com/tests/%s", this.driver.getSessionId());
+            System.out.print(sauceReporter);
+            System.out.print(sauceTestLink);
         }
     }
 

--- a/python/saucebindings/session.py
+++ b/python/saucebindings/session.py
@@ -76,3 +76,7 @@ class SauceSession():
             result = 'failed'
 
         self.driver.execute_script('sauce:job-result={}'.format(result))
+
+        # Update results for Sauce Jenkins OnDemand plugin and test reporter
+        if self.driver is not None:
+            print("SauceOnDemandSessionID={} job-name={}".format(self.driver.session_id, self.options.name))

--- a/python/saucebindings/session.py
+++ b/python/saucebindings/session.py
@@ -77,6 +77,9 @@ class SauceSession():
 
         self.driver.execute_script('sauce:job-result={}'.format(result))
 
-        # Update results for Sauce Jenkins OnDemand plugin and test reporter
+        # Add output for the Sauce OnDemand Jenkins plugin
+        # The first print statement will automatically populate links on Jenkins to Sauce
+        # The second print statement will output the job link to logging/console
         if self.driver is not None:
-            print("SauceOnDemandSessionID={} job-name={}".format(self.driver.session_id, self.options.name))
+            print("SauceOnDemandSessioID={} job-name={}".format(self.driver.session_id, self.options.name))
+            print("Test Job Link: https://app.saucelabs.com/tests/{}".format(self.driver.session_id))

--- a/ruby/lib/sauce_bindings/session.rb
+++ b/ruby/lib/sauce_bindings/session.rb
@@ -34,7 +34,11 @@ module SauceBindings
       return if @driver.nil?
 
       SauceWhisk::Jobs.change_status(@driver.session_id, result)
+      # Add output for the Sauce OnDemand Jenkins plugin
+      # The first print statement will automatically populate links on Jenkins to Sauce
+      # The second print statement will output the job link to logging/console  
       puts "SauceOnDemandSessionID=#{@driver.session_id} job-name=#{@options.name}"
+      puts "Test Job Link: https://app.saucelabs.com/tests/#{@driver.session_id}"
       @driver.quit
     end
 

--- a/ruby/lib/sauce_bindings/session.rb
+++ b/ruby/lib/sauce_bindings/session.rb
@@ -34,6 +34,7 @@ module SauceBindings
       return if @driver.nil?
 
       SauceWhisk::Jobs.change_status(@driver.session_id, result)
+      puts "SauceOnDemandSessionID=#{@driver.session_id} job-name=#{@options.name}"
       @driver.quit
     end
 


### PR DESCRIPTION
Since Jenkins is such a common CI for many Sauce users, I've included some logic to automatically populate the Sauce test reporter in the Jenkins OnDemand Plugin. 