### PR TITLE
Capability manager

### DIFF
--- a/java/src/main/java/com/saucelabs/saucebindings/CapabilityManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/CapabilityManager.java
@@ -1,0 +1,41 @@
+package com.saucelabs.saucebindings;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+public class CapabilityManager {
+    private final Options options;
+
+    public CapabilityManager(Options options) {
+        this.options = options;
+    }
+
+    public void addCapabilities() {
+        options.getValidOptions().forEach((capability) -> {
+            Object value = getCapability(capability);
+            if (value != null) {
+                options.capabilities.setCapability(capability, value);
+            }
+        });
+    }
+
+    public Object getCapability(String capability) {
+        try {
+            String getter = "get" + capability.substring(0, 1).toUpperCase() + capability.substring(1);
+            Method declaredMethod = null;
+            declaredMethod = options.getClass().getDeclaredMethod(getter);
+            return declaredMethod.invoke(options);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    protected void capabilityValidator(String name, Set values, String value) {
+        if (!values.contains(value)) {
+            String message = value + " is not a valid " + name + ", please choose from: " + values;
+            throw new InvalidSauceOptionsArgumentException(message);
+        }
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/Options.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/Options.java
@@ -1,0 +1,14 @@
+package com.saucelabs.saucebindings;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.util.List;
+
+public abstract class Options {
+    @Setter protected MutableCapabilities capabilities = new MutableCapabilities();
+    @Setter protected CapabilityManager capabilityManager;
+    @Setter protected SystemManager systemManager;
+    @Getter public final List<String> validOptions = null;
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceLabsOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceLabsOptions.java
@@ -1,0 +1,167 @@
+package com.saucelabs.saucebindings;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Accessors(chain = true) @Setter @Getter
+public class SauceLabsOptions extends SauceOptions {
+    // https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+    private Boolean avoidProxy = null;
+    private String build;
+    private Boolean capturePerformance = null;
+    private String chromedriverVersion;
+    private Integer commandTimeout = null;
+    private Map<String, Object> customData = null;
+    private Boolean extendedDebugging = null;
+    private Integer idleTimeout = null;
+    private String iedriverVersion;
+    private Integer maxDuration = null;
+    private String name;
+    private String parentTunnel;
+    private Map<Prerun, Object> prerun;
+    private URL prerunUrl;
+    private Integer priority = null;
+    private JobVisibility jobVisibility; // the actual key for this is a Java reserved keyword "public"; uses enum
+    private Boolean recordLogs = null;
+    private Boolean recordScreenshots = null;
+    private Boolean recordVideo = null;
+    private String screenResolution;
+    private String seleniumVersion;
+    private List<String> tags = null;
+    private String timeZone;
+    private String tunnelIdentifier;
+    private Boolean videoUploadOnPass = null;
+
+
+    public static final List<String> sauceLabsOptions = Arrays.asList(
+            "avoidProxy",
+            "build",
+            "capturePerformance",
+            "chromedriverVersion",
+            "commandTimeout",
+            "customData",
+            "extendedDebugging",
+            "idleTimeout",
+            "iedriverVersion",
+            "jobVisibility",
+            "maxDuration",
+            "name",
+            "parentTunnel",
+            "prerun",
+            "priority",
+            // public, do not use, reserved keyword, using jobVisibility with enum
+            "recordLogs",
+            "recordScreenshots",
+            "recordVideo",
+            "screenResolution",
+            "seleniumVersion",
+            "tags",
+            "timeZone",
+            "tunnelIdentifier",
+            "videoUploadOnPass");
+
+    public MutableCapabilities toCapabilities() {
+        MutableCapabilities sauceLabsCapabilities = addAuthentication();
+
+        sauceLabsOptions.forEach((capability) -> {
+            if ("prerunUrl".equals(capability)) {
+                sauceLabsCapabilities.setCapability("prerun", getCapability("prerunUrl"));
+            } else if ("jobVisibility".equals(capability)) {
+                sauceLabsCapabilities.setCapability("public", getCapability("jobVisibility"));
+            } else {
+                addCapabilityIfDefined(sauceLabsCapabilities, capability);
+            }
+        });
+
+        return sauceLabsCapabilities;
+    }
+
+    protected void setSauceCapabilities(Map<String, Object> sauceLabsCapabilities) {
+        sauceLabsCapabilities.forEach(this::setSauceCapability);
+    }
+
+    protected void setSauceCapability(String key, Object value) {
+        if ("jobVisibility".equals(key)) {
+            enumValidator("JobVisibility", JobVisibility.keys(), (String) value);
+            setJobVisibility(JobVisibility.valueOf(JobVisibility.fromString((String) value)));
+        } else if ("prerun".equals(key)) {
+            Map<Prerun, Object> prerunMap = new HashMap<>();
+            ((Map) value).forEach((oldKey, val) -> {
+                enumValidator("Prerun", Prerun.keys(), (String) oldKey);
+                String keyString = Prerun.fromString((String) oldKey);
+                prerunMap.put(Prerun.valueOf(keyString), val);
+            });
+            setPrerun(prerunMap);
+        } else {
+            try {
+                Class<?> type = SauceLabsOptions.class.getDeclaredField(key).getType();
+                String setter = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
+                Method method = SauceLabsOptions.class.getDeclaredMethod(setter, type);
+                method.invoke(this, value);
+            } catch (NoSuchFieldException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public String getBuild() {
+        if (build != null) {
+            return build;
+        } else if (getEnvironmentVariable(knownCITools.get("Jenkins")) != null) {
+            return getEnvironmentVariable("BUILD_NAME") + ": " + getEnvironmentVariable("BUILD_NUMBER");
+        } else if (getEnvironmentVariable(knownCITools.get("Bamboo")) != null) {
+            return getEnvironmentVariable("bamboo_shortJobName") + ": " + getEnvironmentVariable("bamboo_buildNumber");
+        } else if (getEnvironmentVariable(knownCITools.get("Travis")) != null) {
+            return getEnvironmentVariable("TRAVIS_JOB_NAME") + ": " + getEnvironmentVariable("TRAVIS_JOB_NUMBER");
+        } else if (getEnvironmentVariable(knownCITools.get("Circle")) != null) {
+            return getEnvironmentVariable("CIRCLE_JOB") + ": " + getEnvironmentVariable("CIRCLE_BUILD_NUM");
+        } else if (getEnvironmentVariable(knownCITools.get("GitLab")) != null) {
+            return getEnvironmentVariable("CI_JOB_NAME") + ": " + getEnvironmentVariable("CI_JOB_ID");
+        } else if (getEnvironmentVariable(knownCITools.get("TeamCity")) != null) {
+            return getEnvironmentVariable("TEAMCITY_PROJECT_NAME") + ": " + getEnvironmentVariable("BUILD_NUMBER");
+        } else {
+            return "Build Time: " + System.currentTimeMillis();
+        }
+    }
+
+    public boolean isKnownCI() {
+        return !knownCITools.keySet().stream().allMatch((key) -> getEnvironmentVariable(key) == null);
+    }
+
+    public static final Map<String, String> knownCITools;
+
+    static {
+        knownCITools = new HashMap<>();
+        knownCITools.put("Jenkins", "BUILD_TAG");
+        knownCITools.put("Bamboo", "bamboo_agentId");
+        knownCITools.put("Travis", "TRAVIS_JOB_ID");
+        knownCITools.put("Circle", "CIRCLE_JOB");
+        knownCITools.put("GitLab", "CI");
+        knownCITools.put("TeamCity", "TEAMCITY_PROJECT_NAME");
+    }
+
+    private MutableCapabilities addAuthentication() {
+        MutableCapabilities caps = new MutableCapabilities();
+        caps.setCapability("username", getSauceUsername());
+        caps.setCapability("accessKey", getSauceAccessKey());
+        return caps;
+    }
+
+    protected String getSauceUsername() {
+        return tryToGetVariable("SAUCE_USERNAME", "Sauce Username was not provided");
+    }
+
+    protected String getSauceAccessKey() {
+        return tryToGetVariable("SAUCE_ACCESS_KEY", "Sauce Access Key was not provided");
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -152,210 +152,262 @@ public class SauceOptions extends Options {
      * Prepend with sauce()
      */
 
+    @Deprecated
     public boolean isKnownCI() {
         return sauce().isKnownCI();
     }
 
+    @Deprecated
     public Options setAvoidProxy(Boolean avoidProxy) {
         return sauce().setAvoidProxy(avoidProxy);
     }
 
+    @Deprecated
     public Options setBuild(String build) {
         return sauce().setBuild(build);
     }
 
+    @Deprecated
     public Options setCapturePerformance(Boolean capturePerformance) {
         return sauce().setCapturePerformance(capturePerformance);
     }
 
+    @Deprecated
     public Options setChromedriverVersion(String chromedriverVersion) {
         return sauce().setChromedriverVersion(chromedriverVersion);
     }
 
+    @Deprecated
     public Options setCommandTimeout(Integer commandTimeout) {
         return sauce().setCommandTimeout(commandTimeout);
     }
 
+    @Deprecated
     public Options setCustomData(Map<String, Object> customData) {
         return sauce().setCustomData(customData);
     }
 
+    @Deprecated
     public Options setExtendedDebugging(Boolean extendedDebugging) {
         return sauce().setExtendedDebugging(extendedDebugging);
     }
 
+    @Deprecated
     public Options setIdleTimeout(Integer idleTimeout) {
         return sauce().setIdleTimeout(idleTimeout);
     }
 
+    @Deprecated
     public Options setIedriverVersion(String iedriverVersion) {
         return sauce().setIedriverVersion(iedriverVersion);
     }
 
+    @Deprecated
     public Options setMaxDuration(Integer maxDuration) {
         return sauce().setMaxDuration(maxDuration);
     }
 
+    @Deprecated
     public Options setName(String name) {
         return sauce().setName(name);
     }
 
+    @Deprecated
     public Options setParentTunnel(String parentTunnel) {
         return sauce().setParentTunnel(parentTunnel);
     }
 
+    @Deprecated
     public Options setPrerun(Map<Prerun, Object> prerun) {
         return sauce().setPrerun(prerun);
     }
 
+    @Deprecated
     public Options setPrerunUrl(URL prerunUrl) {
         return sauce().setPrerunUrl(prerunUrl);
     }
 
+    @Deprecated
     public Options setPriority(Integer priority) {
         return sauce().setPriority(priority);
     }
 
+    @Deprecated
     public Options setJobVisibility(JobVisibility jobVisibility) {
         return sauce().setJobVisibility(jobVisibility);
     }
 
+    @Deprecated
     public Options setRecordLogs(Boolean recordLogs) {
         return sauce().setRecordLogs(recordLogs);
     }
 
+    @Deprecated
     public Options setRecordScreenshots(Boolean recordScreenshots) {
         return sauce().setRecordScreenshots(recordScreenshots);
     }
 
+    @Deprecated
     public Options setRecordVideo(Boolean recordVideo) {
         return sauce().setRecordVideo(recordVideo);
     }
 
+    @Deprecated
     public Options setScreenResolution(String screenResolution) {
         return sauce().setScreenResolution(screenResolution);
     }
 
+    @Deprecated
     public Options setSeleniumVersion(String seleniumVersion) {
         return sauce().setSeleniumVersion(seleniumVersion);
     }
 
+    @Deprecated
     public Options setTags(List<String> tags) {
         return sauce().setTags(tags);
     }
 
+    @Deprecated
     public Options setTimeZone(String timeZone) {
         return sauce().setTimeZone(timeZone);
     }
 
+    @Deprecated
     public Options setTunnelIdentifier (String tunnelIdentifier) {
         return sauce().setTunnelIdentifier(tunnelIdentifier);
     }
 
+    @Deprecated
     public Options setVideoUploadOnPass(Boolean videoUploadOnPass) {
         return sauce().setVideoUploadOnPass(videoUploadOnPass);
     }
 
+    @Deprecated
     public Boolean getAvoidProxy() {
         return sauce().getAvoidProxy();
     }
 
+    @Deprecated
     public String getBuild() {
         return sauce().getBuild();
     }
 
+    @Deprecated
     public Boolean getCapturePerformance() {
         return sauce().getCapturePerformance();
     }
 
+    @Deprecated
     public String getChromedriverVersion() {
         return sauce().getChromedriverVersion();
     }
 
+    @Deprecated
     public Integer getCommandTimeout() {
         return sauce().getCommandTimeout();
     }
 
+    @Deprecated
     public Map<String, Object> getCustomData() {
         return sauce().getCustomData();
     }
 
+    @Deprecated
     public Boolean getExtendedDebugging() {
         return sauce().getExtendedDebugging();
     }
 
+    @Deprecated
     public Integer getIdleTimeout() {
         return sauce().getIdleTimeout();
     }
 
+    @Deprecated
     public String getIedriverVersion() {
         return sauce().getIedriverVersion();
     }
 
+    @Deprecated
     public Integer getMaxDuration() {
         return sauce().getMaxDuration();
     }
 
+    @Deprecated
     public String getName() {
         return sauce().getName();
     }
 
+    @Deprecated
     public String getParentTunnel() {
         return sauce().getParentTunnel();
     }
 
+    @Deprecated
     public Map<Prerun, Object> getPrerun() {
         return sauce().getPrerun();
     }
 
+    @Deprecated
     public URL getPrerunUrl() {
         return sauce().getPrerunUrl();
     }
 
+    @Deprecated
     public Integer getPriority() {
         return sauce().getPriority();
     }
 
+    @Deprecated
     public JobVisibility getJobVisibility() {
         return sauce().getJobVisibility();
     }
 
+    @Deprecated
     public Boolean getRecordLogs() {
         return sauce().getRecordLogs();
     }
 
+    @Deprecated
     public Boolean getRecordScreenshots() {
         return sauce().getRecordScreenshots();
     }
 
+    @Deprecated
     public Boolean getRecordVideo() {
         return sauce().getRecordVideo();
     }
 
+    @Deprecated
     public String getScreenResolution() {
         return sauce().getScreenResolution();
     }
 
+    @Deprecated
     public String getSeleniumVersion() {
         return sauce().getSeleniumVersion();
     }
 
+    @Deprecated
     public List<String> getTags() {
         return sauce().getTags();
     }
 
+    @Deprecated
     public String getTimeZone() {
         return sauce().getTimeZone();
     }
 
+    @Deprecated
     public String getTunnelIdentifier () {
         return sauce().getTunnelIdentifier();
     }
 
+    @Deprecated
     public Boolean getVideoUploadOnPass() {
         return sauce().getVideoUploadOnPass();
     }
 
+    @Deprecated
     public MutableCapabilities getSeleniumCapabilities() {
         return capabilities;
     }

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -61,7 +61,7 @@ public class SauceSession {
         // The first print statement will automatically populate links on Jenkins to Sauce
         // The second print statement will output the job link to logging/console
         if (this.driver != null) {
-            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", this.driver.getSessionId(), this.sauceOptions.getName());
+            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", this.driver.getSessionId(), this.sauceOptions.sauce().getName());
             String sauceTestLink = String.format("Test Job Link: https://app.saucelabs.com/tests/%s", this.driver.getSessionId());
             System.out.print(sauceReporter + "\n" + sauceTestLink + "\n");
         }

--- a/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
@@ -1,0 +1,21 @@
+package com.saucelabs.saucebindings;
+
+public class SystemManager {
+    protected String get(String key, String errorMessage) {
+        if (getProperty(key) != null) {
+            return getProperty(key);
+        } else if (getEnv(key) != null) {
+            return getEnv(key);
+        } else {
+            throw new SauceEnvironmentVariablesNotSetException(errorMessage);
+        }
+    }
+
+    protected String getProperty(String key) {
+        return System.getProperty(key);
+    }
+
+    protected String getEnv(String key) {
+        return System.getenv(key);
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
@@ -223,9 +223,12 @@ public class SauceOptionsTest {
 
     @Test
     public void createsDefaultBuildName() {
-        doReturn("Not Empty").when(sauceOptions).getEnvironmentVariable("BUILD_TAG");
-        doReturn("TEMP BUILD").when(sauceOptions).getEnvironmentVariable("BUILD_NAME");
-        doReturn("11").when(sauceOptions).getEnvironmentVariable("BUILD_NUMBER");
+        SauceLabsOptions sauceLabsOptions = spy(new SauceLabsOptions());
+        doReturn(sauceLabsOptions).when(sauceOptions).sauce();
+
+        doReturn("Not Empty").when(sauceLabsOptions).getEnvironmentVariable("BUILD_TAG");
+        doReturn("TEMP BUILD").when(sauceLabsOptions).getEnvironmentVariable("BUILD_NAME");
+        doReturn("11").when(sauceLabsOptions).getEnvironmentVariable("BUILD_NUMBER");
 
         assertEquals("TEMP BUILD: 11", sauceOptions.getBuild());
     }
@@ -348,8 +351,10 @@ public class SauceOptionsTest {
 
     @Test
     public void parsesCapabilitiesFromW3CValues() {
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        SauceLabsOptions sauceLabsOptions = spy(new SauceLabsOptions());
+        doReturn(sauceLabsOptions).when(sauceOptions).sauce();
+        doReturn("test-name").when(sauceLabsOptions).getEnvironmentVariable("SAUCE_USERNAME");
+        doReturn("test-accesskey").when(sauceLabsOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
 
         sauceOptions.setBrowserName(Browser.FIREFOX);
         sauceOptions.setPlatformName(SaucePlatform.MAC_HIGH_SIERRA);
@@ -392,8 +397,10 @@ public class SauceOptionsTest {
 
     @Test
     public void parsesCapabilitiesFromSauceValues() {
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        SauceLabsOptions sauceLabsOptions = spy(new SauceLabsOptions());
+        doReturn(sauceLabsOptions).when(sauceOptions).sauce();
+        doReturn("test-name").when(sauceLabsOptions).getEnvironmentVariable("SAUCE_USERNAME");
+        doReturn("test-accesskey").when(sauceLabsOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
 
         Map<String, Object> customData = new HashMap<>();
         customData.put("foo", "foo");
@@ -488,8 +495,11 @@ public class SauceOptionsTest {
         firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
 
         sauceOptions = spy(new SauceOptions(firefoxOptions));
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+
+        SauceLabsOptions sauceLabsOptions = spy(new SauceLabsOptions());
+        doReturn(sauceLabsOptions).when(sauceOptions).sauce();
+        doReturn("test-name").when(sauceLabsOptions).getEnvironmentVariable("SAUCE_USERNAME");
+        doReturn("test-accesskey").when(sauceLabsOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
 
         sauceOptions.setBuild("Build Name");
 
@@ -520,8 +530,10 @@ public class SauceOptionsTest {
 
         sauceOptions = spy(new SauceOptions(firefoxOptions));
 
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        SauceLabsOptions sauceLabsOptions = spy(new SauceLabsOptions());
+        doReturn(sauceLabsOptions).when(sauceOptions).sauce();
+        doReturn("test-name").when(sauceLabsOptions).getEnvironmentVariable("SAUCE_USERNAME");
+        doReturn("test-accesskey").when(sauceLabsOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
 
         expectedCapabilities.merge(firefoxOptions);
         expectedCapabilities.setCapability("browserVersion", "latest");

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.*;
 
 public class SauceSessionTest {
     private final SauceOptions sauceOptions = spy(new SauceOptions());
+    private final SauceLabsOptions sauceLabsOptions = spy(new SauceLabsOptions());
     private final SauceSession sauceSession = spy(new SauceSession());
     private final SauceSession sauceOptsSession = spy(new SauceSession(sauceOptions));
     private final RemoteWebDriver dummyRemoteDriver = mock(RemoteWebDriver.class);
@@ -73,13 +74,15 @@ public class SauceSessionTest {
 
     @Test(expected = SauceEnvironmentVariablesNotSetException.class)
     public void startThrowsErrorWithoutUsername() {
-        doReturn(null).when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
+        doReturn(sauceLabsOptions).when(sauceOptions).sauce();
+        doReturn(null).when(sauceLabsOptions).getEnvironmentVariable("SAUCE_USERNAME");
         sauceOptsSession.start();
     }
 
     @Test(expected = SauceEnvironmentVariablesNotSetException.class)
     public void startThrowsErrorWithoutAccessKey() {
-        doReturn(null).when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        doReturn(sauceLabsOptions).when(sauceOptions).sauce();
+        doReturn(null).when(sauceLabsOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
         sauceOptsSession.start();
     }
 

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
@@ -74,15 +74,25 @@ public class SauceSessionTest {
 
     @Test(expected = SauceEnvironmentVariablesNotSetException.class)
     public void startThrowsErrorWithoutUsername() {
+        SauceLabsOptions sauceLabsOptions = spy(new SauceLabsOptions());
+        sauceLabsOptions.setCapabilityManager(new CapabilityManager(sauceLabsOptions));
+        SystemManager systemManager = spy(new SystemManager());
+        sauceLabsOptions.setSystemManager(systemManager);
         doReturn(sauceLabsOptions).when(sauceOptions).sauce();
-        doReturn(null).when(sauceLabsOptions).getEnvironmentVariable("SAUCE_USERNAME");
+        doReturn(null).when(systemManager).getEnv("SAUCE_USERNAME");
+
         sauceOptsSession.start();
     }
 
     @Test(expected = SauceEnvironmentVariablesNotSetException.class)
     public void startThrowsErrorWithoutAccessKey() {
+        SauceLabsOptions sauceLabsOptions = spy(new SauceLabsOptions());
+        sauceLabsOptions.setCapabilityManager(new CapabilityManager(sauceLabsOptions));
+        SystemManager systemManager = spy(new SystemManager());
+        sauceLabsOptions.setSystemManager(systemManager);
         doReturn(sauceLabsOptions).when(sauceOptions).sauce();
-        doReturn(null).when(sauceLabsOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        doReturn(null).when(systemManager).getEnv("SAUCE_ACCESS_KEY");
+
         sauceOptsSession.start();
     }
 


### PR DESCRIPTION
This is a continuation of #226 
I didn't care for how SauceLabsOptions subclassed SauceOptions. It doesn't make sense to do `sauceOptions.sauce().setBrowserName(Browser.CHROME)`

This pulls implementations into CapabilitiesManager and EnvironmentManager classes. I'm honestly not sure if this is the right way to do it, but it should be more extensible.

This implementation should be completely 100% backward compatible. Methods that will be removed are marked as deprecated. We need to figure out how to do the right reporting so that explanation shows up in IDE? Not sure how that works, yet.

This PR doesn't add the new "correct" way to set parameters, so this is still in Draft.
