### PR TITLE
Visual4

### DIFF
--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -156,6 +156,12 @@ public class SauceOptions {
         knownCITools.put("TeamCity", "TEAMCITY_PROJECT_NAME");
     }
 
+    public static SauceOptions visual(String visualProjectName) {
+        SauceOptions sauceOptions = new SauceOptions();
+        sauceOptions.setVisualProjectName(visualProjectName);
+        return sauceOptions;
+    }
+
     public SauceOptions() {
         this(new MutableCapabilities());
     }

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -25,7 +25,7 @@ public class SauceSession {
     }
 
     public RemoteWebDriver start() {
-        if(sauceOptions.getVisualProjectName() != null){
+        if(sauceOptions.visual() != null){
             driver = createRemoteWebDriver(getScreenerUrl(), sauceOptions.toCapabilities());
             getDriver().executeScript(
                     "/*@visual.init*/", sauceOptions.getName());
@@ -65,7 +65,7 @@ public class SauceSession {
     }
 
     public void stop(String result) {
-        if(sauceOptions.getVisualProjectName() != null){
+        if(sauceOptions.visual() != null){
             updateVisualResult();
         }
         else{

--- a/java/src/main/java/com/saucelabs/saucebindings/VisualOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/VisualOptions.java
@@ -1,0 +1,78 @@
+package com.saucelabs.saucebindings;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Accessors(chain = true)
+@Setter @Getter
+public class VisualOptions extends SauceOptions {
+    // Sauce Visual Settings
+    // https://screener.io/v2/docs/visual-e2e/visual-options
+    private String projectName;
+    private String viewportSize;
+    private String branch;
+    private String baseBranch;
+    private Map<String, Object> diffOptions = null;
+    private String ignore = null;   // This probably should be a List not a String, but conversions, ugh
+    private Boolean failOnNewStates = null;
+    private Boolean alwaysAcceptBaseBranch = null;
+    private Boolean disableBranchBaseline = null;
+    private Boolean scrollAndStitchScreenshots = null;
+    private Boolean disableCORS = null;
+
+    public static final List<String> sauceVisualOptions = Arrays.asList(
+            "projectName",
+            "viewportSize",
+            "branch",
+            "baseBranch",
+            "diffOptions",
+            "ignore",
+            "failOnNewStates",
+            "alwaysAcceptBaseBranch",
+            "disableBranchBaseline",
+            "scrollAndStitchScreenshots",
+            "disableCORS");
+
+
+    public VisualOptions(String projectName) {
+        setProjectName(projectName);
+    }
+
+    public MutableCapabilities toCapabilities() {
+        MutableCapabilities sauceVisualCapabilities = new MutableCapabilities();
+        sauceVisualCapabilities.setCapability("apiKey", getScreenerApiKey());
+        sauceVisualOptions.forEach((capability) -> {
+            addCapabilityIfDefined(sauceVisualCapabilities, capability);
+        });
+
+        return sauceVisualCapabilities;
+    }
+
+    protected String getScreenerApiKey() {
+        String error = "Screener Access Key was not set in your env variables. Please set SCREENER_API_KEY value.";
+        return tryToGetVariable("SCREENER_API_KEY", error);
+    }
+
+    protected void setVisualCapabilities(Map<String, Object> visualCapabilities) {
+        visualCapabilities.forEach(this::setVisualCapability);
+    }
+
+    private void setVisualCapability(String key, Object value) {
+        try {
+            Class<?> type = VisualOptions.class.getDeclaredField(key).getType();
+            String setter = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
+            Method method = VisualOptions.class.getDeclaredMethod(setter, type);
+            method.invoke(this, value);
+        } catch (NoSuchFieldException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsConstrTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsConstrTest.java
@@ -18,6 +18,6 @@ public class SauceOptionsConstrTest {
         assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
         assertEquals(SaucePlatform.WINDOWS_10, sauceOptions.getPlatformName());
         assertEquals("latest", sauceOptions.getBrowserVersion());
-        assertEquals("projectName", sauceOptions.getVisualProjectName());
+        assertEquals("projectName", sauceOptions.visual().getProjectName());
     }
 }

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsConstrTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsConstrTest.java
@@ -1,0 +1,23 @@
+package com.saucelabs.saucebindings;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.junit.Assert.assertEquals;
+
+public class SauceOptionsConstrTest {
+    @Rule
+    public MockitoRule initRule = MockitoJUnit.rule();
+
+    @Test
+    public void constructsSauceOptionsVisual() {
+        SauceOptions sauceOptions = SauceOptions.visual("projectName");
+
+        assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
+        assertEquals(SaucePlatform.WINDOWS_10, sauceOptions.getPlatformName());
+        assertEquals("latest", sauceOptions.getBrowserVersion());
+        assertEquals("projectName", sauceOptions.getVisualProjectName());
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.openqa.selenium.UnexpectedAlertBehaviour.DISMISS;
@@ -304,32 +303,6 @@ public class SauceOptionsTest {
         assertEquals(false, sauceOptions.getVideoUploadOnPass());
     }
 
-    @Test
-    public void setsVisualCapabilitiesFromMap() {
-        Map<String, Object> map = serialize("visualValues");
-        sauceOptions.mergeCapabilities(map);
-
-        Map<String, Object> diffMap = new HashMap<>();
-        diffMap.put("structure", true);
-        diffMap.put("layout", true);
-        diffMap.put("style", true);
-        diffMap.put("content", true);
-        diffMap.put("minLayoutPosition", 3);
-        diffMap.put("minLayoutDimension", 12);
-
-        assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
-        assertEquals("68", sauceOptions.getBrowserVersion());
-        assertEquals(SaucePlatform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
-        assertEquals("Sample Build Name", sauceOptions.getBuild());
-        assertEquals("fromYAML", sauceOptions.getVisualProjectName());
-        assertEquals("1280x1024", sauceOptions.getViewportSize());
-        assertEquals(diffMap, sauceOptions.getDiffOptions());
-        assertEquals("#foo, .bar", sauceOptions.getIgnore());
-        assertTrue(sauceOptions.getFailOnNewStates());
-        assertTrue(sauceOptions.getScrollAndStitchScreenshots());
-        assertTrue(sauceOptions.getDisableCORS());
-    }
-
     @Test(expected = InvalidSauceOptionsArgumentException.class)
     public void setsBadBrowserFromMap()  {
         Map<String, Object> map = serialize("badBrowser");
@@ -536,67 +509,6 @@ public class SauceOptionsTest {
     }
 
     @Test
-    public void parsesCapabilitiesFromVisualValues() {
-        Map<String, Object> diffMap = new HashMap<>();
-        diffMap.put("structure", false);
-        diffMap.put("layout", false);
-        diffMap.put("style", false);
-        diffMap.put("content", false);
-        diffMap.put("minLayoutPosition", 5);
-        diffMap.put("minLayoutDimension", 9);
-
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-        doReturn("test-visualkey").when(sauceOptions).getEnvironmentVariable("SCREENER_API_KEY");
-        sauceOptions.setBuild("Build Name");
-
-        sauceOptions.setVisualProjectName("myProject");
-        sauceOptions.setViewportSize("1900x1200");
-        sauceOptions.setBranch("my-branch");
-        sauceOptions.setBaseBranch("base-branch");
-        sauceOptions.setIgnore("#some-id, .some-class");
-        sauceOptions.setFailOnNewStates(true);
-        sauceOptions.setAlwaysAcceptBaseBranch(true);
-        sauceOptions.setDisableBranchBaseline(true);
-        sauceOptions.setScrollAndStitchScreenshots(true);
-        sauceOptions.setDisableCORS(true);
-
-        sauceOptions.setDiffOptions(diffMap);
-
-        MutableCapabilities expectedCapabilities = new MutableCapabilities();
-        expectedCapabilities.setCapability("browserName", "chrome");
-        expectedCapabilities.setCapability("browserVersion", "latest");
-        expectedCapabilities.setCapability("platformName", "Windows 10");
-
-        MutableCapabilities sauceCapabilities = new MutableCapabilities();
-        sauceCapabilities.setCapability("build", "Build Name");
-        sauceCapabilities.setCapability("username", "test-name");
-        sauceCapabilities.setCapability("accessKey", "test-accesskey");
-        expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
-
-        MutableCapabilities visualCapabilities = new MutableCapabilities();
-        visualCapabilities.setCapability("projectName", "myProject");
-        visualCapabilities.setCapability("viewportSize", "1900x1200");
-        visualCapabilities.setCapability("branch", "my-branch");
-        visualCapabilities.setCapability("baseBranch", "base-branch");
-
-        visualCapabilities.setCapability("diffOptions", diffMap);
-        visualCapabilities.setCapability("ignore", "#some-id, .some-class");
-
-        visualCapabilities.setCapability("failOnNewStates", true);
-        visualCapabilities.setCapability("alwaysAcceptBaseBranch", true);
-        visualCapabilities.setCapability("disableBranchBaseline", true);
-        visualCapabilities.setCapability("scrollAndStitchScreenshots", true);
-        visualCapabilities.setCapability("disableCORS", true);
-
-        expectedCapabilities.setCapability("sauce:visual", visualCapabilities);
-
-        MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
-        // toString() serializes the enums
-        assertEquals(expectedCapabilities.asMap().toString(), actualCapabilities.asMap().toString());
-    }
-
-        @Test
     public void parsesW3CAndSauceAndSeleniumSettings() {
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
         MutableCapabilities sauceCapabilities = new MutableCapabilities();

--- a/java/src/test/java/com/saucelabs/saucebindings/VisualOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/VisualOptionsTest.java
@@ -1,0 +1,140 @@
+package com.saucelabs.saucebindings;
+
+import lombok.SneakyThrows;
+import org.junit.Test;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.openqa.selenium.UnexpectedAlertBehaviour.DISMISS;
+
+public class VisualOptionsTest {
+    @Test
+    public void acceptsChromeOptionsClass() {
+        ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.addArguments("--foo");
+        chromeOptions.setUnhandledPromptBehaviour(DISMISS);
+
+        SauceOptions sauceOptions = SauceOptions.visual("acceptsChromeOptionsClass", chromeOptions);
+
+        assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
+        assertEquals(chromeOptions, sauceOptions.getSeleniumCapabilities());
+        assertNotNull(sauceOptions.visual());
+    }
+
+    @Test
+    public void acceptsEdgeOptionsClass() {
+        EdgeOptions edgeOptions = new EdgeOptions();
+        edgeOptions.setPageLoadStrategy("eager");
+
+        SauceOptions sauceOptions = SauceOptions.visual("acceptsEdgeOptionsClass", edgeOptions);
+
+        assertEquals(Browser.EDGE, sauceOptions.getBrowserName());
+        assertEquals(edgeOptions, sauceOptions.getSeleniumCapabilities());
+        assertNotNull(sauceOptions.visual());
+    }
+
+    @SneakyThrows
+    public Map<String, Object> serialize(String key) {
+        InputStream input = new FileInputStream(new File("src/test/java/com/saucelabs/saucebindings/options.yml"));
+        Yaml yaml = new Yaml();
+        Map<String, Object> data = yaml.load(input);
+        return (Map<String, Object>) data.get(key);
+    }
+
+    @Test
+    public void setsVisualCapabilitiesFromMap() {
+        SauceOptions sauceOptions = SauceOptions.visual("setsVisualCapabilitiesFromMap");
+
+        Map<String, Object> map = serialize("visualValues");
+        sauceOptions.mergeCapabilities(map);
+
+        Map<String, Object> diffMap = new HashMap<>();
+        diffMap.put("structure", true);
+        diffMap.put("layout", true);
+        diffMap.put("style", true);
+        diffMap.put("content", true);
+        diffMap.put("minLayoutPosition", 3);
+        diffMap.put("minLayoutDimension", 12);
+
+        assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals("68", sauceOptions.getBrowserVersion());
+        assertEquals(SaucePlatform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
+        assertEquals("Sample Build Name", sauceOptions.getBuild());
+        assertEquals("fromYAML", sauceOptions.visual().getProjectName());
+        assertEquals("1280x1024", sauceOptions.visual().getViewportSize());
+        assertEquals(diffMap, sauceOptions.visual().getDiffOptions());
+        assertEquals("#foo, .bar", sauceOptions.visual().getIgnore());
+        assertTrue(sauceOptions.visual().getFailOnNewStates());
+        assertTrue(sauceOptions.visual().getScrollAndStitchScreenshots());
+        assertTrue(sauceOptions.visual().getDisableCORS());
+    }
+
+    @Test
+    public void parsesCapabilitiesFromVisualValues() {
+        SauceOptions sauceOptions = SauceOptions.visual("parsesCapabilitiesFromVisualValues");
+
+        Map<String, Object> diffMap = new HashMap<>();
+        diffMap.put("structure", false);
+        diffMap.put("layout", false);
+        diffMap.put("style", false);
+        diffMap.put("content", false);
+        diffMap.put("minLayoutPosition", 5);
+        diffMap.put("minLayoutDimension", 9);
+
+        sauceOptions.setBuild("Build Name");
+
+        sauceOptions.visual().setViewportSize("1900x1200");
+        sauceOptions.visual().setBranch("my-branch");
+        sauceOptions.visual().setBaseBranch("base-branch");
+        sauceOptions.visual().setIgnore("#some-id, .some-class");
+        sauceOptions.visual().setFailOnNewStates(true);
+        sauceOptions.visual().setAlwaysAcceptBaseBranch(true);
+        sauceOptions.visual().setDisableBranchBaseline(true);
+        sauceOptions.visual().setScrollAndStitchScreenshots(true);
+        sauceOptions.visual().setDisableCORS(true);
+        sauceOptions.visual().setDiffOptions(diffMap);
+
+        MutableCapabilities expectedCapabilities = new MutableCapabilities();
+        expectedCapabilities.setCapability("browserName", "chrome");
+        expectedCapabilities.setCapability("browserVersion", "latest");
+        expectedCapabilities.setCapability("platformName", "Windows 10");
+
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+        sauceCapabilities.setCapability("build", "Build Name");
+        sauceCapabilities.setCapability("username", System.getenv("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", System.getenv("SAUCE_ACCESS_KEY"));
+        expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
+
+        MutableCapabilities visualCapabilities = new MutableCapabilities();
+        visualCapabilities.setCapability("apiKey", System.getenv("SCREENER_API_KEY"));
+
+        visualCapabilities.setCapability("projectName", "parsesCapabilitiesFromVisualValues");
+        visualCapabilities.setCapability("viewportSize", "1900x1200");
+        visualCapabilities.setCapability("branch", "my-branch");
+        visualCapabilities.setCapability("baseBranch", "base-branch");
+
+        visualCapabilities.setCapability("diffOptions", diffMap);
+        visualCapabilities.setCapability("ignore", "#some-id, .some-class");
+
+        visualCapabilities.setCapability("failOnNewStates", true);
+        visualCapabilities.setCapability("alwaysAcceptBaseBranch", true);
+        visualCapabilities.setCapability("disableBranchBaseline", true);
+        visualCapabilities.setCapability("scrollAndStitchScreenshots", true);
+        visualCapabilities.setCapability("disableCORS", true);
+
+        expectedCapabilities.setCapability("sauce:visual", visualCapabilities);
+
+        MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
+        // toString() serializes the enums
+        assertEquals(expectedCapabilities.asMap().toString(), actualCapabilities.asMap().toString());
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
@@ -1,0 +1,70 @@
+package com.saucelabs.saucebindings.integration;
+
+import com.saucelabs.saucebindings.SauceOptions;
+import com.saucelabs.saucebindings.SauceSession;
+import org.junit.After;
+import org.junit.Test;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+
+public class VisualTest {
+    private RemoteWebDriver webDriver;
+    private SauceSession session;
+    private SauceOptions sauceOptions;
+
+    @After
+    public void cleanUp() {
+        session.stop(true);
+    }
+
+    @Test
+    public void defaultStart() {
+        sauceOptions = SauceOptions.visual("defaultStart");
+        session = new SauceSession(sauceOptions);
+        session.start();
+        assertNotNull(session.getDriver());
+    }
+
+    @Test
+    public void settingCommonOptions()  {
+        sauceOptions = SauceOptions.visual("settingCommonOptions");
+        sauceOptions.setName("testName");
+        sauceOptions.setViewportSize("1280x1024");
+
+        session = new SauceSession(sauceOptions);
+        webDriver = session.start();
+        assertNotNull(session.getDriver());
+    }
+
+    @Test
+    public void settingUniqueOptions() {
+        sauceOptions = SauceOptions.visual("settingUniqueOptions");
+
+        sauceOptions.setViewportSize("1280x1024");
+
+        Map<String, Object> diffOptions = new HashMap<>();
+        diffOptions.put("structure", true);
+        diffOptions.put("layout", true);
+        diffOptions.put("style", true);
+        diffOptions.put("content", true);
+        diffOptions.put("minLayoutPosition", 4);
+        diffOptions.put("minLayoutDimension", 10);
+
+        sauceOptions.setDiffOptions(diffOptions);
+
+        sauceOptions.setIgnore("#foo, .bar");
+        sauceOptions.setFailOnNewStates(true);
+        sauceOptions.setScrollAndStitchScreenshots(true);
+        sauceOptions.setDisableCORS(true);
+
+        session = new SauceSession(sauceOptions);
+        webDriver = session.start();
+        webDriver.get("https://www.saucedemo.com/");
+        session.takeSnapshot("Snapshot name");
+        assertNotNull(session.getDriver());
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
@@ -33,7 +33,7 @@ public class VisualTest {
     public void settingCommonOptions()  {
         sauceOptions = SauceOptions.visual("settingCommonOptions");
         sauceOptions.setName("testName");
-        sauceOptions.setViewportSize("1280x1024");
+        sauceOptions.visual().setViewportSize("1280x1024");
 
         session = new SauceSession(sauceOptions);
         webDriver = session.start();
@@ -44,7 +44,7 @@ public class VisualTest {
     public void settingUniqueOptions() {
         sauceOptions = SauceOptions.visual("settingUniqueOptions");
 
-        sauceOptions.setViewportSize("1280x1024");
+        sauceOptions.visual().setViewportSize("1280x1024");
 
         Map<String, Object> diffOptions = new HashMap<>();
         diffOptions.put("structure", true);
@@ -54,12 +54,12 @@ public class VisualTest {
         diffOptions.put("minLayoutPosition", 4);
         diffOptions.put("minLayoutDimension", 10);
 
-        sauceOptions.setDiffOptions(diffOptions);
+        sauceOptions.visual().setDiffOptions(diffOptions);
 
-        sauceOptions.setIgnore("#foo, .bar");
-        sauceOptions.setFailOnNewStates(true);
-        sauceOptions.setScrollAndStitchScreenshots(true);
-        sauceOptions.setDisableCORS(true);
+        sauceOptions.visual().setIgnore("#foo, .bar");
+        sauceOptions.visual().setFailOnNewStates(true);
+        sauceOptions.visual().setScrollAndStitchScreenshots(true);
+        sauceOptions.visual().setDisableCORS(true);
 
         session = new SauceSession(sauceOptions);
         webDriver = session.start();

--- a/java/src/test/java/com/saucelabs/saucebindings/options.yml
+++ b/java/src/test/java/com/saucelabs/saucebindings/options.yml
@@ -77,3 +77,22 @@ invalidOption:
   browserVersion: "70"
   platformName: "MacOS 10.12"
   recordScreenshots: false
+
+visualValues:
+  browserName: 'firefox'
+  browserVersion: '68'
+  platformName: 'macOS 10.13'
+  build: 'Sample Build Name'
+  visualProjectName: 'fromYAML'
+  viewportSize: '1280x1024'
+  diffOptions:
+    structure: true
+    layout: true
+    style: true
+    content: true
+    minLayoutPosition: 3
+    minLayoutDimension: 12
+  ignore: '#foo, .bar'
+  failOnNewStates: true
+  scrollAndStitchScreenshots: true
+  disableCORS: true

--- a/java/src/test/java/com/saucelabs/saucebindings/options.yml
+++ b/java/src/test/java/com/saucelabs/saucebindings/options.yml
@@ -83,16 +83,17 @@ visualValues:
   browserVersion: '68'
   platformName: 'macOS 10.13'
   build: 'Sample Build Name'
-  visualProjectName: 'fromYAML'
-  viewportSize: '1280x1024'
-  diffOptions:
-    structure: true
-    layout: true
-    style: true
-    content: true
-    minLayoutPosition: 3
-    minLayoutDimension: 12
-  ignore: '#foo, .bar'
-  failOnNewStates: true
-  scrollAndStitchScreenshots: true
-  disableCORS: true
+  visual:
+    projectName: 'fromYAML'
+    viewportSize: '1280x1024'
+    diffOptions:
+      structure: true
+      layout: true
+      style: true
+      content: true
+      minLayoutPosition: 3
+      minLayoutDimension: 12
+    ignore: '#foo, .bar'
+    failOnNewStates: true
+    scrollAndStitchScreenshots: true
+    disableCORS: true


### PR DESCRIPTION
@nadvolod I'm pretty sure this is much more interesting of an approach to you.
This addresses most of the concerns I had in #223, but still a couple outstanding

Features:
* Required to use static method/factory pattern to construct
* Always requires projectName
* Alternate factory constructor takes MutableCapabilities instance as well
* setters and getters use instance method `visual()`
```
SauceOptions sauceOptions = SauceOptions.visual("acceptsChromeOptionsClass", new FirefoxOptions());
sauceOptions.visual().setViewportSize("1900x1200");
```

If we like this, the next question is if we want to make non-backward-compatible changes to how we are differentiating browser, sauce & w3c capabilities? Or just move forward with this approach for mobile and go from there?