### PR TITLE
Android browser emusim

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,8 +57,8 @@
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -93,6 +93,11 @@
             <artifactId>snakeyaml</artifactId>
             <version>1.25</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.appium</groupId>
+            <artifactId>java-client</artifactId>
+            <version>7.3.3</version>
         </dependency>
     </dependencies>
     <build>

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceAndroidSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceAndroidSession.java
@@ -1,0 +1,24 @@
+package com.saucelabs.saucebindings;
+
+import io.appium.java_client.android.AndroidDriver;
+import lombok.Getter;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.net.URL;
+
+public class SauceAndroidSession extends SauceSession<AndroidDriver>  {
+    @Getter private AndroidDriver driver;
+
+    public SauceAndroidSession() {
+        this(SauceOptions.android());
+    }
+
+    public SauceAndroidSession(SauceOptions options) {
+        setSauceOptions(options);
+    }
+
+    protected AndroidDriver createDriver(URL url, MutableCapabilities capabilities) {
+        this.driver = new AndroidDriver(url, capabilities);
+        return driver;
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceIOSSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceIOSSession.java
@@ -1,0 +1,24 @@
+package com.saucelabs.saucebindings;
+
+import io.appium.java_client.ios.IOSDriver;
+import lombok.Getter;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.net.URL;
+
+public class SauceIOSSession extends SauceSession<IOSDriver>  {
+    @Getter private IOSDriver driver;
+
+    public SauceIOSSession() {
+        this(SauceOptions.ios());
+    }
+
+    public SauceIOSSession(SauceOptions options) {
+        setSauceOptions(options);
+    }
+
+    protected IOSDriver createDriver(URL url, MutableCapabilities capabilities) {
+        this.driver = new IOSDriver(url, capabilities);
+        return driver;
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SaucePlatform.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SaucePlatform.java
@@ -15,7 +15,9 @@ public enum SaucePlatform {
     MAC_HIGH_SIERRA("macOS 10.13"),
     MAC_SIERRA("macOS 10.12"),
     MAC_EL_CAPITAN("OS X 10.11"),
-    MAC_YOSEMITE("OS X 10.10");
+    MAC_YOSEMITE("OS X 10.10"),
+    ANDROID("android"),
+    IOS("IOS");
 
     @Getter
     private final String value;

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -9,9 +9,9 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-public class SauceSession {
+public class SauceSession<T extends RemoteWebDriver>  {
     @Getter @Setter private DataCenter dataCenter = DataCenter.US_WEST;
-    @Getter private final SauceOptions sauceOptions;
+    @Getter @Setter protected SauceOptions sauceOptions;
     @Setter private URL sauceUrl;
 
     @Getter private RemoteWebDriver driver;
@@ -24,9 +24,9 @@ public class SauceSession {
         sauceOptions = options;
     }
 
-    public RemoteWebDriver start() {
-        driver = createRemoteWebDriver(getSauceUrl(), sauceOptions.toCapabilities());
-        return driver;
+    public T start() {
+        this.driver = createDriver(getSauceUrl(), sauceOptions.toCapabilities());
+        return (T) driver;
 	}
 
     public URL getSauceUrl() {
@@ -41,8 +41,8 @@ public class SauceSession {
         }
     }
 
-    protected RemoteWebDriver createRemoteWebDriver(URL url, MutableCapabilities capabilities) {
-        return new RemoteWebDriver(url, capabilities);
+    protected T createDriver(URL url, MutableCapabilities capabilities) {
+        return (T) new RemoteWebDriver(url, capabilities);
     }
 
     public void stop(Boolean passed) {
@@ -60,16 +60,16 @@ public class SauceSession {
         // Add output for the Sauce OnDemand Jenkins plugin
         // The first print statement will automatically populate links on Jenkins to Sauce
         // The second print statement will output the job link to logging/console
-        if (this.driver != null) {
-            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", this.driver.getSessionId(), this.sauceOptions.getName());
-            String sauceTestLink = String.format("Test Job Link: https://app.saucelabs.com/tests/%s", this.driver.getSessionId());
+        if (getDriver() != null) {
+            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", getDriver().getSessionId(), this.getSauceOptions().getName());
+            String sauceTestLink = String.format("Test Job Link: https://app.saucelabs.com/tests/%s", getDriver().getSessionId());
             System.out.print(sauceReporter + "\n" + sauceTestLink + "\n");
         }
     }
 
     private void stop() {
-        if(driver !=null) {
-            driver.quit();
+        if(getDriver() !=null) {
+            getDriver().quit();
         }
     }
 }

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
@@ -33,10 +33,9 @@ public class SauceOptionsTest {
     public MockitoRule initRule = MockitoJUnit.rule();
 
     @Test
-    public void usesLatestChromeWindowsVersionsByDefault() {
+    public void usesChromeWindowsVersionsByDefault() {
         assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
         assertEquals(SaucePlatform.WINDOWS_10, sauceOptions.getPlatformName());
-        assertEquals("latest", sauceOptions.getBrowserVersion());
     }
 
     @Test
@@ -63,6 +62,7 @@ public class SauceOptionsTest {
 
     @Test
     public void acceptsOtherW3CValues() {
+        sauceOptions.setBrowserVersion("68");
         sauceOptions.setAcceptInsecureCerts(true);
         sauceOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
         sauceOptions.setSetWindowRect(true);
@@ -78,6 +78,7 @@ public class SauceOptionsTest {
         timeouts.put(Timeouts.PAGE_LOAD, 100);
         timeouts.put(Timeouts.SCRIPT, 10);
 
+        assertEquals("68", sauceOptions.getBrowserVersion());
         assertEquals(true, sauceOptions.getAcceptInsecureCerts());
         assertEquals(PageLoadStrategy.EAGER, sauceOptions.getPageLoadStrategy());
         assertEquals(true, sauceOptions.getSetWindowRect());
@@ -422,7 +423,6 @@ public class SauceOptionsTest {
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
         expectedCapabilities.setCapability("browserName", "chrome");
-        expectedCapabilities.setCapability("browserVersion", "latest");
         expectedCapabilities.setCapability("platformName", "Windows 10");
 
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
@@ -447,7 +447,6 @@ public class SauceOptionsTest {
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
         expectedCapabilities.setCapability("browserName", "firefox");
-        expectedCapabilities.setCapability("browserVersion", "latest");
         expectedCapabilities.setCapability("platformName", "Windows 10");
         expectedCapabilities.merge(firefoxOptions);
 
@@ -476,9 +475,11 @@ public class SauceOptionsTest {
         doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
 
         expectedCapabilities.merge(firefoxOptions);
-        expectedCapabilities.setCapability("browserVersion", "latest");
         expectedCapabilities.setCapability("platformName", "Windows 10");
         expectedCapabilities.setCapability("acceptInsecureCerts", true);
+
+        sauceOptions.setBrowserVersion("latest");
+        expectedCapabilities.setCapability("browserVersion", "latest");
 
         sauceOptions.setBuild("CUSTOM BUILD: 12");
         sauceCapabilities.setCapability("build", "CUSTOM BUILD: 12");

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
@@ -27,24 +27,23 @@ public class SauceSessionTest {
 
     @Before
     public void setUp() {
-        doReturn(dummyRemoteDriver).when(sauceSession).createRemoteWebDriver(any(URL.class), any(MutableCapabilities.class));
+        doReturn(dummyRemoteDriver).when(sauceSession).createDriver(any(URL.class), any(MutableCapabilities.class));
     }
 
     @Test
-    public void sauceSessionDefaultsToLatestChromeOnWindows() {
+    public void sauceSessionDefaultsToChromeOnWindows() {
         Browser actualBrowser = sauceSession.getSauceOptions().getBrowserName();
         String actualBrowserVersion = sauceSession.getSauceOptions().getBrowserVersion();
         SaucePlatform actualPlatformName = sauceSession.getSauceOptions().getPlatformName();
 
         assertEquals(Browser.CHROME, actualBrowser);
         assertEquals(SaucePlatform.WINDOWS_10, actualPlatformName);
-        assertEquals("latest", actualBrowserVersion);
     }
 
     @Test
     public void sauceSessionUsesProvidedSauceOptions() {
         doReturn(dummyMutableCapabilities).when(sauceOptions).toCapabilities();
-        doReturn(dummyRemoteDriver).when(sauceOptsSession).createRemoteWebDriver(any(URL.class), eq(dummyMutableCapabilities));
+        doReturn(dummyRemoteDriver).when(sauceOptsSession).createDriver(any(URL.class), eq(dummyMutableCapabilities));
 
         sauceOptsSession.start();
 

--- a/java/src/test/java/com/saucelabs/saucebindings/integration/DesktopBrowserTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/integration/DesktopBrowserTest.java
@@ -4,7 +4,7 @@ import com.saucelabs.saucebindings.DataCenter;
 import com.saucelabs.saucebindings.SauceOptions;
 import com.saucelabs.saucebindings.SaucePlatform;
 import com.saucelabs.saucebindings.SauceSession;
-import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
@@ -15,14 +15,15 @@ public class DesktopBrowserTest {
     private SauceSession session = new SauceSession();
     private RemoteWebDriver webDriver;
 
-    @After
-    public void cleanUp() {
-        session.stop(true);
-    }
+    @Rule
+    public SauceTestWatcher testWatcher = new SauceTestWatcher();
 
     @Test
     public void defaultsToUSWest() {
+        testWatcher.setSauceSession(session);
+
         webDriver = session.start();
+
         assertNotNull(webDriver);
         assertTrue(session.getSauceUrl().toString().contains("us-west-"));
     }
@@ -32,7 +33,10 @@ public class DesktopBrowserTest {
         SauceOptions options = new SauceOptions();
         options.setPlatformName(SaucePlatform.LINUX);
         session = new SauceSession(options);
+
         session.setDataCenter(DataCenter.US_EAST);
+        testWatcher.setSauceSession(session);
+
         webDriver = session.start();
 
         assertNotNull(webDriver);
@@ -42,6 +46,8 @@ public class DesktopBrowserTest {
     @Test
     public void runsEUCentral() {
         session.setDataCenter(DataCenter.EU_CENTRAL);
+        testWatcher.setSauceSession(session);
+
         webDriver = session.start();
 
         assertNotNull(webDriver);

--- a/java/src/test/java/com/saucelabs/saucebindings/integration/SauceEmuSimBrowserTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/integration/SauceEmuSimBrowserTest.java
@@ -1,0 +1,66 @@
+package com.saucelabs.saucebindings.integration;
+
+import com.saucelabs.saucebindings.DataCenter;
+import com.saucelabs.saucebindings.SauceOptions;
+import com.saucelabs.saucebindings.SauceSession;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SauceEmuSimBrowserTest {
+    private SauceOptions options;
+    private SauceSession<RemoteWebDriver> session;
+    private RemoteWebDriver driver;
+
+    @Rule
+    public SauceTestWatcher testWatcher = new SauceTestWatcher();
+
+    @Test
+    public void androidUSWest() {
+        options = SauceOptions.android();
+        session = new SauceSession<>(options);
+        testWatcher.setSauceSession(session);
+        driver = session.start();
+
+        assertNotNull(driver);
+        assertTrue(session.getSauceUrl().toString().contains("us-west-"));
+    }
+
+    @Test
+    public void runsEUCentral() {
+        options = SauceOptions.android();
+        session = new SauceSession<>(options);
+        session.setDataCenter(DataCenter.EU_CENTRAL);
+        testWatcher.setSauceSession(session);
+        driver = session.start();
+
+        assertNotNull(driver);
+        assertTrue(session.getSauceUrl().toString().contains("eu-central-1"));
+    }
+
+    @Test
+    public void iosUSWest() {
+        options = SauceOptions.ios();
+        session = new SauceSession<>(options);
+        testWatcher.setSauceSession(session);
+        driver = session.start();
+
+        assertNotNull(driver);
+        assertTrue(session.getSauceUrl().toString().contains("us-west-"));
+    }
+
+    @Test
+    public void iosEUCentral() {
+        options = SauceOptions.ios();
+        session = new SauceSession<>(options);
+        session.setDataCenter(DataCenter.EU_CENTRAL);
+        testWatcher.setSauceSession(session);
+        driver = session.start();
+
+        assertNotNull(driver);
+        assertTrue(session.getSauceUrl().toString().contains("eu-central-1"));
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/integration/SauceTestWatcher.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/integration/SauceTestWatcher.java
@@ -1,0 +1,20 @@
+package com.saucelabs.saucebindings.integration;
+
+import com.saucelabs.saucebindings.SauceSession;
+import lombok.Setter;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+public class SauceTestWatcher extends TestWatcher {
+    @Setter private SauceSession sauceSession;
+
+    @Override
+    protected void succeeded(Description description) {
+        sauceSession.stop("passed");
+    }
+
+    @Override
+    protected void failed(Throwable e, Description description) {
+        sauceSession.stop("failed");
+    }
+}


### PR DESCRIPTION
Update: 
1. I changed to code to use `SauceOptions` instead of `MobileSauceOptions`
2. I added static methods to `SauceOptions` for all the browsers + android + ios
3. I added the iOS things
4. Removed browser default of "latest" since it doesn't work with mobile, and Sauce defaults to that now for Desktop
5. Added TestWatcher to Integration Tests
6. This is missing unit tests
7. Integration Tests will not pass as-is, since they rely on a locally built Appium java-client

Ok, I got it working with subclassing and generics:

```java
SauceOptions options = SauceOptions.android();
SauceAndroidSession session = new SauceAndroidSession(options);
AndroidDriver driver = session.start()
```
Then everything else is samesies.

This look like what we want?

still to go:
1. iOS Browser EmuSim
2. Native App EmuSim
3. Real Device Unified Platform Private
4. Real Device Unified Platform Public
5. Real Device  Private TO
6. Real Device Public TO