### PR TITLE
[java] move system and capability commands into their own classes

### DIFF
--- a/java/src/main/java/com/saucelabs/saucebindings/CapabilityManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/CapabilityManager.java
@@ -1,0 +1,106 @@
+package com.saucelabs.saucebindings;
+
+import org.openqa.selenium.MutableCapabilities;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class CapabilityManager {
+    private final SauceOptions options;
+
+    /**
+     * Class constructor created for a specific SauceOptions instance
+     *
+     * @param options the SauceOptions instance using this capabilities manager
+     */
+    public CapabilityManager(SauceOptions options) {
+        this.options = options;
+    }
+
+    /**
+     * Add values of valid capabilities to the capabilities object
+     *
+     * @param capabilities the capabilities instance that valid options get added to
+     * @param validOptions the list of options matching the options being used
+     */
+    public void addCapabilities(MutableCapabilities capabilities, List<String> validOptions) {
+        validOptions.forEach((capability) -> {
+            Object value = getCapability(capability);
+            if (value != null) {
+                capabilities.setCapability(capability, value);
+            }
+        });
+    }
+
+    /**
+     * Dynamically sets the provided value onto the associated options instance
+     * Alternate way of setting values, primarily used as part of merge() class
+     *
+     * @param key   Name of the capability to set on the options instance
+     * @param value Value of the capability to set on the options instance
+     * @see SauceOptions#mergeCapabilities(Map)
+     */
+    public void setCapability(String key, Object value) {
+        try {
+            Class<?> type = getField(options.getClass(), key).getType();
+            String setter = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
+            Method method = options.getClass().getMethod(setter, type);
+            method.invoke(options, value);
+        } catch (NoSuchFieldException e) {
+            throw new InvalidSauceOptionsArgumentException(key + " is not a valid configuration value");
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException("Unable to set capability for " + key, e);
+        }
+    }
+
+    /**
+     * Dynamically obtain the value of the Field set on the options instance
+     *
+     * @param capability    the name of the field to get the value from
+     * @return              the value of the provided field name
+     */
+    public Object getCapability(String capability) {
+        try {
+            String getter = "get" + capability.substring(0, 1).toUpperCase() + capability.substring(1);
+            Method method = options.getClass().getMethod(getter);
+            return method.invoke(options);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException("Unable to get capability for " + capability, e);
+        }
+    }
+
+    /**
+     * This ensures that a parameter passed in by the mergeCapabilities method matches a valid enum
+     *
+     * @param name      Which enum we are working with for better error message
+     * @param values    Valid options for the provided capability
+     * @param value     Value of the option we want to merge into the capabilities
+     * @see SauceOptions#mergeCapabilities(Map)
+     */
+    public void validateCapability(String name, Set values, String value) {
+        if (!values.contains(value)) {
+            String message = value + " is not a valid " + name + ", please choose from: " + values;
+            throw new InvalidSauceOptionsArgumentException(message);
+        }
+    }
+
+    /**
+     * Recursively searches superclasses to find desired Field even when private
+     */
+    private Field getField(Class<?> optionsClass, String fieldName) throws NoSuchFieldException {
+        try {
+            return optionsClass.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            Class<?> superclass = optionsClass.getSuperclass();
+            if (superclass == null) {
+                throw e;
+            } else {
+                return getField(optionsClass.getSuperclass(), fieldName);
+            }
+        }
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -12,19 +12,17 @@ import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.ie.InternetExplorerOptions;
 import org.openqa.selenium.safari.SafariOptions;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @Accessors(chain = true)
 @Setter @Getter
 public class SauceOptions {
-    @Setter(AccessLevel.NONE) private MutableCapabilities seleniumCapabilities;
+    @Setter(AccessLevel.NONE) private MutableCapabilities capabilities;
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) private CapabilityManager capabilityManager;
     public TimeoutStore timeout = new TimeoutStore();
 
     // w3c Settings
@@ -65,20 +63,6 @@ public class SauceOptions {
     private String timeZone;
     private String tunnelIdentifier;
     private Boolean videoUploadOnPass = null;
-
-    public static final List<String> primaryEnum = Arrays.asList(
-            "browserName",
-            "jobVisibility",
-            "pageLoadStrategy",
-            "platformName",
-            "timeouts",
-            "unhandledPromptBehavior"
-    );
-
-    public static final List<String> secondaryEnum = Arrays.asList(
-            "prerun",
-            "timeouts"
-    );
 
     public static final List<String> w3cDefinedOptions = Arrays.asList(
             "browserName",
@@ -161,64 +145,58 @@ public class SauceOptions {
     }
 
     private SauceOptions(MutableCapabilities options) {
-        seleniumCapabilities = new MutableCapabilities(options.asMap());
+        capabilities = new MutableCapabilities(options.asMap());
+        capabilityManager = new CapabilityManager(this);
         if (options.getCapability("browserName") != null) {
             setCapability("browserName", options.getCapability("browserName"));
         }
     }
 
     public MutableCapabilities toCapabilities() {
-        MutableCapabilities sauceCapabilities = addAuthentication();
+        capabilityManager.addCapabilities(capabilities, w3cDefinedOptions);
 
-        if (getCapability("jobVisibility") != null) {
-            sauceCapabilities.setCapability("public", getCapability("jobVisibility"));
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+        sauceCapabilities.setCapability("username", getSauceUsername());
+        sauceCapabilities.setCapability("accessKey", getSauceAccessKey());
+
+        capabilityManager.addCapabilities(sauceCapabilities, sauceDefinedOptions);
+
+        Object visibilityValue = capabilityManager.getCapability("jobVisibility");
+        if (visibilityValue != null) {
+            sauceCapabilities.setCapability("public", visibilityValue);
         }
 
-        if (getCapability("prerunUrl") != null) {
-            sauceCapabilities.setCapability("prerun", getCapability("prerunUrl"));
+        Object prerunValue = capabilityManager.getCapability("prerunUrl");
+        if (prerunValue != null) {
+            sauceCapabilities.setCapability("prerun", prerunValue);
         }
 
-        w3cDefinedOptions.forEach((capability) -> {
-            addCapabilityIfDefined(seleniumCapabilities, capability);
-        });
-
-        sauceDefinedOptions.forEach((capability) -> {
-            addCapabilityIfDefined(sauceCapabilities, capability);
-        });
-
-        seleniumCapabilities.setCapability("sauce:options", sauceCapabilities);
-        return seleniumCapabilities;
-    }
-
-    private void addCapabilityIfDefined(MutableCapabilities capabilities, String capability) {
-        Object value = getCapability(capability);
-        if (value != null) {
-            capabilities.setCapability(capability, value);
-        }
+        capabilities.setCapability("sauce:options", sauceCapabilities);
+        return capabilities;
     }
 
     public String getBuild() {
         if (build != null) {
             return build;
-        } else if (getEnvironmentVariable(knownCITools.get("Jenkins")) != null) {
-            return getEnvironmentVariable("BUILD_NAME") + ": " + getEnvironmentVariable("BUILD_NUMBER");
-        } else if (getEnvironmentVariable(knownCITools.get("Bamboo")) != null) {
-            return getEnvironmentVariable("bamboo_shortJobName") + ": " + getEnvironmentVariable("bamboo_buildNumber");
-        } else if (getEnvironmentVariable(knownCITools.get("Travis")) != null) {
-            return getEnvironmentVariable("TRAVIS_JOB_NAME") + ": " + getEnvironmentVariable("TRAVIS_JOB_NUMBER");
-        } else if (getEnvironmentVariable(knownCITools.get("Circle")) != null) {
-            return getEnvironmentVariable("CIRCLE_JOB") + ": " + getEnvironmentVariable("CIRCLE_BUILD_NUM");
-        } else if (getEnvironmentVariable(knownCITools.get("GitLab")) != null) {
-            return getEnvironmentVariable("CI_JOB_NAME") + ": " + getEnvironmentVariable("CI_JOB_ID");
-        } else if (getEnvironmentVariable(knownCITools.get("TeamCity")) != null) {
-            return getEnvironmentVariable("TEAMCITY_PROJECT_NAME") + ": " + getEnvironmentVariable("BUILD_NUMBER");
+        } else if (SystemManager.get(knownCITools.get("Jenkins")) != null) {
+            return SystemManager.get("BUILD_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
+        } else if (SystemManager.get(knownCITools.get("Bamboo")) != null) {
+            return SystemManager.get("bamboo_shortJobName") + ": " + SystemManager.get("bamboo_buildNumber");
+        } else if (SystemManager.get(knownCITools.get("Travis")) != null) {
+            return SystemManager.get("TRAVIS_JOB_NAME") + ": " + SystemManager.get("TRAVIS_JOB_NUMBER");
+        } else if (SystemManager.get(knownCITools.get("Circle")) != null) {
+            return SystemManager.get("CIRCLE_JOB") + ": " + SystemManager.get("CIRCLE_BUILD_NUM");
+        } else if (SystemManager.get(knownCITools.get("GitLab")) != null) {
+            return SystemManager.get("CI_JOB_NAME") + ": " + SystemManager.get("CI_JOB_ID");
+        } else if (SystemManager.get(knownCITools.get("TeamCity")) != null) {
+            return SystemManager.get("TEAMCITY_PROJECT_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
         } else {
             return "Build Time: " + System.currentTimeMillis();
         }
     }
 
     public boolean isKnownCI() {
-        return !knownCITools.keySet().stream().allMatch((key) -> getEnvironmentVariable(key) == null);
+        return !knownCITools.keySet().stream().allMatch((key) -> SystemManager.get(key) == null);
     }
 
     // Use Case is pulling serialized information from JSON/YAML, converting it to a HashMap and passing it in
@@ -227,126 +205,66 @@ public class SauceOptions {
         capabilities.forEach(this::setCapability);
     }
 
-    // This might be made public in future version; For now, no good reason to prefer it over direct accessor
-    private Object getCapability(String capability) {
-        try {
-            String getter = "get" + capability.substring(0, 1).toUpperCase() + capability.substring(1);
-            Method declaredMethod = null;
-            declaredMethod = SauceOptions.class.getDeclaredMethod(getter);
-            return declaredMethod.invoke(this);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
+    // Switch statement here to handle enums
     public void setCapability(String key, Object value) {
-        if (primaryEnum.contains(key) && value.getClass().equals(String.class)) {
-            setEnumCapability(key, (String) value);
-        } else if (secondaryEnum.contains(key) && isKeyString((HashMap) value)) {
-            setEnumCapability(key, (HashMap) value);
-        } else {
-            try {
-                Class<?> type = SauceOptions.class.getDeclaredField(key).getType();
-                String setter = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
-                Method method = SauceOptions.class.getDeclaredMethod(setter, type);
-                method.invoke(this, value);
-            } catch (NoSuchFieldException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-                e.printStackTrace();
-            }
-        }
-    }
-
-    private boolean isKeyString(HashMap map) {
-        return map.keySet().toArray()[0].getClass().equals(String.class);
-    }
-
-    // this method is only used when setting capabilities from mergeCapabilities method
-    private void setEnumCapability(String key, HashMap value) {
-        if ("prerun".equals(key)) {
-            Map<Prerun, Object> prerunMap = new HashMap<>();
-            value.forEach((oldKey, val) -> {
-                enumValidator("Prerun", Prerun.keys(), (String) oldKey);
-                String keyString = Prerun.fromString((String) oldKey);
-                prerunMap.put(Prerun.valueOf(keyString), val);
-            });
-            setPrerun(prerunMap);
-        } else if ("timeouts".equals(key)) {
-            Map<Timeouts, Integer> timeoutsMap = new HashMap<>();
-            value.forEach((oldKey, val) -> {
-                enumValidator("Timeouts", Timeouts.keys(), (String) oldKey);
-                String keyString = Timeouts.fromString((String) oldKey);
-                timeoutsMap.put(Timeouts.valueOf(keyString), (Integer) val);
-            });
-            setTimeouts(timeoutsMap);
-        }
-    }
-
-    // this method is only used when setting capabilities from mergeCapabilities method
-    private void setEnumCapability(String key, String value) {
         switch (key) {
             case "browserName":
-                enumValidator("Browser", Browser.keys(), value);
-                setBrowserName(Browser.valueOf(Browser.fromString(value)));
+                capabilityManager.validateCapability("Browser", Browser.keys(), (String) value);
+                setBrowserName(Browser.valueOf(Browser.fromString((String) value)));
                 break;
             case "platformName":
-                enumValidator("SaucePlatform", SaucePlatform.keys(), value);
-                setPlatformName(SaucePlatform.valueOf(SaucePlatform.fromString(value)));
-                break;
-            case "jobVisibility":
-                enumValidator("JobVisibility", JobVisibility.keys(), value);
-                setJobVisibility(JobVisibility.valueOf(JobVisibility.fromString(value)));
+                capabilityManager.validateCapability("SaucePlatform", SaucePlatform.keys(), (String) value);
+                setPlatformName(SaucePlatform.valueOf(SaucePlatform.fromString((String) value)));
                 break;
             case "pageLoadStrategy":
-                enumValidator("PageLoadStrategy", PageLoadStrategy.keys(), value);
-                setPageLoadStrategy(PageLoadStrategy.valueOf(PageLoadStrategy.fromString(value)));
+                capabilityManager.validateCapability("PageLoadStrategy", PageLoadStrategy.keys(), (String) value);
+                setPageLoadStrategy(PageLoadStrategy.valueOf(PageLoadStrategy.fromString((String) value)));
                 break;
             case "unhandledPromptBehavior":
-                enumValidator("UnhandledPromptBehavior", UnhandledPromptBehavior.keys(), value);
-                setUnhandledPromptBehavior(UnhandledPromptBehavior.valueOf(UnhandledPromptBehavior.fromString(value)));
+                capabilityManager.validateCapability("UnhandledPromptBehavior", UnhandledPromptBehavior.keys(), (String) value);
+                setUnhandledPromptBehavior(UnhandledPromptBehavior.valueOf(UnhandledPromptBehavior.fromString((String) value)));
+                break;
+            case "timeouts":
+                Map<Timeouts, Integer> timeoutsMap = new HashMap<>();
+                ((Map) value).forEach((oldKey, val) -> {
+                    capabilityManager.validateCapability("Timeouts", Timeouts.keys(), (String) oldKey);
+                    String keyString = Timeouts.fromString((String) oldKey);
+                    timeoutsMap.put(Timeouts.valueOf(keyString), (Integer) val);
+                });
+                setTimeouts(timeoutsMap);
+                break;
+            case "jobVisibility":
+                capabilityManager.validateCapability("JobVisibility", JobVisibility.keys(), (String) value);
+                setJobVisibility(JobVisibility.valueOf(JobVisibility.fromString((String) value)));
+                break;
+            case "prerun":
+                Map<Prerun, Object> prerunMap = new HashMap<>();
+                ((Map) value).forEach((oldKey, val) -> {
+                    capabilityManager.validateCapability("Prerun", Prerun.keys(), (String) oldKey);
+                    String keyString = Prerun.fromString((String) oldKey);
+                    prerunMap.put(Prerun.valueOf(keyString), val);
+                });
+                setPrerun(prerunMap);
                 break;
             default:
-                break;
+                capabilityManager.setCapability(key, value);
         }
-    }
-
-    private void enumValidator(String name, Set values, String value) {
-        if (!values.contains(value)) {
-            String message = value + " is not a valid " + name + ", please choose from: " + values;
-            throw new InvalidSauceOptionsArgumentException(message);
-        }
-    }
-
-    private MutableCapabilities addAuthentication() {
-        MutableCapabilities caps = new MutableCapabilities();
-        caps.setCapability("username", getSauceUsername());
-        caps.setCapability("accessKey", getSauceAccessKey());
-        return caps;
     }
 
     protected String getSauceUsername() {
-        return tryToGetVariable("SAUCE_USERNAME", "Sauce Username was not provided");
-    }
-
-    private String tryToGetVariable(String key, String errorMessage) {
-        if (getSystemProperty(key) != null) {
-            return getSystemProperty(key);
-        } else if (getEnvironmentVariable(key) != null) {
-            return getEnvironmentVariable(key);
-        } else {
-            throw new SauceEnvironmentVariablesNotSetException(errorMessage);
-        }
+        return SystemManager.get("SAUCE_USERNAME", "Sauce Username was not provided");
     }
 
     protected String getSauceAccessKey() {
-        return tryToGetVariable("SAUCE_ACCESS_KEY", "Sauce Access Key was not provided");
+        return SystemManager.get("SAUCE_ACCESS_KEY", "Sauce Access Key was not provided");
     }
 
-    protected String getSystemProperty(String key) {
-        return System.getProperty(key);
-    }
-
-    protected String getEnvironmentVariable(String key) {
-        return System.getenv(key);
+    /**
+     * @deprecated Use getCapabilities() instead
+     * @return
+     */
+    @Deprecated
+    public MutableCapabilities getSeleniumCapabilities() {
+        return capabilities;
     }
 }

--- a/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
@@ -1,0 +1,37 @@
+package com.saucelabs.saucebindings;
+
+public class SystemManager {
+
+    /**
+     * Shortcut for getting the System Property or the Environment Variable
+     * If the no value is found, an exception is thrown with the provided message
+     *
+     * @param key           the name of the property or environment variable
+     * @param errorMessage  the error message if the property or environment variable is not found
+     * @return              the value of the provided field name
+     */
+    public static String get(String key, String errorMessage) {
+        String value = get(key);
+        if (value == null) {
+            throw new SauceEnvironmentVariablesNotSetException(errorMessage);
+        } else {
+            return value;
+        }
+    }
+
+    /**
+     * Shortcut for getting the System Property or the Environment Variable
+     *
+     * @param key           the name of the property or environment variable
+     * @return              the value of the provided field name
+     */
+    public static String get(String key) {
+        if (System.getProperty(key) != null) {
+            return System.getProperty(key);
+        } else if (System.getenv(key) != null) {
+            return System.getenv(key);
+        } else {
+            return null;
+        }
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
@@ -23,12 +23,11 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
+import static org.junit.Assert.assertNotNull;
 import static org.openqa.selenium.UnexpectedAlertBehaviour.DISMISS;
 
 public class SauceOptionsTest {
-    private SauceOptions sauceOptions = spy(new SauceOptions());
+    private SauceOptions sauceOptions = new SauceOptions();
 
     @Rule
     public MockitoRule initRule = MockitoJUnit.rule();
@@ -223,11 +222,7 @@ public class SauceOptionsTest {
 
     @Test
     public void createsDefaultBuildName() {
-        doReturn("Not Empty").when(sauceOptions).getEnvironmentVariable("BUILD_TAG");
-        doReturn("TEMP BUILD").when(sauceOptions).getEnvironmentVariable("BUILD_NAME");
-        doReturn("11").when(sauceOptions).getEnvironmentVariable("BUILD_NUMBER");
-
-        assertEquals("TEMP BUILD: 11", sauceOptions.getBuild());
+        assertNotNull(sauceOptions.getBuild());
     }
 
     @SneakyThrows
@@ -348,9 +343,6 @@ public class SauceOptionsTest {
 
     @Test
     public void parsesCapabilitiesFromW3CValues() {
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-
         sauceOptions.setBrowserName(Browser.FIREFOX);
         sauceOptions.setPlatformName(SaucePlatform.MAC_HIGH_SIERRA);
         sauceOptions.setBrowserVersion("77");
@@ -382,8 +374,8 @@ public class SauceOptionsTest {
 
         MutableCapabilities sauceCapabilities = new MutableCapabilities();
         sauceCapabilities.setCapability("build", "Build Name");
-        sauceCapabilities.setCapability("username", "test-name");
-        sauceCapabilities.setCapability("accessKey", "test-accesskey");
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
         MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
 
@@ -392,9 +384,6 @@ public class SauceOptionsTest {
 
     @Test
     public void parsesCapabilitiesFromSauceValues() {
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-
         Map<String, Object> customData = new HashMap<>();
         customData.put("foo", "foo");
         customData.put("bar", "bar");
@@ -465,8 +454,8 @@ public class SauceOptionsTest {
         sauceCapabilities.setCapability("timeZone", "San Francisco");
         sauceCapabilities.setCapability("tunnelIdentifier", "tunnelname");
         sauceCapabilities.setCapability("videoUploadOnPass", false);
-        sauceCapabilities.setCapability("username", "test-name");
-        sauceCapabilities.setCapability("accessKey", "test-accesskey");
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
         expectedCapabilities.setCapability("browserName", "chrome");
@@ -487,10 +476,7 @@ public class SauceOptionsTest {
         firefoxOptions.addPreference("foo", "bar");
         firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
 
-        sauceOptions = spy(new SauceOptions(firefoxOptions));
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-
+        sauceOptions = new SauceOptions(firefoxOptions);
         sauceOptions.setBuild("Build Name");
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
@@ -501,8 +487,8 @@ public class SauceOptionsTest {
 
         MutableCapabilities sauceCapabilities = new MutableCapabilities();
         sauceCapabilities.setCapability("build", "Build Name");
-        sauceCapabilities.setCapability("username", "test-name");
-        sauceCapabilities.setCapability("accessKey", "test-accesskey");
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
         MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
 
@@ -518,10 +504,7 @@ public class SauceOptionsTest {
         firefoxOptions.addArguments("--foo");
         firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
 
-        sauceOptions = spy(new SauceOptions(firefoxOptions));
-
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        sauceOptions = new SauceOptions(firefoxOptions);
 
         expectedCapabilities.merge(firefoxOptions);
         expectedCapabilities.setCapability("browserVersion", "latest");
@@ -555,8 +538,8 @@ public class SauceOptionsTest {
 
         sauceOptions.setJobVisibility(JobVisibility.SHARE);
         sauceCapabilities.setCapability("public", JobVisibility.SHARE);
-        sauceCapabilities.setCapability("username", "test-name");
-        sauceCapabilities.setCapability("accessKey", "test-accesskey");
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
 
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
         MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
@@ -71,18 +71,6 @@ public class SauceSessionTest {
         assertEquals(expetedSauceUrl, sauceSession.getSauceUrl().toString());
     }
 
-    @Test(expected = SauceEnvironmentVariablesNotSetException.class)
-    public void startThrowsErrorWithoutUsername() {
-        doReturn(null).when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        sauceOptsSession.start();
-    }
-
-    @Test(expected = SauceEnvironmentVariablesNotSetException.class)
-    public void startThrowsErrorWithoutAccessKey() {
-        doReturn(null).when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-        sauceOptsSession.start();
-    }
-
     @Test
     public void stopCallsDriverQuitPassing() {
         sauceSession.start();


### PR DESCRIPTION
I'm going to step through the ideas I discussed today in smaller incremental commits.

@mmerrell if you have time, can you tell me if this is the right way in Java to pull out methods from a class?
I'm creating/storing an instance of CapabilitiesManager in SauceOptions, and then using EnvironmentManager with static methods.

This is ready to merge if everyone is good with it.