### PR TITLE
[java] implement visual options within sauce options

### DIFF
--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -156,6 +156,12 @@ public class SauceOptions {
         knownCITools.put("TeamCity", "TEAMCITY_PROJECT_NAME");
     }
 
+    public static SauceOptions visual(String visualProjectName) {
+        SauceOptions sauceOptions = new SauceOptions();
+        sauceOptions.setVisualProjectName(visualProjectName);
+        return sauceOptions;
+    }
+
     public SauceOptions() {
         this(new MutableCapabilities());
     }

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsConstrTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsConstrTest.java
@@ -1,0 +1,23 @@
+package com.saucelabs.saucebindings;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.junit.Assert.assertEquals;
+
+public class SauceOptionsConstrTest {
+    @Rule
+    public MockitoRule initRule = MockitoJUnit.rule();
+
+    @Test
+    public void constructsSauceOptionsVisual() {
+        SauceOptions sauceOptions = SauceOptions.visual("projectName");
+
+        assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
+        assertEquals(SaucePlatform.WINDOWS_10, sauceOptions.getPlatformName());
+        assertEquals("latest", sauceOptions.getBrowserVersion());
+        assertEquals("projectName", sauceOptions.getVisualProjectName());
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
@@ -1,0 +1,70 @@
+package com.saucelabs.saucebindings.integration;
+
+import com.saucelabs.saucebindings.SauceOptions;
+import com.saucelabs.saucebindings.SauceSession;
+import org.junit.After;
+import org.junit.Test;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+
+public class VisualTest {
+    private RemoteWebDriver webDriver;
+    private SauceSession session;
+    private SauceOptions sauceOptions;
+
+    @After
+    public void cleanUp() {
+        session.stop(true);
+    }
+
+    @Test
+    public void defaultStart() {
+        sauceOptions = SauceOptions.visual("defaultStart");
+        session = new SauceSession(sauceOptions);
+        session.start();
+        assertNotNull(session.getDriver());
+    }
+
+    @Test
+    public void settingCommonOptions()  {
+        sauceOptions = SauceOptions.visual("settingCommonOptions");
+        sauceOptions.setName("testName");
+        sauceOptions.setViewportSize("1280x1024");
+
+        session = new SauceSession(sauceOptions);
+        webDriver = session.start();
+        assertNotNull(session.getDriver());
+    }
+
+    @Test
+    public void settingUniqueOptions() {
+        sauceOptions = SauceOptions.visual("settingUniqueOptions");
+
+        sauceOptions.setViewportSize("1280x1024");
+
+        Map<String, Object> diffOptions = new HashMap<>();
+        diffOptions.put("structure", true);
+        diffOptions.put("layout", true);
+        diffOptions.put("style", true);
+        diffOptions.put("content", true);
+        diffOptions.put("minLayoutPosition", 4);
+        diffOptions.put("minLayoutDimension", 10);
+
+        sauceOptions.setDiffOptions(diffOptions);
+
+        sauceOptions.setIgnore("#foo, .bar");
+        sauceOptions.setFailOnNewStates(true);
+        sauceOptions.setScrollAndStitchScreenshots(true);
+        sauceOptions.setDisableCORS(true);
+
+        session = new SauceSession(sauceOptions);
+        webDriver = session.start();
+        webDriver.get("https://www.saucedemo.com/");
+        session.takeSnapshot("Snapshot name");
+        assertNotNull(session.getDriver());
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/options.yml
+++ b/java/src/test/java/com/saucelabs/saucebindings/options.yml
@@ -77,3 +77,22 @@ invalidOption:
   browserVersion: "70"
   platformName: "MacOS 10.12"
   recordScreenshots: false
+
+visualValues:
+  browserName: 'firefox'
+  browserVersion: '68'
+  platformName: 'macOS 10.13'
+  build: 'Sample Build Name'
+  visualProjectName: 'fromYAML'
+  viewportSize: '1280x1024'
+  diffOptions:
+    structure: true
+    layout: true
+    style: true
+    content: true
+    minLayoutPosition: 3
+    minLayoutDimension: 12
+  ignore: '#foo, .bar'
+  failOnNewStates: true
+  scrollAndStitchScreenshots: true
+  disableCORS: true


### PR DESCRIPTION
I broke this into 2 commits. The first is what is completely matching the current structure of the code...
(Almost) all public instance methods in `SauceOptions` are lombok-generated getters & setters

Minimum required
```java
SauceOptions sauceOptions = new SauceOptions();
sauceOptions.setVisualProjectName("My Project Name");
```
We need this to work so we can set values from a config file. (see `parsesCapabilitiesFromVisualValues()` test below)

The second commit is optional. It's how I was thinking we might encourage people to use a factory pattern type approach to initializing options with the basic things that make sense, and could be extended to include mobile, etc. It looks like this:
```
SauceOptions sauceOptions = SauceOptions.visual("My Project Name");
```

My current big concern with this is the extent to which the method names for these options make sense external to the context of visual...
for instance:
`projectName` doesn't immediately make me think of visual, so I renamed it "visualProjectName" for the bindings
`ignore` also doesn't really seem obvious. `ignoreCSS` maybe? or `visualIgnore`? 

Makes me wonder if the context  for saying these are Visual and only visual objects might not be worthwhile. But I guess that's not where I think we should go first.


Other Stuff
1. This renames `projectName` to `visualProjectName`
2. This does not rename `ignore` to anything that would be easier to understand
3. This sets Sauce Labs Test Name to Visual Project Name
4. This doesn't allow ignore parameters to be a List, only a String (should get fixed before merged)
5. What should we do when a non-visual test calls takeSnapshot?
6. This should get updated with the Session pattern in #218 
7. @nadvolod I'm not sure why #213 had special logic for [`getScreenerApiKey()`](https://github.com/saucelabs/sauce_bindings/pull/218/files#diff-49a321ee5882d79545dd8f7728516ace51372a046901f91fe3b6dac5532ae440R363)
