### PR TITLE
[java] support Options constructor with DesiredCapabilities instance

### DIFF
--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.ie.InternetExplorerOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.safari.SafariOptions;
 
 import java.lang.reflect.InvocationTargetException;
@@ -150,6 +151,16 @@ public class SauceOptions {
 
     public SauceOptions(SafariOptions options) {
         this(new MutableCapabilities(options));
+    }
+
+    /**
+     * @deprecated
+     * This constructor is provided to easily convert to SauceOptions from existing code
+     * Selenium will be deprecating DesiredCapabilities, so you are encouraged to update
+     */
+    @Deprecated
+    public SauceOptions(DesiredCapabilities capabilities) {
+        this(new MutableCapabilities(capabilities));
     }
 
     public Map<Timeouts, Integer> getTimeouts() {

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
@@ -9,6 +9,7 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.ie.InternetExplorerOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.safari.SafariOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -169,6 +170,18 @@ public class SauceOptionsTest {
 
         assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
         assertEquals(chromeOptions, sauceOptions.getSeleniumCapabilities());
+    }
+
+    @Test
+    public void acceptsDesiredeCapabilitiesClass() {
+        DesiredCapabilities capabilities = DesiredCapabilities.firefox();
+        capabilities.setCapability("args", "--foo");
+        capabilities.setCapability("unHandledPromptBehavior", "dismiss");
+
+        sauceOptions = new SauceOptions(capabilities);
+
+        assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals(capabilities.asMap(), sauceOptions.getSeleniumCapabilities().asMap());
     }
 
     @Test


### PR DESCRIPTION
After reviewing this code with a user, I realized that people have crazy complicated ways that they have put together DesiredCapabilities. Lots of conditionals, sometimes DataProviders, sometimes pulling from property files. The easiest way to get people to switch to using SauceBindings is to just allow them to pass in what they have. 

To mitigate people's reliance on it, I'm thinking we can add a deprecation notice. But then I think we also need to create some tutorials for "future-proofing your DesiredCapabilities"  and maybe add a link in the deprecation.