### PR TITLE
[java] support for Browser on EmuSim

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,8 +57,8 @@
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -93,6 +93,11 @@
             <artifactId>snakeyaml</artifactId>
             <version>1.25</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.appium</groupId>
+            <artifactId>java-client</artifactId>
+            <version>7.3.4</version>
         </dependency>
     </dependencies>
     <build>

--- a/java/src/main/java/com/saucelabs/saucebindings/DeviceOrientation.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/DeviceOrientation.java
@@ -1,0 +1,36 @@
+package com.saucelabs.saucebindings;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public enum DeviceOrientation {
+    LANDSCAPE("landscape"),
+    PORTRAIT("portrait");
+
+    @Getter
+    private final String value;
+
+    private static final class DeviceOrientationLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    public static Set keys() {
+        return DeviceOrientationLookup.lookup.keySet();
+    }
+
+    DeviceOrientation(String value) {
+        this.value = value;
+        DeviceOrientationLookup.lookup.put(value, this.name());
+    }
+
+    public static String fromString(String value) {
+        return DeviceOrientationLookup.lookup.get(value);
+    }
+
+    public String toString() {
+        return this.value;
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/DeviceType.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/DeviceType.java
@@ -1,0 +1,36 @@
+package com.saucelabs.saucebindings;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public enum DeviceType {
+    PHONE("phone"),
+    TABLET("tablet");
+
+    @Getter
+    private final String value;
+
+    private static final class DeviceTypeLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    public static Set keys() {
+        return DeviceTypeLookup.lookup.keySet();
+    }
+
+    DeviceType(String value) {
+        this.value = value;
+        DeviceTypeLookup.lookup.put(value, this.name());
+    }
+
+    public static String fromString(String value) {
+        return DeviceTypeLookup.lookup.get(value);
+    }
+
+    public String toString() {
+        return this.value;
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceAndroidSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceAndroidSession.java
@@ -1,0 +1,24 @@
+package com.saucelabs.saucebindings;
+
+import io.appium.java_client.android.AndroidDriver;
+import lombok.Getter;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.net.URL;
+
+public class SauceAndroidSession extends SauceSession<AndroidDriver>  {
+    @Getter private AndroidDriver driver;
+
+    public SauceAndroidSession() {
+        this(SauceOptions.android());
+    }
+
+    public SauceAndroidSession(SauceOptions options) {
+        setSauceOptions(options);
+    }
+
+    protected AndroidDriver createDriver(URL url, MutableCapabilities capabilities) {
+        this.driver = new AndroidDriver(url, capabilities);
+        return driver;
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceAutomationName.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceAutomationName.java
@@ -1,0 +1,36 @@
+package com.saucelabs.saucebindings;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public enum SauceAutomationName {
+    UIAUTOMATOR2("UiAutomator2"),
+    APPIUM("Appium");
+
+    @Getter
+    private final String value;
+
+    private static final class AutomationNameLookup {
+        private static final Map<String, String> lookup = new HashMap<String, String>();
+    }
+
+    public static Set keys() {
+        return AutomationNameLookup.lookup.keySet();
+    }
+
+    SauceAutomationName(String value) {
+        this.value = value;
+        AutomationNameLookup.lookup.put(value, this.name());
+    }
+
+    public static String fromString(String value) {
+        return AutomationNameLookup.lookup.get(value);
+    }
+
+    public String toString() {
+        return this.value;
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceIOSSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceIOSSession.java
@@ -1,0 +1,24 @@
+package com.saucelabs.saucebindings;
+
+import io.appium.java_client.ios.IOSDriver;
+import lombok.Getter;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.net.URL;
+
+public class SauceIOSSession extends SauceSession<IOSDriver>  {
+    @Getter private IOSDriver driver;
+
+    public SauceIOSSession() {
+        this(SauceOptions.ios());
+    }
+
+    public SauceIOSSession(SauceOptions options) {
+        setSauceOptions(options);
+    }
+
+    protected IOSDriver createDriver(URL url, MutableCapabilities capabilities) {
+        this.driver = new IOSDriver(url, capabilities);
+        return driver;
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SaucePlatform.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SaucePlatform.java
@@ -15,7 +15,9 @@ public enum SaucePlatform {
     MAC_HIGH_SIERRA("macOS 10.13"),
     MAC_SIERRA("macOS 10.12"),
     MAC_EL_CAPITAN("OS X 10.11"),
-    MAC_YOSEMITE("OS X 10.10");
+    MAC_YOSEMITE("OS X 10.10"),
+    ANDROID("android"),
+    IOS("IOS");
 
     @Getter
     private final String value;

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -9,9 +9,9 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-public class SauceSession {
+public class SauceSession<T extends RemoteWebDriver>  {
     @Getter @Setter private DataCenter dataCenter = DataCenter.US_WEST;
-    @Getter private final SauceOptions sauceOptions;
+    @Getter @Setter protected SauceOptions sauceOptions;
     @Setter private URL sauceUrl;
 
     @Getter private RemoteWebDriver driver;
@@ -24,9 +24,9 @@ public class SauceSession {
         sauceOptions = options;
     }
 
-    public RemoteWebDriver start() {
-        driver = createRemoteWebDriver(getSauceUrl(), sauceOptions.toCapabilities());
-        return driver;
+    public T start() {
+        this.driver = createDriver(getSauceUrl(), sauceOptions.toCapabilities());
+        return (T) driver;
 	}
 
     public URL getSauceUrl() {
@@ -41,8 +41,8 @@ public class SauceSession {
         }
     }
 
-    protected RemoteWebDriver createRemoteWebDriver(URL url, MutableCapabilities capabilities) {
-        return new RemoteWebDriver(url, capabilities);
+    protected T createDriver(URL url, MutableCapabilities capabilities) {
+        return (T) new RemoteWebDriver(url, capabilities);
     }
 
     public void stop(Boolean passed) {
@@ -60,16 +60,16 @@ public class SauceSession {
         // Add output for the Sauce OnDemand Jenkins plugin
         // The first print statement will automatically populate links on Jenkins to Sauce
         // The second print statement will output the job link to logging/console
-        if (this.driver != null) {
-            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", this.driver.getSessionId(), this.sauceOptions.getName());
-            String sauceTestLink = String.format("Test Job Link: https://app.saucelabs.com/tests/%s", this.driver.getSessionId());
+        if (getDriver() != null) {
+            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", getDriver().getSessionId(), this.getSauceOptions().getName());
+            String sauceTestLink = String.format("Test Job Link: https://app.saucelabs.com/tests/%s", getDriver().getSessionId());
             System.out.print(sauceReporter + "\n" + sauceTestLink + "\n");
         }
     }
 
     private void stop() {
-        if(driver !=null) {
-            driver.quit();
+        if(getDriver() !=null) {
+            getDriver().quit();
         }
     }
 }

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceAndroidSessionTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceAndroidSessionTest.java
@@ -1,0 +1,63 @@
+package com.saucelabs.saucebindings;
+
+import io.appium.java_client.android.AndroidDriver;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class SauceAndroidSessionTest {
+    private SauceOptions sauceOptions = spy(SauceOptions.android());
+    private SauceAndroidSession sauceSession = spy(new SauceAndroidSession());
+    private AndroidDriver dummyAndroidDriver = mock(AndroidDriver.class);
+
+    @Rule
+    public MockitoRule initRule = MockitoJUnit.rule();
+
+    @Before
+    public void setUp() {
+        doReturn(dummyAndroidDriver).when(sauceSession).createDriver(any(URL.class), any(MutableCapabilities.class));
+    }
+
+    @Test
+    public void sauceAndroidSessionUsesDefaultAndroidSettings() {
+        SauceOptions sauceOptions = sauceSession.getSauceOptions();
+
+        assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
+        assertEquals(SaucePlatform.ANDROID, sauceOptions.getPlatformName());
+        assertEquals("Android GoogleAPI Emulator", sauceOptions.getDeviceName());
+        assertEquals("8.1", sauceOptions.getPlatformVersion());
+    }
+
+    @Test
+    public void sauceAndroidSessionUsesProvidedSauceOptions() {
+        SauceAndroidSession sauceOptsSession = spy(new SauceAndroidSession(sauceOptions));
+        MutableCapabilities dummyMutableCapabilities = mock(MutableCapabilities.class);
+
+        doReturn(dummyMutableCapabilities).when(sauceOptions).toCapabilities();
+        doReturn(dummyAndroidDriver).when(sauceOptsSession).createDriver(any(URL.class), eq(dummyMutableCapabilities));
+
+        sauceOptsSession.start();
+
+        verify(sauceOptions).toCapabilities();
+    }
+
+    @Test
+    public void staticAndConstructorCreateSameOptions() {
+        System.setProperty("BUILD_NAME", "Static Build Name");
+        SauceOptions sauceOptions = SauceOptions.android();
+
+        SauceAndroidSession sauceOptsSession = new SauceAndroidSession(sauceOptions);
+        SauceAndroidSession sauceAndroidSession = new SauceAndroidSession();
+
+        assertEquals(sauceAndroidSession.getSauceOptions().toCapabilities(),
+                sauceOptsSession.getSauceOptions().toCapabilities());
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceIOSSessionTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceIOSSessionTest.java
@@ -1,0 +1,64 @@
+package com.saucelabs.saucebindings;
+
+import io.appium.java_client.ios.IOSDriver;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class SauceIOSSessionTest {
+    private SauceOptions sauceOptions = spy(SauceOptions.ios());
+    private SauceIOSSession sauceSession = spy(new SauceIOSSession());
+    private IOSDriver dummyIOSDriver = mock(IOSDriver.class);
+
+    @Rule
+    public MockitoRule initRule = MockitoJUnit.rule();
+
+    @Before
+    public void setUp() {
+        doReturn(dummyIOSDriver).when(sauceSession).createDriver(any(URL.class), any(MutableCapabilities.class));
+    }
+
+    @Test
+    public void SauceIOSSessionUsesDefaultAndroidSettings() {
+        SauceOptions sauceOptions = sauceSession.getSauceOptions();
+
+        assertEquals(Browser.SAFARI, sauceOptions.getBrowserName());
+        assertEquals(SaucePlatform.IOS, sauceOptions.getPlatformName());
+        assertEquals("iPhone Simulator", sauceOptions.getDeviceName());
+        assertEquals("13.2", sauceOptions.getPlatformVersion());
+    }
+
+    @Test
+    public void SauceIOSSessionUsesProvidedSauceOptions() {
+        SauceIOSSession sauceOptsSession = spy(new SauceIOSSession(sauceOptions));
+        MutableCapabilities dummyMutableCapabilities = mock(MutableCapabilities.class);
+
+        doReturn(dummyMutableCapabilities).when(sauceOptions).toCapabilities();
+        doReturn(dummyIOSDriver).when(sauceOptsSession).createDriver(any(URL.class), eq(dummyMutableCapabilities));
+
+        sauceOptsSession.start();
+
+        verify(sauceOptions).toCapabilities();
+    }
+
+    @Test
+    public void staticAndConstructorCreateSameOptions() {
+        System.setProperty("BUILD_NAME", "Static Build Name");
+        SauceOptions sauceOptions = SauceOptions.ios();
+
+        SauceIOSSession sauceOptsSession = new SauceIOSSession(sauceOptions);
+        SauceIOSSession SauceIOSSession = new SauceIOSSession();
+
+        assertEquals(SauceIOSSession.getSauceOptions().toCapabilities(),
+                sauceOptsSession.getSauceOptions().toCapabilities());
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceMobileOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceMobileOptionsTest.java
@@ -1,0 +1,178 @@
+package com.saucelabs.saucebindings;
+
+import io.appium.java_client.android.AndroidOptions;
+import io.appium.java_client.ios.IOSOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.openqa.selenium.MutableCapabilities;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+public class SauceMobileOptionsTest {
+    private SauceOptions sauceOptions;
+
+    @Rule
+    public MockitoRule initRule = MockitoJUnit.rule();
+
+    @Test
+    public void staticAndroidDefaultsToAndroid(){
+        sauceOptions = SauceOptions.android();
+
+        assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
+        assertEquals(SaucePlatform.ANDROID, sauceOptions.getPlatformName());
+        assertEquals("Android GoogleAPI Emulator", sauceOptions.getDeviceName());
+        assertEquals("8.1", sauceOptions.getPlatformVersion());
+    }
+
+    @Test
+    public void staticIOSDefaultsToIOS(){
+        sauceOptions = SauceOptions.ios();
+
+        assertEquals(Browser.SAFARI, sauceOptions.getBrowserName());
+        assertEquals(SaucePlatform.IOS, sauceOptions.getPlatformName());
+        assertEquals("iPhone Simulator", sauceOptions.getDeviceName());
+        assertEquals("13.2", sauceOptions.getPlatformVersion());
+    }
+
+    @Test
+    public void acceptsMobileSpecificSettings() {
+        sauceOptions = SauceOptions.android();
+
+        sauceOptions.setApp("http://path.com/to/app");
+        sauceOptions.setAppiumVersion("1.17.0");
+        sauceOptions.setAppActivity(".MainActivity");
+        sauceOptions.setAppPackage("com.example.android.myApp, com.android.settings");
+        sauceOptions.setAutoAcceptAlerts(true);
+        sauceOptions.setAutomationName(SauceAutomationName.UIAUTOMATOR2);
+        sauceOptions.setDeviceName("Google Nexus 7 HD Emulator");
+        sauceOptions.setDeviceOrientation(DeviceOrientation.LANDSCAPE);
+        sauceOptions.setDeviceType(DeviceType.TABLET);
+        sauceOptions.setPlatformVersion("9.1");
+
+        assertEquals("http://path.com/to/app", sauceOptions.getApp());
+        assertEquals("1.17.0", sauceOptions.getAppiumVersion());
+        assertEquals(".MainActivity", sauceOptions.getAppActivity());
+        assertEquals("com.example.android.myApp, com.android.settings", sauceOptions.getAppPackage());
+        assertTrue(sauceOptions.getAutoAcceptAlerts());
+        assertEquals(SauceAutomationName.UIAUTOMATOR2, sauceOptions.getAutomationName());
+        assertEquals("Google Nexus 7 HD Emulator", sauceOptions.getDeviceName());
+        assertEquals(DeviceOrientation.LANDSCAPE, sauceOptions.getDeviceOrientation());
+        assertEquals(DeviceType.TABLET, sauceOptions.getDeviceType());
+        assertEquals("9.1", sauceOptions.getPlatformVersion());
+    }
+
+    @Test
+    public void acceptsAndroidOptionsClass() {
+        AndroidOptions androidOptions = new AndroidOptions();
+        androidOptions.setEnablePerformanceLogging();
+
+        sauceOptions = SauceOptions.android(androidOptions);
+
+        assertEquals(SaucePlatform.ANDROID, sauceOptions.getPlatformName());
+        assertEquals(androidOptions, sauceOptions.getSeleniumCapabilities());
+    }
+
+    @Test
+    public void acceptsIOSOptionsClass() {
+        IOSOptions iOSOptions = new IOSOptions();
+        iOSOptions.setEnablePerformanceLogging();
+
+        sauceOptions = SauceOptions.ios(iOSOptions);
+
+        assertEquals(SaucePlatform.IOS, sauceOptions.getPlatformName());
+        assertEquals(iOSOptions, sauceOptions.getSeleniumCapabilities());
+    }
+
+    // This is important to make sure serialized values can be converted into type safe option keys
+    @Test
+    public void setsCapabilitiesFromMap() throws FileNotFoundException {
+        InputStream input = new FileInputStream(new File("src/test/java/com/saucelabs/saucebindings/options.yml"));
+        Yaml yaml = new Yaml();
+        Map<String, Object> data = yaml.load(input);
+        Map<String, Object> map = (Map<String, Object>) data.get("mobileValues");
+
+        sauceOptions = SauceOptions.android();
+        sauceOptions.mergeCapabilities(map);
+
+        assertEquals("http://path.com/to/app", sauceOptions.getApp());
+        assertEquals("1.17.0", sauceOptions.getAppiumVersion());
+        assertEquals(".MainActivity", sauceOptions.getAppActivity());
+        assertEquals("com.example.android.myApp, com.android.settings", sauceOptions.getAppPackage());
+        assertTrue(sauceOptions.getAutoAcceptAlerts());
+        assertEquals(SauceAutomationName.UIAUTOMATOR2, sauceOptions.getAutomationName());
+        assertEquals("Google Nexus 7 HD Emulator", sauceOptions.getDeviceName());
+        assertEquals(DeviceOrientation.LANDSCAPE, sauceOptions.getDeviceOrientation());
+        assertEquals(DeviceType.TABLET, sauceOptions.getDeviceType());
+        assertEquals("9.1", sauceOptions.getPlatformVersion());
+    }
+
+    @Test
+    public void parsesMobileCapabilities() {
+        MutableCapabilities androidCaps = new MutableCapabilities();
+        androidCaps.setCapability("autoWebView", true);
+        AndroidOptions androidOptions = new AndroidOptions(androidCaps);
+        androidOptions.setEnablePerformanceLogging();
+        androidOptions.setOtherApps("path/to/app.apk");
+
+        sauceOptions = spy(SauceOptions.android(androidOptions));
+
+        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
+        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+
+        sauceOptions.setBuild("CUSTOM BUILD: 12");
+
+        sauceOptions.setApp("http://path.com/to/app");
+        sauceOptions.setAppiumVersion("1.17.0");
+        sauceOptions.setAppActivity(".MainActivity");
+        sauceOptions.setAppPackage("com.example.android.myApp, com.android.settings");
+        sauceOptions.setAutoAcceptAlerts(true);
+        sauceOptions.setAutomationName(SauceAutomationName.UIAUTOMATOR2);
+        sauceOptions.setDeviceName("Google Nexus 7 HD Emulator");
+        sauceOptions.setDeviceOrientation(DeviceOrientation.LANDSCAPE);
+        sauceOptions.setDeviceType(DeviceType.TABLET);
+        sauceOptions.setPlatformVersion("9.1");
+
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+        sauceCapabilities.setCapability("username", "test-name");
+        sauceCapabilities.setCapability("accessKey", "test-accesskey");
+        sauceCapabilities.setCapability("build", "CUSTOM BUILD: 12");
+        sauceCapabilities.setCapability("appiumVersion", "1.17.0");
+        sauceCapabilities.setCapability("deviceType", "tablet");
+
+        MutableCapabilities expectedCapabilities = new MutableCapabilities();
+        expectedCapabilities.setCapability("browserName", "chrome");
+        expectedCapabilities.setCapability("platformName", "android");
+        expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
+        expectedCapabilities.setCapability("appium:deviceName", "Android GoogleAPI Emulator");
+        expectedCapabilities.setCapability("appium:platformVersion", "8.1");
+        expectedCapabilities.setCapability("appium:app", "http://path.com/to/app");
+        expectedCapabilities.setCapability("appium:appActivity", ".MainActivity");
+        expectedCapabilities.setCapability("appium:appPackage", "com.example.android.myApp, com.android.settings");
+        expectedCapabilities.setCapability("appium:autoAcceptAlerts", true);
+        expectedCapabilities.setCapability("appium:automationName", "UiAutomator2");
+        expectedCapabilities.setCapability("appium:deviceName", "Google Nexus 7 HD Emulator");
+        expectedCapabilities.setCapability("appium:deviceOrientation", "landscape");
+        expectedCapabilities.setCapability("appium:platformVersion", "9.1");
+
+        expectedCapabilities.setCapability("appium:autoWebView", true);
+        expectedCapabilities.setCapability("appium:enablePerformanceLogging", true);
+        expectedCapabilities.setCapability("appium:otherApps", "path/to/app.apk");
+
+        MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
+
+        // toString() serializes the enums
+        assertEquals(expectedCapabilities.asMap().toString(), actualCapabilities.asMap().toString());
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
@@ -33,10 +33,45 @@ public class SauceOptionsTest {
     public MockitoRule initRule = MockitoJUnit.rule();
 
     @Test
-    public void usesLatestChromeWindowsVersionsByDefault() {
+    public void staticChromeDefaultsToChrome(){
+        sauceOptions = SauceOptions.chrome();
+
+        assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
+    }
+
+    @Test
+    public void staticFirefoxDefaultsToFirefox(){
+        sauceOptions = SauceOptions.firefox();
+
+        assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
+    }
+
+    @Test
+    public void staticIEDefaultsToIE(){
+        sauceOptions = SauceOptions.internetExplorer();
+
+        assertEquals(Browser.INTERNET_EXPLORER, sauceOptions.getBrowserName());
+    }
+
+    @Test
+    public void staticEdgeDefaultsToEdge(){
+        sauceOptions = SauceOptions.edge();
+
+        assertEquals(Browser.EDGE, sauceOptions.getBrowserName());
+    }
+
+    @Test
+    public void staticSafariDefaultsToSafariMacLatest(){
+        sauceOptions = SauceOptions.safari();
+
+        assertEquals(Browser.SAFARI, sauceOptions.getBrowserName());
+        assertEquals(SaucePlatform.MAC_MOJAVE, sauceOptions.getPlatformName());
+    }
+
+    @Test
+    public void usesChromeWindowsVersionsByDefault() {
         assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
         assertEquals(SaucePlatform.WINDOWS_10, sauceOptions.getPlatformName());
-        assertEquals("latest", sauceOptions.getBrowserVersion());
     }
 
     @Test
@@ -63,6 +98,7 @@ public class SauceOptionsTest {
 
     @Test
     public void acceptsOtherW3CValues() {
+        sauceOptions.setBrowserVersion("68");
         sauceOptions.setAcceptInsecureCerts(true);
         sauceOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
         sauceOptions.setSetWindowRect(true);
@@ -78,6 +114,7 @@ public class SauceOptionsTest {
         timeouts.put(Timeouts.PAGE_LOAD, 100);
         timeouts.put(Timeouts.SCRIPT, 10);
 
+        assertEquals("68", sauceOptions.getBrowserVersion());
         assertEquals(true, sauceOptions.getAcceptInsecureCerts());
         assertEquals(PageLoadStrategy.EAGER, sauceOptions.getPageLoadStrategy());
         assertEquals(true, sauceOptions.getSetWindowRect());
@@ -165,7 +202,7 @@ public class SauceOptionsTest {
         chromeOptions.addArguments("--foo");
         chromeOptions.setUnhandledPromptBehaviour(DISMISS);
 
-        sauceOptions = new SauceOptions(chromeOptions);
+        sauceOptions = SauceOptions.chrome(chromeOptions);
 
         assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
         assertEquals(chromeOptions, sauceOptions.getSeleniumCapabilities());
@@ -176,7 +213,7 @@ public class SauceOptionsTest {
         EdgeOptions edgeOptions = new EdgeOptions();
         edgeOptions.setPageLoadStrategy("eager");
 
-        sauceOptions = new SauceOptions(edgeOptions);
+        sauceOptions = SauceOptions.edge(edgeOptions);
 
         assertEquals(Browser.EDGE, sauceOptions.getBrowserName());
         assertEquals(edgeOptions, sauceOptions.getSeleniumCapabilities());
@@ -189,7 +226,7 @@ public class SauceOptionsTest {
         firefoxOptions.addPreference("foo", "bar");
         firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
 
-        sauceOptions = new SauceOptions(firefoxOptions);
+        sauceOptions = SauceOptions.firefox(firefoxOptions);
 
         assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
         assertEquals(firefoxOptions, sauceOptions.getSeleniumCapabilities());
@@ -202,21 +239,22 @@ public class SauceOptionsTest {
         internetExplorerOptions.setPageLoadStrategy(org.openqa.selenium.PageLoadStrategy.EAGER);
         internetExplorerOptions.setUnhandledPromptBehaviour(DISMISS);
 
-        sauceOptions = new SauceOptions(internetExplorerOptions);
+        sauceOptions = SauceOptions.internetExplorer(internetExplorerOptions);
 
         assertEquals(Browser.INTERNET_EXPLORER, sauceOptions.getBrowserName());
         assertEquals(internetExplorerOptions, sauceOptions.getSeleniumCapabilities());
     }
 
     @Test
-    public void acceptsSafariOptionsClass() {
+    public void acceptsSafariOptionsClassSetsMacPlatform() {
         SafariOptions safariOptions = new SafariOptions();
         safariOptions.setAutomaticInspection(true);
         safariOptions.setAutomaticProfiling(true);
 
-        sauceOptions = new SauceOptions(safariOptions);
+        sauceOptions = SauceOptions.safari(safariOptions);
 
         assertEquals(Browser.SAFARI, sauceOptions.getBrowserName());
+        assertEquals(SaucePlatform.MAC_MOJAVE, sauceOptions.getPlatformName());
         assertEquals(safariOptions, sauceOptions.getSeleniumCapabilities());
     }
 
@@ -422,7 +460,6 @@ public class SauceOptionsTest {
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
         expectedCapabilities.setCapability("browserName", "chrome");
-        expectedCapabilities.setCapability("browserVersion", "latest");
         expectedCapabilities.setCapability("platformName", "Windows 10");
 
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
@@ -447,7 +484,6 @@ public class SauceOptionsTest {
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
         expectedCapabilities.setCapability("browserName", "firefox");
-        expectedCapabilities.setCapability("browserVersion", "latest");
         expectedCapabilities.setCapability("platformName", "Windows 10");
         expectedCapabilities.merge(firefoxOptions);
 
@@ -476,9 +512,11 @@ public class SauceOptionsTest {
         doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
 
         expectedCapabilities.merge(firefoxOptions);
-        expectedCapabilities.setCapability("browserVersion", "latest");
         expectedCapabilities.setCapability("platformName", "Windows 10");
         expectedCapabilities.setCapability("acceptInsecureCerts", true);
+
+        sauceOptions.setBrowserVersion("latest");
+        expectedCapabilities.setCapability("browserVersion", "latest");
 
         sauceOptions.setBuild("CUSTOM BUILD: 12");
         sauceCapabilities.setCapability("build", "CUSTOM BUILD: 12");

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
@@ -27,24 +27,23 @@ public class SauceSessionTest {
 
     @Before
     public void setUp() {
-        doReturn(dummyRemoteDriver).when(sauceSession).createRemoteWebDriver(any(URL.class), any(MutableCapabilities.class));
+        doReturn(dummyRemoteDriver).when(sauceSession).createDriver(any(URL.class), any(MutableCapabilities.class));
     }
 
     @Test
-    public void sauceSessionDefaultsToLatestChromeOnWindows() {
+    public void sauceSessionDefaultsToChromeOnWindows() {
         Browser actualBrowser = sauceSession.getSauceOptions().getBrowserName();
         String actualBrowserVersion = sauceSession.getSauceOptions().getBrowserVersion();
         SaucePlatform actualPlatformName = sauceSession.getSauceOptions().getPlatformName();
 
         assertEquals(Browser.CHROME, actualBrowser);
         assertEquals(SaucePlatform.WINDOWS_10, actualPlatformName);
-        assertEquals("latest", actualBrowserVersion);
     }
 
     @Test
     public void sauceSessionUsesProvidedSauceOptions() {
         doReturn(dummyMutableCapabilities).when(sauceOptions).toCapabilities();
-        doReturn(dummyRemoteDriver).when(sauceOptsSession).createRemoteWebDriver(any(URL.class), eq(dummyMutableCapabilities));
+        doReturn(dummyRemoteDriver).when(sauceOptsSession).createDriver(any(URL.class), eq(dummyMutableCapabilities));
 
         sauceOptsSession.start();
 

--- a/java/src/test/java/com/saucelabs/saucebindings/integration/DesktopBrowserTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/integration/DesktopBrowserTest.java
@@ -4,7 +4,7 @@ import com.saucelabs.saucebindings.DataCenter;
 import com.saucelabs.saucebindings.SauceOptions;
 import com.saucelabs.saucebindings.SaucePlatform;
 import com.saucelabs.saucebindings.SauceSession;
-import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
@@ -15,14 +15,15 @@ public class DesktopBrowserTest {
     private SauceSession session = new SauceSession();
     private RemoteWebDriver webDriver;
 
-    @After
-    public void cleanUp() {
-        session.stop(true);
-    }
+    @Rule
+    public SauceTestWatcher testWatcher = new SauceTestWatcher();
 
     @Test
     public void defaultsToUSWest() {
+        testWatcher.setSauceSession(session);
+
         webDriver = session.start();
+
         assertNotNull(webDriver);
         assertTrue(session.getSauceUrl().toString().contains("us-west-"));
     }
@@ -32,7 +33,10 @@ public class DesktopBrowserTest {
         SauceOptions options = new SauceOptions();
         options.setPlatformName(SaucePlatform.LINUX);
         session = new SauceSession(options);
+
         session.setDataCenter(DataCenter.US_EAST);
+        testWatcher.setSauceSession(session);
+
         webDriver = session.start();
 
         assertNotNull(webDriver);
@@ -42,6 +46,8 @@ public class DesktopBrowserTest {
     @Test
     public void runsEUCentral() {
         session.setDataCenter(DataCenter.EU_CENTRAL);
+        testWatcher.setSauceSession(session);
+
         webDriver = session.start();
 
         assertNotNull(webDriver);

--- a/java/src/test/java/com/saucelabs/saucebindings/integration/SauceEmuSimBrowserTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/integration/SauceEmuSimBrowserTest.java
@@ -1,0 +1,66 @@
+package com.saucelabs.saucebindings.integration;
+
+import com.saucelabs.saucebindings.DataCenter;
+import com.saucelabs.saucebindings.SauceOptions;
+import com.saucelabs.saucebindings.SauceSession;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SauceEmuSimBrowserTest {
+    private SauceOptions options;
+    private SauceSession<RemoteWebDriver> session;
+    private RemoteWebDriver driver;
+
+    @Rule
+    public SauceTestWatcher testWatcher = new SauceTestWatcher();
+
+    @Test
+    public void androidUSWest() {
+        options = SauceOptions.android();
+        session = new SauceSession<>(options);
+        testWatcher.setSauceSession(session);
+        driver = session.start();
+
+        assertNotNull(driver);
+        assertTrue(session.getSauceUrl().toString().contains("us-west-"));
+    }
+
+    @Test
+    public void runsEUCentral() {
+        options = SauceOptions.android();
+        session = new SauceSession<>(options);
+        session.setDataCenter(DataCenter.EU_CENTRAL);
+        testWatcher.setSauceSession(session);
+        driver = session.start();
+
+        assertNotNull(driver);
+        assertTrue(session.getSauceUrl().toString().contains("eu-central-1"));
+    }
+
+    @Test
+    public void iosUSWest() {
+        options = SauceOptions.ios();
+        session = new SauceSession<>(options);
+        testWatcher.setSauceSession(session);
+        driver = session.start();
+
+        assertNotNull(driver);
+        assertTrue(session.getSauceUrl().toString().contains("us-west-"));
+    }
+
+    @Test
+    public void iosEUCentral() {
+        options = SauceOptions.ios();
+        session = new SauceSession<>(options);
+        session.setDataCenter(DataCenter.EU_CENTRAL);
+        testWatcher.setSauceSession(session);
+        driver = session.start();
+
+        assertNotNull(driver);
+        assertTrue(session.getSauceUrl().toString().contains("eu-central-1"));
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/integration/SauceTestWatcher.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/integration/SauceTestWatcher.java
@@ -1,0 +1,20 @@
+package com.saucelabs.saucebindings.integration;
+
+import com.saucelabs.saucebindings.SauceSession;
+import lombok.Setter;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+public class SauceTestWatcher extends TestWatcher {
+    @Setter private SauceSession sauceSession;
+
+    @Override
+    protected void succeeded(Description description) {
+        sauceSession.stop("passed");
+    }
+
+    @Override
+    protected void failed(Throwable e, Description description) {
+        sauceSession.stop("failed");
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/options.yml
+++ b/java/src/test/java/com/saucelabs/saucebindings/options.yml
@@ -54,3 +54,15 @@ invalidOption:
   browserVersion: "70"
   platformName: "MacOS 10.12"
   recordScreenshots: false
+
+mobileValues:
+  app: "http://path.com/to/app"
+  appiumVersion: "1.17.0"
+  appActivity: ".MainActivity"
+  appPackage: "com.example.android.myApp, com.android.settings"
+  autoAcceptAlerts: true
+  automationName: "UiAutomator2"
+  deviceName: "Google Nexus 7 HD Emulator"
+  deviceOrientation: "landscape"
+  deviceType: "tablet"
+  platformVersion: "9.1"


### PR DESCRIPTION
This replaces #169 

Note that this is Draft, because it relies on [a new PR to Appium](https://github.com/appium/java-client/pull/1356) getting merged and released. I've built the jar with that commit locally and used it to ensure that this code works as intended.

The main updates from 169 is that I've added all the tests, and iOS is completely supported

So now it looks like this:
```java
AndroidOptions androidOptions = new AndroidOptions();
SauceOptions sauceOptions = SauceOptions.android(androidOptions);
SauceAndroidSession session = new SauceAndroidSession(sauceOptions);
AndroidDriver driver = session.start()
```

When reviewing, please check out the things I labeled "TODO" for potential considerations.