### PR TITLE
Update setEnumCapability() to be cleaner

### DIFF
--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -239,7 +239,6 @@ public class SauceOptions {
         }
     }
 
-    // This might be made public in future version; For now, no good reason to prefer it over direct accessor
     public void setCapability(String key, Object value) {
         if (primaryEnum.contains(key) && value.getClass().equals(String.class)) {
             setEnumCapability(key, (String) value);

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -282,44 +282,22 @@ public class SauceOptions {
     private void setEnumCapability(String key, String value) {
         switch (key) {
             case "browserName":
-                if (!Browser.keys().contains(value)) {
-                    String message = value + " is not a valid Browser, please choose from: " + Browser.keys();
-                    throw new InvalidSauceOptionsArgumentException(message);
-                } else {
-                    setBrowserName(Browser.valueOf(Browser.fromString(value)));
-                }
+                setBrowserName(Browser.valueOf(Browser.fromString(value)));
                 break;
             case "platformName":
-                if (!SaucePlatform.keys().contains(value)) {
-                    String message = value + " is not a valid Platform, please choose from: " + SaucePlatform.keys();
-                    throw new InvalidSauceOptionsArgumentException(message);
-                } else {
-                    setPlatformName(SaucePlatform.valueOf(SaucePlatform.fromString(value)));
-                }
+                setPlatformName(SaucePlatform.valueOf(SaucePlatform.fromString(value)));
                 break;
             case "jobVisibility":
-                if (!JobVisibility.keys().contains(value)) {
-                    String message = value + " is not a valid Job Visibility, please choose from: " + JobVisibility.keys();
-                    throw new InvalidSauceOptionsArgumentException(message);
-                } else {
-                    setJobVisibility(JobVisibility.valueOf(JobVisibility.fromString(value)));
-                }
+                setJobVisibility(JobVisibility.valueOf(JobVisibility.fromString(value)));
                 break;
             case "pageLoadStrategy":
-                if (!PageLoadStrategy.keys().contains(value)) {
-                    String message = value + " is not a valid Job Visibility, please choose from: " + PageLoadStrategy.keys();
-                    throw new InvalidSauceOptionsArgumentException(message);
-                } else {
-                    setPageLoadStrategy(PageLoadStrategy.valueOf(PageLoadStrategy.fromString(value)));
-                }
+                setPageLoadStrategy(PageLoadStrategy.valueOf(
+                        PageLoadStrategy.fromString(value)));
                 break;
             case "unhandledPromptBehavior":
-                if (!UnhandledPromptBehavior.keys().contains(value)) {
-                    String message = value + " is not a valid Job Visibility, please choose from: " + UnhandledPromptBehavior.keys();
-                    throw new InvalidSauceOptionsArgumentException(message);
-                } else {
-                    setUnhandledPromptBehavior(UnhandledPromptBehavior.valueOf(UnhandledPromptBehavior.fromString(value)));
-                }
+                setUnhandledPromptBehavior(
+                        UnhandledPromptBehavior.valueOf(
+                                UnhandledPromptBehavior.fromString(value)));
                 break;
             default:
                 break;

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
@@ -515,13 +515,4 @@ public class SauceOptionsTest {
 
         assertEquals(expectedCapabilities.asMap().toString(), actualCapabilities.asMap().toString());
     }
-
-    @Test(expected = NullPointerException.class)
-    public void setEnumCapabilityWithInvalidKeysThrowsException() {
-        sauceOptions.setCapability("browserName", "FOO");
-        sauceOptions.setCapability("platformName", "FOO");
-        sauceOptions.setCapability("jobVisibility", "FOO");
-        sauceOptions.setCapability("pageLoadStrategy", "FOO");
-        sauceOptions.setCapability("unhandledPromptBehavior", "FOO");
-    }
 }

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
@@ -515,4 +515,13 @@ public class SauceOptionsTest {
 
         assertEquals(expectedCapabilities.asMap().toString(), actualCapabilities.asMap().toString());
     }
+
+    @Test(expected = NullPointerException.class)
+    public void setEnumCapabilityWithInvalidKeysThrowsException() {
+        sauceOptions.setCapability("browserName", "FOO");
+        sauceOptions.setCapability("platformName", "FOO");
+        sauceOptions.setCapability("jobVisibility", "FOO");
+        sauceOptions.setCapability("pageLoadStrategy", "FOO");
+        sauceOptions.setCapability("unhandledPromptBehavior", "FOO");
+    }
 }


### PR DESCRIPTION
- Cleaning up setEnumCapability() which was getting massive
- Increased code coverage of SauceOptions by 4%
- Also, I removed code that isn't possible to reach because the value of an enum can't be anything but what's included in the enum. Hence, the logic to check if the value is valid was unecessary.
- However, it is possible for someone to use this method `public void setCapability(String key, Object value)` in which case `Enum.valueOf(Enum.fromString(value)` will throw a `NullPointer`. I can add logic to handle this if we want. I added a test to show this