### PR TITLE
[java] move sauce specific options into their own class

### DIFF
--- a/java/src/main/java/com/saucelabs/saucebindings/CapabilityManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/CapabilityManager.java
@@ -1,0 +1,45 @@
+package com.saucelabs.saucebindings;
+
+import org.openqa.selenium.MutableCapabilities;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Set;
+
+public class CapabilityManager {
+    private final SauceOptions options;
+
+    public CapabilityManager(SauceOptions options) {
+        this.options = options;
+    }
+
+    public MutableCapabilities addCapabilities(MutableCapabilities capabilities, List<String> validOptions) {
+        validOptions.forEach((capability) -> {
+            Object value = getCapability(capability);
+            if (value != null) {
+                capabilities.setCapability(capability, value);
+            }
+        });
+        return capabilities;
+    }
+
+    public Object getCapability(String capability) {
+        try {
+            String getter = "get" + capability.substring(0, 1).toUpperCase() + capability.substring(1);
+            Method declaredMethod = null;
+            declaredMethod = options.getClass().getDeclaredMethod(getter);
+            return declaredMethod.invoke(options);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    protected void capabilityValidator(String name, Set values, String value) {
+        if (!values.contains(value)) {
+            String message = value + " is not a valid " + name + ", please choose from: " + values;
+            throw new InvalidSauceOptionsArgumentException(message);
+        }
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/CapabilityManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/CapabilityManager.java
@@ -1,27 +1,23 @@
 package com.saucelabs.saucebindings;
 
-import org.openqa.selenium.MutableCapabilities;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.List;
 import java.util.Set;
 
 public class CapabilityManager {
-    private final SauceOptions options;
+    private final Options options;
 
-    public CapabilityManager(SauceOptions options) {
+    public CapabilityManager(Options options) {
         this.options = options;
     }
 
-    public MutableCapabilities addCapabilities(MutableCapabilities capabilities, List<String> validOptions) {
-        validOptions.forEach((capability) -> {
+    public void addCapabilities() {
+        options.getValidOptions().forEach((capability) -> {
             Object value = getCapability(capability);
             if (value != null) {
-                capabilities.setCapability(capability, value);
+                options.capabilities.setCapability(capability, value);
             }
         });
-        return capabilities;
     }
 
     public Object getCapability(String capability) {

--- a/java/src/main/java/com/saucelabs/saucebindings/InvalidSauceOptionsArgumentException.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/InvalidSauceOptionsArgumentException.java
@@ -1,6 +1,6 @@
 package com.saucelabs.saucebindings;
 
-class InvalidSauceOptionsArgumentException extends RuntimeException {
+public class InvalidSauceOptionsArgumentException extends RuntimeException {
     public InvalidSauceOptionsArgumentException(String message) {
         super(message);
     }

--- a/java/src/main/java/com/saucelabs/saucebindings/Options.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/Options.java
@@ -1,0 +1,37 @@
+package com.saucelabs.saucebindings;
+
+import lombok.Getter;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+public abstract class Options {
+    @Getter protected MutableCapabilities capabilities = new MutableCapabilities();
+    protected CapabilityManager capabilityManager;
+    protected SystemManager systemManager;
+    @Getter public final List<String> validOptions = null;
+
+    // Use Case is pulling serialized information from JSON/YAML, converting it to a HashMap and passing it in
+    // This is a preferred pattern as it avoids conditionals in code
+    public void mergeCapabilities(Map<String, Object> mergingCapabilities) {
+        mergingCapabilities.forEach(this::setCapability);
+    }
+
+    // This dynamically calls setter
+    // Applicable enums must be dealt with in subclass method
+    protected void setCapability(String key, Object value) {
+        try {
+            Class<?> type = this.getClass().getDeclaredField(key).getType();
+            String setter = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
+            Method method = this.getClass().getDeclaredMethod(setter, type);
+            method.invoke(this, value);
+        } catch (NoSuchFieldException e) {
+            throw new InvalidSauceOptionsArgumentException(key + "is not a valid configuration value");
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    };
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceLabsOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceLabsOptions.java
@@ -1,0 +1,157 @@
+package com.saucelabs.saucebindings;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Accessors(chain = true) @Setter @Getter
+public class SauceLabsOptions extends Options {
+    // https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+    private Boolean avoidProxy = null;
+    private String build;
+    private Boolean capturePerformance = null;
+    private String chromedriverVersion;
+    private Integer commandTimeout = null;
+    private Map<String, Object> customData = null;
+    private Boolean extendedDebugging = null;
+    private Integer idleTimeout = null;
+    private String iedriverVersion;
+    private Integer maxDuration = null;
+    private String name;
+    private String parentTunnel;
+    private Map<Prerun, Object> prerun;
+    private URL prerunUrl;
+    private Integer priority = null;
+    private JobVisibility jobVisibility; // the actual key for this is a Java reserved keyword "public"; uses enum
+    private Boolean recordLogs = null;
+    private Boolean recordScreenshots = null;
+    private Boolean recordVideo = null;
+    private String screenResolution;
+    private String seleniumVersion;
+    private List<String> tags = null;
+    private String timeZone;
+    private String tunnelIdentifier;
+    private Boolean videoUploadOnPass = null;
+
+
+    public final List<String> validOptions = Arrays.asList(
+            "avoidProxy",
+            "build",
+            "capturePerformance",
+            "chromedriverVersion",
+            "commandTimeout",
+            "customData",
+            "extendedDebugging",
+            "idleTimeout",
+            "iedriverVersion",
+            "jobVisibility",
+            "maxDuration",
+            "name",
+            "parentTunnel",
+            "prerun",
+            "prerunUrl",
+            "priority",
+            // public, do not use, reserved keyword, using jobVisibility with enum
+            "recordLogs",
+            "recordScreenshots",
+            "recordVideo",
+            "screenResolution",
+            "seleniumVersion",
+            "tags",
+            "timeZone",
+            "tunnelIdentifier",
+            "videoUploadOnPass");
+
+    public SauceLabsOptions() {
+        capabilityManager = new CapabilityManager(this);
+    }
+
+    public MutableCapabilities toCapabilities() {
+        capabilities.setCapability("username", getSauceUsername());
+        capabilities.setCapability("accessKey", getSauceAccessKey());
+
+        Object visibilityValue = capabilityManager.getCapability("jobVisibility");
+        if (visibilityValue != null) {
+            capabilities.setCapability("public", visibilityValue);
+            setJobVisibility(null);
+        }
+
+        Object prerunValue = capabilityManager.getCapability("prerunUrl");
+        if (prerunValue != null) {
+            capabilities.setCapability("prerun", prerunValue);
+            setPrerunUrl(null);
+        }
+
+        capabilityManager.addCapabilities();
+        return capabilities;
+    }
+
+    @Override
+    protected void setCapability(String key, Object value) {
+        if ("jobVisibility".equals(key)) {
+            capabilityManager.capabilityValidator("JobVisibility", JobVisibility.keys(), (String) value);
+            setJobVisibility(JobVisibility.valueOf(JobVisibility.fromString((String) value)));
+        } else if ("prerun".equals(key)) {
+            Map<Prerun, Object> prerunMap = new HashMap<>();
+            ((Map) value).forEach((oldKey, val) -> {
+                capabilityManager.capabilityValidator("Prerun", Prerun.keys(), (String) oldKey);
+                String keyString = Prerun.fromString((String) oldKey);
+                prerunMap.put(Prerun.valueOf(keyString), val);
+            });
+            setPrerun(prerunMap);
+        } else {
+            super.setCapability(key, value);
+        }
+    }
+
+    public String getBuild() {
+        if (build != null) {
+            return build;
+        } else if (SystemManager.getEnv(knownCITools.get("Jenkins")) != null) {
+            return SystemManager.getEnv("BUILD_NAME") + ": " + SystemManager.getEnv("BUILD_NUMBER");
+        } else if (SystemManager.getEnv(knownCITools.get("Bamboo")) != null) {
+            return SystemManager.getEnv("bamboo_shortJobName") + ": " + SystemManager.getEnv("bamboo_buildNumber");
+        } else if (SystemManager.getEnv(knownCITools.get("Travis")) != null) {
+            return SystemManager.getEnv("TRAVIS_JOB_NAME") + ": " + SystemManager.getEnv("TRAVIS_JOB_NUMBER");
+        } else if (SystemManager.getEnv(knownCITools.get("Circle")) != null) {
+            return SystemManager.getEnv("CIRCLE_JOB") + ": " + SystemManager.getEnv("CIRCLE_BUILD_NUM");
+        } else if (SystemManager.getEnv(knownCITools.get("GitLab")) != null) {
+            return SystemManager.getEnv("CI_JOB_NAME") + ": " + SystemManager.getEnv("CI_JOB_ID");
+        } else if (SystemManager.getEnv(knownCITools.get("TeamCity")) != null) {
+            return SystemManager.getEnv("TEAMCITY_PROJECT_NAME") + ": " + SystemManager.getEnv("BUILD_NUMBER");
+        } else {
+            return "Build Time: " + System.currentTimeMillis();
+        }
+    }
+
+    public boolean isKnownCI() {
+        return !knownCITools.keySet().stream().allMatch((key) -> SystemManager.getEnv(key) == null);
+    }
+
+    public static final Map<String, String> knownCITools;
+
+    static {
+        knownCITools = new HashMap<>();
+        knownCITools.put("Jenkins", "BUILD_TAG");
+        knownCITools.put("Bamboo", "bamboo_agentId");
+        knownCITools.put("Travis", "TRAVIS_JOB_ID");
+        knownCITools.put("Circle", "CIRCLE_JOB");
+        knownCITools.put("GitLab", "CI");
+        knownCITools.put("TeamCity", "TEAMCITY_PROJECT_NAME");
+    }
+
+    protected String getSauceUsername() {
+        return SystemManager.get("SAUCE_USERNAME", "Sauce Username was not provided");
+    }
+
+    protected String getSauceAccessKey() {
+        return SystemManager.get("SAUCE_ACCESS_KEY", "Sauce Access Key was not provided");
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -19,12 +19,12 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @Accessors(chain = true)
 @Setter @Getter
 public class SauceOptions {
-    @Setter(AccessLevel.NONE) private MutableCapabilities seleniumCapabilities;
+    @Setter(AccessLevel.NONE) private MutableCapabilities capabilities;
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) private CapabilityManager capabilityManager;
     public TimeoutStore timeout = new TimeoutStore();
 
     // w3c Settings
@@ -65,20 +65,6 @@ public class SauceOptions {
     private String timeZone;
     private String tunnelIdentifier;
     private Boolean videoUploadOnPass = null;
-
-    public static final List<String> primaryEnum = Arrays.asList(
-            "browserName",
-            "jobVisibility",
-            "pageLoadStrategy",
-            "platformName",
-            "timeouts",
-            "unhandledPromptBehavior"
-    );
-
-    public static final List<String> secondaryEnum = Arrays.asList(
-            "prerun",
-            "timeouts"
-    );
 
     public static final List<String> w3cDefinedOptions = Arrays.asList(
             "browserName",
@@ -161,64 +147,58 @@ public class SauceOptions {
     }
 
     private SauceOptions(MutableCapabilities options) {
-        seleniumCapabilities = new MutableCapabilities(options.asMap());
+        capabilities = new MutableCapabilities(options.asMap());
+        capabilityManager = new CapabilityManager(this);
         if (options.getCapability("browserName") != null) {
             setCapability("browserName", options.getCapability("browserName"));
         }
     }
 
     public MutableCapabilities toCapabilities() {
-        MutableCapabilities sauceCapabilities = addAuthentication();
+        capabilityManager.addCapabilities(capabilities, w3cDefinedOptions);
 
-        if (getCapability("jobVisibility") != null) {
-            sauceCapabilities.setCapability("public", getCapability("jobVisibility"));
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+        sauceCapabilities.setCapability("username", getSauceUsername());
+        sauceCapabilities.setCapability("accessKey", getSauceAccessKey());
+
+        capabilityManager.addCapabilities(sauceCapabilities, sauceDefinedOptions);
+
+        Object visibilityValue = capabilityManager.getCapability("jobVisibility");
+        if (visibilityValue != null) {
+            sauceCapabilities.setCapability("public", visibilityValue);
         }
 
-        if (getCapability("prerunUrl") != null) {
-            sauceCapabilities.setCapability("prerun", getCapability("prerunUrl"));
+        Object prerunValue = capabilityManager.getCapability("prerunUrl");
+        if (prerunValue != null) {
+            sauceCapabilities.setCapability("prerun", prerunValue);
         }
 
-        w3cDefinedOptions.forEach((capability) -> {
-            addCapabilityIfDefined(seleniumCapabilities, capability);
-        });
-
-        sauceDefinedOptions.forEach((capability) -> {
-            addCapabilityIfDefined(sauceCapabilities, capability);
-        });
-
-        seleniumCapabilities.setCapability("sauce:options", sauceCapabilities);
-        return seleniumCapabilities;
-    }
-
-    private void addCapabilityIfDefined(MutableCapabilities capabilities, String capability) {
-        Object value = getCapability(capability);
-        if (value != null) {
-            capabilities.setCapability(capability, value);
-        }
+        capabilities.setCapability("sauce:options", sauceCapabilities);
+        return capabilities;
     }
 
     public String getBuild() {
         if (build != null) {
             return build;
-        } else if (getEnvironmentVariable(knownCITools.get("Jenkins")) != null) {
-            return getEnvironmentVariable("BUILD_NAME") + ": " + getEnvironmentVariable("BUILD_NUMBER");
-        } else if (getEnvironmentVariable(knownCITools.get("Bamboo")) != null) {
-            return getEnvironmentVariable("bamboo_shortJobName") + ": " + getEnvironmentVariable("bamboo_buildNumber");
-        } else if (getEnvironmentVariable(knownCITools.get("Travis")) != null) {
-            return getEnvironmentVariable("TRAVIS_JOB_NAME") + ": " + getEnvironmentVariable("TRAVIS_JOB_NUMBER");
-        } else if (getEnvironmentVariable(knownCITools.get("Circle")) != null) {
-            return getEnvironmentVariable("CIRCLE_JOB") + ": " + getEnvironmentVariable("CIRCLE_BUILD_NUM");
-        } else if (getEnvironmentVariable(knownCITools.get("GitLab")) != null) {
-            return getEnvironmentVariable("CI_JOB_NAME") + ": " + getEnvironmentVariable("CI_JOB_ID");
-        } else if (getEnvironmentVariable(knownCITools.get("TeamCity")) != null) {
-            return getEnvironmentVariable("TEAMCITY_PROJECT_NAME") + ": " + getEnvironmentVariable("BUILD_NUMBER");
+        } else if (SystemManager.get(knownCITools.get("Jenkins")) != null) {
+            return SystemManager.get("BUILD_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
+        } else if (SystemManager.get(knownCITools.get("Bamboo")) != null) {
+            return SystemManager.get("bamboo_shortJobName") + ": " + SystemManager.get("bamboo_buildNumber");
+        } else if (SystemManager.get(knownCITools.get("Travis")) != null) {
+            return SystemManager.get("TRAVIS_JOB_NAME") + ": " + SystemManager.get("TRAVIS_JOB_NUMBER");
+        } else if (SystemManager.get(knownCITools.get("Circle")) != null) {
+            return SystemManager.get("CIRCLE_JOB") + ": " + SystemManager.get("CIRCLE_BUILD_NUM");
+        } else if (SystemManager.get(knownCITools.get("GitLab")) != null) {
+            return SystemManager.get("CI_JOB_NAME") + ": " + SystemManager.get("CI_JOB_ID");
+        } else if (SystemManager.get(knownCITools.get("TeamCity")) != null) {
+            return SystemManager.get("TEAMCITY_PROJECT_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
         } else {
             return "Build Time: " + System.currentTimeMillis();
         }
     }
 
     public boolean isKnownCI() {
-        return !knownCITools.keySet().stream().allMatch((key) -> getEnvironmentVariable(key) == null);
+        return !knownCITools.keySet().stream().allMatch((key) -> SystemManager.get(key) == null);
     }
 
     // Use Case is pulling serialized information from JSON/YAML, converting it to a HashMap and passing it in
@@ -227,24 +207,38 @@ public class SauceOptions {
         capabilities.forEach(this::setCapability);
     }
 
-    // This might be made public in future version; For now, no good reason to prefer it over direct accessor
-    private Object getCapability(String capability) {
-        try {
-            String getter = "get" + capability.substring(0, 1).toUpperCase() + capability.substring(1);
-            Method declaredMethod = null;
-            declaredMethod = SauceOptions.class.getDeclaredMethod(getter);
-            return declaredMethod.invoke(this);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
     public void setCapability(String key, Object value) {
-        if (primaryEnum.contains(key) && value.getClass().equals(String.class)) {
-            setEnumCapability(key, (String) value);
-        } else if (secondaryEnum.contains(key) && isKeyString((HashMap) value)) {
-            setEnumCapability(key, (HashMap) value);
+        if ("browserName".equals(key)) {
+            capabilityManager.capabilityValidator("Browser", Browser.keys(), (String) value);
+            setBrowserName(Browser.valueOf(Browser.fromString((String) value)));
+        } else if ("platformName".equals(key)) {
+            capabilityManager.capabilityValidator("SaucePlatform", SaucePlatform.keys(), (String) value);
+            setPlatformName(SaucePlatform.valueOf(SaucePlatform.fromString((String) value)));
+        } else if ("pageLoadStrategy".equals(key)) {
+            capabilityManager.capabilityValidator("PageLoadStrategy", PageLoadStrategy.keys(), (String) value);
+            setPageLoadStrategy(PageLoadStrategy.valueOf(PageLoadStrategy.fromString((String) value)));
+        } else if ("unhandledPromptBehavior".equals(key)) {
+            capabilityManager.capabilityValidator("UnhandledPromptBehavior", UnhandledPromptBehavior.keys(), (String) value);
+            setUnhandledPromptBehavior(UnhandledPromptBehavior.valueOf(UnhandledPromptBehavior.fromString((String) value)));
+        } else if ("timeouts".equals(key)) {
+            Map<Timeouts, Integer> timeoutsMap = new HashMap<>();
+            ((Map) value).forEach((oldKey, val) -> {
+                capabilityManager.capabilityValidator("Timeouts", Timeouts.keys(), (String) oldKey);
+                String keyString = Timeouts.fromString((String) oldKey);
+                timeoutsMap.put(Timeouts.valueOf(keyString), (Integer) val);
+            });
+            setTimeouts(timeoutsMap);
+        } else if ("jobVisibility".equals(key)) {
+            capabilityManager.capabilityValidator("JobVisibility", JobVisibility.keys(), (String) value);
+            setJobVisibility(JobVisibility.valueOf(JobVisibility.fromString((String) value)));
+        } else if ("prerun".equals(key)) {
+            Map<Prerun, Object> prerunMap = new HashMap<>();
+            ((Map) value).forEach((oldKey, val) -> {
+                capabilityManager.capabilityValidator("Prerun", Prerun.keys(), (String) oldKey);
+                String keyString = Prerun.fromString((String) oldKey);
+                prerunMap.put(Prerun.valueOf(keyString), val);
+            });
+            setPrerun(prerunMap);
         } else {
             try {
                 Class<?> type = SauceOptions.class.getDeclaredField(key).getType();
@@ -257,96 +251,20 @@ public class SauceOptions {
         }
     }
 
-    private boolean isKeyString(HashMap map) {
-        return map.keySet().toArray()[0].getClass().equals(String.class);
-    }
-
-    // this method is only used when setting capabilities from mergeCapabilities method
-    private void setEnumCapability(String key, HashMap value) {
-        if ("prerun".equals(key)) {
-            Map<Prerun, Object> prerunMap = new HashMap<>();
-            value.forEach((oldKey, val) -> {
-                enumValidator("Prerun", Prerun.keys(), (String) oldKey);
-                String keyString = Prerun.fromString((String) oldKey);
-                prerunMap.put(Prerun.valueOf(keyString), val);
-            });
-            setPrerun(prerunMap);
-        } else if ("timeouts".equals(key)) {
-            Map<Timeouts, Integer> timeoutsMap = new HashMap<>();
-            value.forEach((oldKey, val) -> {
-                enumValidator("Timeouts", Timeouts.keys(), (String) oldKey);
-                String keyString = Timeouts.fromString((String) oldKey);
-                timeoutsMap.put(Timeouts.valueOf(keyString), (Integer) val);
-            });
-            setTimeouts(timeoutsMap);
-        }
-    }
-
-    // this method is only used when setting capabilities from mergeCapabilities method
-    private void setEnumCapability(String key, String value) {
-        switch (key) {
-            case "browserName":
-                enumValidator("Browser", Browser.keys(), value);
-                setBrowserName(Browser.valueOf(Browser.fromString(value)));
-                break;
-            case "platformName":
-                enumValidator("SaucePlatform", SaucePlatform.keys(), value);
-                setPlatformName(SaucePlatform.valueOf(SaucePlatform.fromString(value)));
-                break;
-            case "jobVisibility":
-                enumValidator("JobVisibility", JobVisibility.keys(), value);
-                setJobVisibility(JobVisibility.valueOf(JobVisibility.fromString(value)));
-                break;
-            case "pageLoadStrategy":
-                enumValidator("PageLoadStrategy", PageLoadStrategy.keys(), value);
-                setPageLoadStrategy(PageLoadStrategy.valueOf(PageLoadStrategy.fromString(value)));
-                break;
-            case "unhandledPromptBehavior":
-                enumValidator("UnhandledPromptBehavior", UnhandledPromptBehavior.keys(), value);
-                setUnhandledPromptBehavior(UnhandledPromptBehavior.valueOf(UnhandledPromptBehavior.fromString(value)));
-                break;
-            default:
-                break;
-        }
-    }
-
-    private void enumValidator(String name, Set values, String value) {
-        if (!values.contains(value)) {
-            String message = value + " is not a valid " + name + ", please choose from: " + values;
-            throw new InvalidSauceOptionsArgumentException(message);
-        }
-    }
-
-    private MutableCapabilities addAuthentication() {
-        MutableCapabilities caps = new MutableCapabilities();
-        caps.setCapability("username", getSauceUsername());
-        caps.setCapability("accessKey", getSauceAccessKey());
-        return caps;
-    }
-
     protected String getSauceUsername() {
-        return tryToGetVariable("SAUCE_USERNAME", "Sauce Username was not provided");
-    }
-
-    private String tryToGetVariable(String key, String errorMessage) {
-        if (getSystemProperty(key) != null) {
-            return getSystemProperty(key);
-        } else if (getEnvironmentVariable(key) != null) {
-            return getEnvironmentVariable(key);
-        } else {
-            throw new SauceEnvironmentVariablesNotSetException(errorMessage);
-        }
+        return SystemManager.get("SAUCE_USERNAME", "Sauce Username was not provided");
     }
 
     protected String getSauceAccessKey() {
-        return tryToGetVariable("SAUCE_ACCESS_KEY", "Sauce Access Key was not provided");
+        return SystemManager.get("SAUCE_ACCESS_KEY", "Sauce Access Key was not provided");
     }
 
-    protected String getSystemProperty(String key) {
-        return System.getProperty(key);
-    }
-
-    protected String getEnvironmentVariable(String key) {
-        return System.getenv(key);
+    /**
+     * @deprecated Use getCapabilities() instead
+     * @return
+     */
+    @Deprecated
+    public MutableCapabilities getSeleniumCapabilities() {
+        return capabilities;
     }
 }

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -61,7 +61,7 @@ public class SauceSession {
         // The first print statement will automatically populate links on Jenkins to Sauce
         // The second print statement will output the job link to logging/console
         if (this.driver != null) {
-            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", this.driver.getSessionId(), this.sauceOptions.getName());
+            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", this.driver.getSessionId(), this.sauceOptions.sauce().getName());
             String sauceTestLink = String.format("Test Job Link: https://app.saucelabs.com/tests/%s", this.driver.getSessionId());
             System.out.print(sauceReporter + "\n" + sauceTestLink + "\n");
         }

--- a/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
@@ -1,0 +1,29 @@
+package com.saucelabs.saucebindings;
+
+public class SystemManager {
+    protected static String get(String key, String errorMessage) {
+        try {
+            return get(key);
+        } catch (Exception e) {
+            throw new SauceEnvironmentVariablesNotSetException(errorMessage);
+        }
+    }
+
+    public static String get(String key) {
+        if (getProperty(key) != null) {
+            return getProperty(key);
+        } else if (getEnv(key) != null) {
+            return getEnv(key);
+        } else {
+            return getProperty(key);
+        }
+    }
+
+    protected static String getProperty(String key) {
+        return System.getProperty(key);
+    }
+
+    protected static String getEnv(String key) {
+        return System.getenv(key);
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
@@ -1,7 +1,7 @@
 package com.saucelabs.saucebindings;
 
 public class SystemManager {
-    protected static String get(String key, String errorMessage) {
+    public static String get(String key, String errorMessage) {
         try {
             return get(key);
         } catch (Exception e) {
@@ -23,7 +23,7 @@ public class SystemManager {
         return System.getProperty(key);
     }
 
-    protected static String getEnv(String key) {
+    public static String getEnv(String key) {
         return System.getenv(key);
     }
 }

--- a/java/src/main/java/com/saucelabs/saucebindings/examples/BasicOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/examples/BasicOptions.java
@@ -1,6 +1,9 @@
 package com.saucelabs.saucebindings.examples;
 
 import com.saucelabs.saucebindings.*;
+import com.saucelabs.saucebindings.SauceOptions;
+import com.saucelabs.saucebindings.Browser;
+import com.saucelabs.saucebindings.SaucePlatform;
 import org.junit.Test;
 import org.openqa.selenium.remote.RemoteWebDriver;
 

--- a/java/src/main/java/com/saucelabs/saucebindings/examples/BrowserOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/examples/BrowserOptions.java
@@ -1,6 +1,7 @@
 package com.saucelabs.saucebindings.examples;
 
 import com.saucelabs.saucebindings.*;
+import com.saucelabs.saucebindings.SauceOptions;
 import org.junit.Test;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;

--- a/java/src/main/java/com/saucelabs/saucebindings/examples/SauceSpecificOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/examples/SauceSpecificOptions.java
@@ -1,6 +1,7 @@
 package com.saucelabs.saucebindings.examples;
 
 import com.saucelabs.saucebindings.*;
+import com.saucelabs.saucebindings.SauceOptions;
 import org.junit.Test;
 import org.openqa.selenium.remote.RemoteWebDriver;
 

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsDeprecatedTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsDeprecatedTest.java
@@ -1,0 +1,326 @@
+package com.saucelabs.saucebindings;
+
+import lombok.SneakyThrows;
+import org.junit.Test;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.openqa.selenium.UnexpectedAlertBehaviour.DISMISS;
+
+public class SauceOptionsDeprecatedTest {
+    private SauceOptions sauceOptions = new SauceOptions();
+
+    @Test
+    public void acceptsSauceLabsSettings() {
+        Map<String, Object> customData = new HashMap<>();
+        customData.put("foo", "foo");
+        customData.put("bar", "bar");
+
+        List<String> args = new ArrayList<>();
+        args.add("--silent");
+        args.add("-a");
+        args.add("-q");
+
+        Map<Prerun, Object> prerun = new HashMap<>();
+        prerun.put(Prerun.EXECUTABLE, "http://url.to/your/executable.exe");
+        prerun.put(Prerun.ARGS, args);
+        prerun.put(Prerun.BACKGROUND, false);
+        prerun.put(Prerun.TIMEOUT, 120);
+
+        List<String> tags = new ArrayList<>();
+        tags.add("Foo");
+        tags.add("Bar");
+        tags.add("Foobar");
+
+        sauceOptions.setAvoidProxy(true);
+        sauceOptions.setBuild("Sample Build Name");
+        sauceOptions.setCapturePerformance(true);
+        sauceOptions.setChromedriverVersion("71");
+        sauceOptions.setCommandTimeout(2);
+        sauceOptions.setCustomData(customData);
+        sauceOptions.setExtendedDebugging(true);
+        sauceOptions.setIdleTimeout(3);
+        sauceOptions.setIedriverVersion("3.141.0");
+        sauceOptions.setMaxDuration(300);
+        sauceOptions.setName("Test name");
+        sauceOptions.setParentTunnel("Mommy");
+        sauceOptions.setPrerun(prerun);
+        sauceOptions.setPriority(0);
+        sauceOptions.setJobVisibility(JobVisibility.TEAM);
+        sauceOptions.setRecordLogs(false);
+        sauceOptions.setRecordScreenshots(false);
+        sauceOptions.setRecordVideo(false);
+        sauceOptions.setScreenResolution("10x10");
+        sauceOptions.setSeleniumVersion("3.141.59");
+        sauceOptions.setTags(tags);
+        sauceOptions.setTimeZone("San Francisco");
+        sauceOptions.setTunnelIdentifier("tunnelname");
+        sauceOptions.setVideoUploadOnPass(false);
+
+        assertEquals(true, sauceOptions.getAvoidProxy());
+        assertEquals("Sample Build Name", sauceOptions.getBuild());
+        assertEquals(true, sauceOptions.getCapturePerformance());
+        assertEquals("71", sauceOptions.getChromedriverVersion());
+        assertEquals(Integer.valueOf(2), sauceOptions.getCommandTimeout());
+        assertEquals(customData, sauceOptions.getCustomData());
+        assertEquals(true, sauceOptions.getExtendedDebugging());
+        assertEquals(Integer.valueOf(3), sauceOptions.getIdleTimeout());
+        assertEquals("3.141.0", sauceOptions.getIedriverVersion());
+        assertEquals(Integer.valueOf(300), sauceOptions.getMaxDuration());
+        assertEquals("Test name", sauceOptions.getName());
+        assertEquals("Mommy", sauceOptions.getParentTunnel());
+        assertEquals(prerun, sauceOptions.getPrerun());
+        assertEquals(Integer.valueOf(0), sauceOptions.getPriority());
+        assertEquals(JobVisibility.TEAM, sauceOptions.getJobVisibility());
+        assertEquals(false, sauceOptions.getRecordLogs());
+        assertEquals(false, sauceOptions.getRecordScreenshots());
+        assertEquals(false, sauceOptions.getRecordVideo());
+        assertEquals("10x10", sauceOptions.getScreenResolution());
+        assertEquals("3.141.59", sauceOptions.getSeleniumVersion());
+        assertEquals(tags, sauceOptions.getTags());
+        assertEquals("San Francisco", sauceOptions.getTimeZone());
+        assertEquals("tunnelname", sauceOptions.getTunnelIdentifier());
+        assertEquals(false, sauceOptions.getVideoUploadOnPass());
+    }
+
+    @Test
+    public void createsDefaultBuildName() {
+        assertNotNull(sauceOptions.getBuild());
+    }
+
+    @SneakyThrows
+    public Map<String, Object> serialize(String key) {
+        InputStream input = new FileInputStream(new File("src/test/java/com/saucelabs/saucebindings/deprecated_options.yml"));
+        Yaml yaml = new Yaml();
+        Map<String, Object> data = yaml.load(input);
+        return (Map<String, Object>) data.get(key);
+    }
+
+    @Test
+    public void setsCapabilitiesFromMap() {
+        Map<String, Object> map = serialize("exampleValues");
+
+        sauceOptions.mergeCapabilities(map);
+
+        Map<String, Object> customData = new HashMap<>();
+        customData.put("foo", "foo");
+        customData.put("bar", "bar");
+
+        List<String> args = new ArrayList<>();
+        args.add("--silent");
+        args.add("-a");
+        args.add("-q");
+
+        Map<Prerun, Object> prerun = new HashMap<>();
+        prerun.put(Prerun.EXECUTABLE, "http://url.to/your/executable.exe");
+        prerun.put(Prerun.ARGS, args);
+        prerun.put(Prerun.BACKGROUND, false);
+        prerun.put(Prerun.TIMEOUT, 120);
+
+        List<String> tags = new ArrayList<>();
+        tags.add("foo");
+        tags.add("bar");
+        tags.add("foobar");
+
+        Map<Timeouts, Integer> timeouts = new HashMap<>();
+        timeouts.put(Timeouts.IMPLICIT, 1);
+        timeouts.put(Timeouts.PAGE_LOAD, 59);
+        timeouts.put(Timeouts.SCRIPT, 29);
+
+        assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals("68", sauceOptions.getBrowserVersion());
+        assertEquals(SaucePlatform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
+        assertEquals(true, sauceOptions.getAcceptInsecureCerts());
+        assertEquals(PageLoadStrategy.EAGER, sauceOptions.getPageLoadStrategy());
+        assertEquals(true, sauceOptions.getSetWindowRect());
+        assertEquals(UnhandledPromptBehavior.ACCEPT, sauceOptions.getUnhandledPromptBehavior());
+        assertEquals(true, sauceOptions.getStrictFileInteractability());
+        assertEquals(timeouts, sauceOptions.getTimeouts());
+        assertEquals(true, sauceOptions.getAvoidProxy());
+        assertEquals("Sample Build Name", sauceOptions.getBuild());
+        assertEquals(true, sauceOptions.getCapturePerformance());
+        assertEquals("71", sauceOptions.getChromedriverVersion());
+        assertEquals(Integer.valueOf(2), sauceOptions.getCommandTimeout());
+        assertEquals(customData, sauceOptions.getCustomData());
+        assertEquals(true, sauceOptions.getExtendedDebugging());
+        assertEquals(Integer.valueOf(3), sauceOptions.getIdleTimeout());
+        assertEquals("3.141.0", sauceOptions.getIedriverVersion());
+        assertEquals(Integer.valueOf(300), sauceOptions.getMaxDuration());
+        assertEquals("Sample Test Name", sauceOptions.getName());
+        assertEquals("Mommy", sauceOptions.getParentTunnel());
+        assertEquals(prerun, sauceOptions.getPrerun());
+        assertEquals(Integer.valueOf(0), sauceOptions.getPriority());
+        assertEquals(JobVisibility.TEAM, sauceOptions.getJobVisibility());
+        assertEquals(false, sauceOptions.getRecordLogs());
+        assertEquals(false, sauceOptions.getRecordScreenshots());
+        assertEquals(false, sauceOptions.getRecordVideo());
+        assertEquals("10x10", sauceOptions.getScreenResolution());
+        assertEquals("3.141.59", sauceOptions.getSeleniumVersion());
+        assertEquals(tags, sauceOptions.getTags());
+        assertEquals("San Francisco", sauceOptions.getTimeZone());
+        assertEquals("tunnelname", sauceOptions.getTunnelIdentifier());
+        assertEquals(false, sauceOptions.getVideoUploadOnPass());
+    }
+
+    @Test(expected = InvalidSauceOptionsArgumentException.class)
+    public void setsBadJobVisibilityFromMap() {
+        Map<String, Object> map = serialize("badJobVisibility");
+        sauceOptions.mergeCapabilities(map);
+    }
+
+    @Test(expected = InvalidSauceOptionsArgumentException.class)
+    public void setsBadPrerunFromMap() {
+        Map<String, Object> map = serialize("badPrerun");
+        sauceOptions.mergeCapabilities(map);
+    }
+
+    @Test
+    public void parsesCapabilitiesFromSauceValues() {
+        Map<String, Object> customData = new HashMap<>();
+        customData.put("foo", "foo");
+        customData.put("bar", "bar");
+
+        List<String> args = new ArrayList<>();
+        args.add("--silent");
+        args.add("-a");
+        args.add("-q");
+
+        Map<Prerun, Object> prerun = new HashMap<>();
+        prerun.put(Prerun.EXECUTABLE, "http://url.to/your/executable.exe");
+        prerun.put(Prerun.ARGS, args);
+        prerun.put(Prerun.BACKGROUND, false);
+        prerun.put(Prerun.TIMEOUT, 120);
+
+        List<String> tags = new ArrayList<>();
+        tags.add("Foo");
+        tags.add("Bar");
+        tags.add("Foobar");
+
+        sauceOptions.setAvoidProxy(true);
+        sauceOptions.setBuild("Sample Build Name");
+        sauceOptions.setCapturePerformance(true);
+        sauceOptions.setChromedriverVersion("71");
+        sauceOptions.setCommandTimeout(2);
+        sauceOptions.setCustomData(customData);
+        sauceOptions.setExtendedDebugging(true);
+        sauceOptions.setIdleTimeout(3);
+        sauceOptions.setIedriverVersion("3.141.0");
+        sauceOptions.setMaxDuration(300);
+        sauceOptions.setName("Test name");
+        sauceOptions.setParentTunnel("Mommy");
+        sauceOptions.setPrerun(prerun);
+        sauceOptions.setPriority(0);
+        sauceOptions.setJobVisibility(JobVisibility.TEAM);
+        sauceOptions.setRecordLogs(false);
+        sauceOptions.setRecordScreenshots(false);
+        sauceOptions.setRecordVideo(false);
+        sauceOptions.setScreenResolution("10x10");
+        sauceOptions.setSeleniumVersion("3.141.59");
+        sauceOptions.setTags(tags);
+        sauceOptions.setTimeZone("San Francisco");
+        sauceOptions.setTunnelIdentifier("tunnelname");
+        sauceOptions.setVideoUploadOnPass(false);
+
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+        sauceCapabilities.setCapability("avoidProxy", true);
+        sauceCapabilities.setCapability("build", "Sample Build Name");
+        sauceCapabilities.setCapability("capturePerformance", true);
+        sauceCapabilities.setCapability("chromedriverVersion", "71");
+        sauceCapabilities.setCapability("commandTimeout", 2);
+        sauceCapabilities.setCapability("customData", customData);
+        sauceCapabilities.setCapability("extendedDebugging", true);
+        sauceCapabilities.setCapability("idleTimeout", 3);
+        sauceCapabilities.setCapability("iedriverVersion", "3.141.0");
+        sauceCapabilities.setCapability("maxDuration", 300);
+        sauceCapabilities.setCapability("name", "Test name");
+        sauceCapabilities.setCapability("parentTunnel", "Mommy");
+        sauceCapabilities.setCapability("prerun", prerun);
+        sauceCapabilities.setCapability("priority", 0);
+        sauceCapabilities.setCapability("public", "team");
+        sauceCapabilities.setCapability("recordLogs", false);
+        sauceCapabilities.setCapability("recordScreenshots", false);
+        sauceCapabilities.setCapability("recordVideo", false);
+        sauceCapabilities.setCapability("screenResolution", "10x10");
+        sauceCapabilities.setCapability("seleniumVersion", "3.141.59");
+        sauceCapabilities.setCapability("tags", tags);
+        sauceCapabilities.setCapability("timeZone", "San Francisco");
+        sauceCapabilities.setCapability("tunnelIdentifier", "tunnelname");
+        sauceCapabilities.setCapability("videoUploadOnPass", false);
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
+
+        MutableCapabilities expectedCapabilities = new MutableCapabilities();
+        expectedCapabilities.setCapability("browserName", "chrome");
+        expectedCapabilities.setCapability("browserVersion", "latest");
+        expectedCapabilities.setCapability("platformName", "Windows 10");
+
+        expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
+        MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
+
+        // toString() serializes the enums
+        assertEquals(expectedCapabilities.asMap().toString(), actualCapabilities.asMap().toString());
+    }
+
+    @Test
+    public void parsesW3CAndSauceAndSeleniumSettings() {
+        MutableCapabilities expectedCapabilities = new MutableCapabilities();
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+
+        FirefoxOptions firefoxOptions = new FirefoxOptions();
+        firefoxOptions.addArguments("--foo");
+        firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
+
+        sauceOptions = new SauceOptions(firefoxOptions);
+
+        expectedCapabilities.merge(firefoxOptions);
+        expectedCapabilities.setCapability("browserVersion", "latest");
+        expectedCapabilities.setCapability("platformName", "Windows 10");
+        expectedCapabilities.setCapability("acceptInsecureCerts", true);
+
+        sauceOptions.setBuild("CUSTOM BUILD: 12");
+        sauceCapabilities.setCapability("build", "CUSTOM BUILD: 12");
+
+        sauceOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
+        expectedCapabilities.setCapability("pageLoadStrategy", PageLoadStrategy.EAGER);
+        sauceOptions.setAcceptInsecureCerts(true);
+        expectedCapabilities.setCapability("acceptInsecureCerts", true);
+        sauceOptions.timeout.setImplicitWait(1)
+                .setPageLoad(100)
+                .setScript(10);
+        Map<Timeouts, Integer> timeouts = new HashMap<>();
+        timeouts.put(Timeouts.IMPLICIT, 1);
+        timeouts.put(Timeouts.SCRIPT, 10);
+        timeouts.put(Timeouts.PAGE_LOAD, 100);
+        expectedCapabilities.setCapability("timeouts", timeouts);
+        sauceOptions.setUnhandledPromptBehavior(UnhandledPromptBehavior.IGNORE);
+        expectedCapabilities.setCapability("unhandledPromptBehavior", UnhandledPromptBehavior.IGNORE);
+
+        sauceOptions.setExtendedDebugging(true);
+        sauceCapabilities.setCapability("extendedDebugging", true);
+        sauceOptions.setName("Test name");
+        sauceCapabilities.setCapability("name", "Test name");
+        sauceOptions.setParentTunnel("Mommy");
+        sauceCapabilities.setCapability("parentTunnel", "Mommy");
+
+        sauceOptions.setJobVisibility(JobVisibility.SHARE);
+        sauceCapabilities.setCapability("public", JobVisibility.SHARE);
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
+
+        expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
+        MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
+
+        assertEquals(expectedCapabilities.asMap().toString(), actualCapabilities.asMap().toString());
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
@@ -23,12 +23,11 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
+import static org.junit.Assert.assertNotNull;
 import static org.openqa.selenium.UnexpectedAlertBehaviour.DISMISS;
 
 public class SauceOptionsTest {
-    private SauceOptions sauceOptions = spy(new SauceOptions());
+    private SauceOptions sauceOptions = new SauceOptions();
 
     @Rule
     public MockitoRule initRule = MockitoJUnit.rule();
@@ -223,11 +222,7 @@ public class SauceOptionsTest {
 
     @Test
     public void createsDefaultBuildName() {
-        doReturn("Not Empty").when(sauceOptions).getEnvironmentVariable("BUILD_TAG");
-        doReturn("TEMP BUILD").when(sauceOptions).getEnvironmentVariable("BUILD_NAME");
-        doReturn("11").when(sauceOptions).getEnvironmentVariable("BUILD_NUMBER");
-
-        assertEquals("TEMP BUILD: 11", sauceOptions.getBuild());
+        assertNotNull(sauceOptions.getBuild());
     }
 
     @SneakyThrows
@@ -348,9 +343,6 @@ public class SauceOptionsTest {
 
     @Test
     public void parsesCapabilitiesFromW3CValues() {
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-
         sauceOptions.setBrowserName(Browser.FIREFOX);
         sauceOptions.setPlatformName(SaucePlatform.MAC_HIGH_SIERRA);
         sauceOptions.setBrowserVersion("77");
@@ -382,8 +374,8 @@ public class SauceOptionsTest {
 
         MutableCapabilities sauceCapabilities = new MutableCapabilities();
         sauceCapabilities.setCapability("build", "Build Name");
-        sauceCapabilities.setCapability("username", "test-name");
-        sauceCapabilities.setCapability("accessKey", "test-accesskey");
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
         MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
 
@@ -392,9 +384,6 @@ public class SauceOptionsTest {
 
     @Test
     public void parsesCapabilitiesFromSauceValues() {
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-
         Map<String, Object> customData = new HashMap<>();
         customData.put("foo", "foo");
         customData.put("bar", "bar");
@@ -465,8 +454,8 @@ public class SauceOptionsTest {
         sauceCapabilities.setCapability("timeZone", "San Francisco");
         sauceCapabilities.setCapability("tunnelIdentifier", "tunnelname");
         sauceCapabilities.setCapability("videoUploadOnPass", false);
-        sauceCapabilities.setCapability("username", "test-name");
-        sauceCapabilities.setCapability("accessKey", "test-accesskey");
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
         expectedCapabilities.setCapability("browserName", "chrome");
@@ -487,10 +476,7 @@ public class SauceOptionsTest {
         firefoxOptions.addPreference("foo", "bar");
         firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
 
-        sauceOptions = spy(new SauceOptions(firefoxOptions));
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-
+        sauceOptions = new SauceOptions(firefoxOptions);
         sauceOptions.setBuild("Build Name");
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
@@ -501,8 +487,8 @@ public class SauceOptionsTest {
 
         MutableCapabilities sauceCapabilities = new MutableCapabilities();
         sauceCapabilities.setCapability("build", "Build Name");
-        sauceCapabilities.setCapability("username", "test-name");
-        sauceCapabilities.setCapability("accessKey", "test-accesskey");
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
         MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
 
@@ -518,10 +504,7 @@ public class SauceOptionsTest {
         firefoxOptions.addArguments("--foo");
         firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
 
-        sauceOptions = spy(new SauceOptions(firefoxOptions));
-
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        sauceOptions = new SauceOptions(firefoxOptions);
 
         expectedCapabilities.merge(firefoxOptions);
         expectedCapabilities.setCapability("browserVersion", "latest");
@@ -555,8 +538,8 @@ public class SauceOptionsTest {
 
         sauceOptions.setJobVisibility(JobVisibility.SHARE);
         sauceCapabilities.setCapability("public", JobVisibility.SHARE);
-        sauceCapabilities.setCapability("username", "test-name");
-        sauceCapabilities.setCapability("accessKey", "test-accesskey");
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
 
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
         MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
@@ -15,7 +15,6 @@ import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -108,55 +107,76 @@ public class SauceOptionsTest {
         tags.add("Bar");
         tags.add("Foobar");
 
-        sauceOptions.setAvoidProxy(true);
-        sauceOptions.setBuild("Sample Build Name");
-        sauceOptions.setCapturePerformance(true);
-        sauceOptions.setChromedriverVersion("71");
-        sauceOptions.setCommandTimeout(2);
-        sauceOptions.setCustomData(customData);
-        sauceOptions.setExtendedDebugging(true);
-        sauceOptions.setIdleTimeout(3);
-        sauceOptions.setIedriverVersion("3.141.0");
-        sauceOptions.setMaxDuration(300);
-        sauceOptions.setName("Test name");
-        sauceOptions.setParentTunnel("Mommy");
-        sauceOptions.setPrerun(prerun);
-        sauceOptions.setPriority(0);
-        sauceOptions.setJobVisibility(JobVisibility.TEAM);
-        sauceOptions.setRecordLogs(false);
-        sauceOptions.setRecordScreenshots(false);
-        sauceOptions.setRecordVideo(false);
-        sauceOptions.setScreenResolution("10x10");
-        sauceOptions.setSeleniumVersion("3.141.59");
-        sauceOptions.setTags(tags);
-        sauceOptions.setTimeZone("San Francisco");
-        sauceOptions.setTunnelIdentifier("tunnelname");
-        sauceOptions.setVideoUploadOnPass(false);
+        sauceOptions.sauce().setAvoidProxy(true);
+        sauceOptions.sauce().setBuild("Sample Build Name");
+        sauceOptions.sauce().setCapturePerformance(true);
+        sauceOptions.sauce().setChromedriverVersion("71");
+        sauceOptions.sauce().setCommandTimeout(2);
+        sauceOptions.sauce().setCustomData(customData);
+        sauceOptions.sauce().setExtendedDebugging(true);
+        sauceOptions.sauce().setIdleTimeout(3);
+        sauceOptions.sauce().setIedriverVersion("3.141.0");
+        sauceOptions.sauce().setMaxDuration(300);
+        sauceOptions.sauce().setName("Test name");
+        sauceOptions.sauce().setParentTunnel("Mommy");
+        sauceOptions.sauce().setPrerun(prerun);
+        sauceOptions.sauce().setPriority(0);
+        sauceOptions.sauce().setJobVisibility(JobVisibility.TEAM);
+        sauceOptions.sauce().setRecordLogs(false);
+        sauceOptions.sauce().setRecordScreenshots(false);
+        sauceOptions.sauce().setRecordVideo(false);
+        sauceOptions.sauce().setScreenResolution("10x10");
+        sauceOptions.sauce().setSeleniumVersion("3.141.59");
+        sauceOptions.sauce().setTags(tags);
+        sauceOptions.sauce().setTimeZone("San Francisco");
+        sauceOptions.sauce().setTunnelIdentifier("tunnelname");
+        sauceOptions.sauce().setVideoUploadOnPass(false);
 
-        assertEquals(true, sauceOptions.getAvoidProxy());
-        assertEquals("Sample Build Name", sauceOptions.getBuild());
-        assertEquals(true, sauceOptions.getCapturePerformance());
-        assertEquals("71", sauceOptions.getChromedriverVersion());
-        assertEquals(Integer.valueOf(2), sauceOptions.getCommandTimeout());
-        assertEquals(customData, sauceOptions.getCustomData());
-        assertEquals(true, sauceOptions.getExtendedDebugging());
-        assertEquals(Integer.valueOf(3), sauceOptions.getIdleTimeout());
-        assertEquals("3.141.0", sauceOptions.getIedriverVersion());
-        assertEquals(Integer.valueOf(300), sauceOptions.getMaxDuration());
-        assertEquals("Test name", sauceOptions.getName());
-        assertEquals("Mommy", sauceOptions.getParentTunnel());
-        assertEquals(prerun, sauceOptions.getPrerun());
-        assertEquals(Integer.valueOf(0), sauceOptions.getPriority());
-        assertEquals(JobVisibility.TEAM, sauceOptions.getJobVisibility());
-        assertEquals(false, sauceOptions.getRecordLogs());
-        assertEquals(false, sauceOptions.getRecordScreenshots());
-        assertEquals(false, sauceOptions.getRecordVideo());
-        assertEquals("10x10", sauceOptions.getScreenResolution());
-        assertEquals("3.141.59", sauceOptions.getSeleniumVersion());
-        assertEquals(tags, sauceOptions.getTags());
-        assertEquals("San Francisco", sauceOptions.getTimeZone());
-        assertEquals("tunnelname", sauceOptions.getTunnelIdentifier());
-        assertEquals(false, sauceOptions.getVideoUploadOnPass());
+        assertEquals(true, sauceOptions.sauce().getAvoidProxy());
+        assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
+        assertEquals(true, sauceOptions.sauce().getCapturePerformance());
+        assertEquals("71", sauceOptions.sauce().getChromedriverVersion());
+        assertEquals(Integer.valueOf(2), sauceOptions.sauce().getCommandTimeout());
+        assertEquals(customData, sauceOptions.sauce().getCustomData());
+        assertEquals(true, sauceOptions.sauce().getExtendedDebugging());
+        assertEquals(Integer.valueOf(3), sauceOptions.sauce().getIdleTimeout());
+        assertEquals("3.141.0", sauceOptions.sauce().getIedriverVersion());
+        assertEquals(Integer.valueOf(300), sauceOptions.sauce().getMaxDuration());
+        assertEquals("Test name", sauceOptions.sauce().getName());
+        assertEquals("Mommy", sauceOptions.sauce().getParentTunnel());
+        assertEquals(prerun, sauceOptions.sauce().getPrerun());
+        assertEquals(Integer.valueOf(0), sauceOptions.sauce().getPriority());
+        assertEquals(JobVisibility.TEAM, sauceOptions.sauce().getJobVisibility());
+        assertEquals(false, sauceOptions.sauce().getRecordLogs());
+        assertEquals(false, sauceOptions.sauce().getRecordScreenshots());
+        assertEquals(false, sauceOptions.sauce().getRecordVideo());
+        assertEquals("10x10", sauceOptions.sauce().getScreenResolution());
+        assertEquals("3.141.59", sauceOptions.sauce().getSeleniumVersion());
+        assertEquals(tags, sauceOptions.sauce().getTags());
+        assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
+        assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
+        assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());
+    }
+
+    @Test
+    public void fluentPatternWorksSauce() {
+        sauceOptions.setBrowserName(Browser.FIREFOX)
+                .setBrowserVersion("68")
+                .setPlatformName(SaucePlatform.MAC_HIGH_SIERRA)
+                .sauce().setAvoidProxy(true)
+                        .setBuild("Sample Build Name")
+                        .setCapturePerformance(true)
+                        .setChromedriverVersion("71")
+                        .setCommandTimeout(2);
+
+        assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals("68", sauceOptions.getBrowserVersion());
+        assertEquals(SaucePlatform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
+        assertEquals(true, sauceOptions.sauce().getAvoidProxy());
+        assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
+        assertEquals(true, sauceOptions.sauce().getCapturePerformance());
+        assertEquals("71", sauceOptions.sauce().getChromedriverVersion());
+        assertEquals(Integer.valueOf(2), sauceOptions.sauce().getCommandTimeout());
     }
 
     @Test
@@ -222,7 +242,7 @@ public class SauceOptionsTest {
 
     @Test
     public void createsDefaultBuildName() {
-        assertNotNull(sauceOptions.getBuild());
+        assertNotNull(sauceOptions.sauce().getBuild());
     }
 
     @SneakyThrows
@@ -234,7 +254,7 @@ public class SauceOptionsTest {
     }
 
     @Test
-    public void setsCapabilitiesFromMap() throws FileNotFoundException {
+    public void setsCapabilitiesFromMap() {
         Map<String, Object> map = serialize("exampleValues");
 
         sauceOptions.mergeCapabilities(map);
@@ -273,30 +293,30 @@ public class SauceOptionsTest {
         assertEquals(UnhandledPromptBehavior.ACCEPT, sauceOptions.getUnhandledPromptBehavior());
         assertEquals(true, sauceOptions.getStrictFileInteractability());
         assertEquals(timeouts, sauceOptions.getTimeouts());
-        assertEquals(true, sauceOptions.getAvoidProxy());
-        assertEquals("Sample Build Name", sauceOptions.getBuild());
-        assertEquals(true, sauceOptions.getCapturePerformance());
-        assertEquals("71", sauceOptions.getChromedriverVersion());
-        assertEquals(Integer.valueOf(2), sauceOptions.getCommandTimeout());
-        assertEquals(customData, sauceOptions.getCustomData());
-        assertEquals(true, sauceOptions.getExtendedDebugging());
-        assertEquals(Integer.valueOf(3), sauceOptions.getIdleTimeout());
-        assertEquals("3.141.0", sauceOptions.getIedriverVersion());
-        assertEquals(Integer.valueOf(300), sauceOptions.getMaxDuration());
-        assertEquals("Sample Test Name", sauceOptions.getName());
-        assertEquals("Mommy", sauceOptions.getParentTunnel());
-        assertEquals(prerun, sauceOptions.getPrerun());
-        assertEquals(Integer.valueOf(0), sauceOptions.getPriority());
-        assertEquals(JobVisibility.TEAM, sauceOptions.getJobVisibility());
-        assertEquals(false, sauceOptions.getRecordLogs());
-        assertEquals(false, sauceOptions.getRecordScreenshots());
-        assertEquals(false, sauceOptions.getRecordVideo());
-        assertEquals("10x10", sauceOptions.getScreenResolution());
-        assertEquals("3.141.59", sauceOptions.getSeleniumVersion());
-        assertEquals(tags, sauceOptions.getTags());
-        assertEquals("San Francisco", sauceOptions.getTimeZone());
-        assertEquals("tunnelname", sauceOptions.getTunnelIdentifier());
-        assertEquals(false, sauceOptions.getVideoUploadOnPass());
+        assertEquals(true, sauceOptions.sauce().getAvoidProxy());
+        assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
+        assertEquals(true, sauceOptions.sauce().getCapturePerformance());
+        assertEquals("71", sauceOptions.sauce().getChromedriverVersion());
+        assertEquals(Integer.valueOf(2), sauceOptions.sauce().getCommandTimeout());
+        assertEquals(customData, sauceOptions.sauce().getCustomData());
+        assertEquals(true, sauceOptions.sauce().getExtendedDebugging());
+        assertEquals(Integer.valueOf(3), sauceOptions.sauce().getIdleTimeout());
+        assertEquals("3.141.0", sauceOptions.sauce().getIedriverVersion());
+        assertEquals(Integer.valueOf(300), sauceOptions.sauce().getMaxDuration());
+        assertEquals("Sample Test Name", sauceOptions.sauce().getName());
+        assertEquals("Mommy", sauceOptions.sauce().getParentTunnel());
+        assertEquals(prerun, sauceOptions.sauce().getPrerun());
+        assertEquals(Integer.valueOf(0), sauceOptions.sauce().getPriority());
+        assertEquals(JobVisibility.TEAM, sauceOptions.sauce().getJobVisibility());
+        assertEquals(false, sauceOptions.sauce().getRecordLogs());
+        assertEquals(false, sauceOptions.sauce().getRecordScreenshots());
+        assertEquals(false, sauceOptions.sauce().getRecordVideo());
+        assertEquals("10x10", sauceOptions.sauce().getScreenResolution());
+        assertEquals("3.141.59", sauceOptions.sauce().getSeleniumVersion());
+        assertEquals(tags, sauceOptions.sauce().getTags());
+        assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
+        assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
+        assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());
     }
 
     @Test(expected = InvalidSauceOptionsArgumentException.class)
@@ -338,6 +358,18 @@ public class SauceOptionsTest {
     @Test(expected = InvalidSauceOptionsArgumentException.class)
     public void setsBadPageLoadFromMap() {
         Map<String, Object> map = serialize("badPageLoad");
+        sauceOptions.mergeCapabilities(map);
+    }
+
+    @Test(expected = InvalidSauceOptionsArgumentException.class)
+    public void setsInvalidOptionFromMap() {
+        Map<String, Object> map = serialize("invalidOption");
+        sauceOptions.mergeCapabilities(map);
+    }
+
+    @Test(expected = InvalidSauceOptionsArgumentException.class)
+    public void setsInvalidSauceOptionFromMap() {
+        Map<String, Object> map = serialize("invalidSauceOption");
         sauceOptions.mergeCapabilities(map);
     }
 
@@ -404,30 +436,30 @@ public class SauceOptionsTest {
         tags.add("Bar");
         tags.add("Foobar");
 
-        sauceOptions.setAvoidProxy(true);
-        sauceOptions.setBuild("Sample Build Name");
-        sauceOptions.setCapturePerformance(true);
-        sauceOptions.setChromedriverVersion("71");
-        sauceOptions.setCommandTimeout(2);
-        sauceOptions.setCustomData(customData);
-        sauceOptions.setExtendedDebugging(true);
-        sauceOptions.setIdleTimeout(3);
-        sauceOptions.setIedriverVersion("3.141.0");
-        sauceOptions.setMaxDuration(300);
-        sauceOptions.setName("Test name");
-        sauceOptions.setParentTunnel("Mommy");
-        sauceOptions.setPrerun(prerun);
-        sauceOptions.setPriority(0);
-        sauceOptions.setJobVisibility(JobVisibility.TEAM);
-        sauceOptions.setRecordLogs(false);
-        sauceOptions.setRecordScreenshots(false);
-        sauceOptions.setRecordVideo(false);
-        sauceOptions.setScreenResolution("10x10");
-        sauceOptions.setSeleniumVersion("3.141.59");
-        sauceOptions.setTags(tags);
-        sauceOptions.setTimeZone("San Francisco");
-        sauceOptions.setTunnelIdentifier("tunnelname");
-        sauceOptions.setVideoUploadOnPass(false);
+        sauceOptions.sauce().setAvoidProxy(true);
+        sauceOptions.sauce().setBuild("Sample Build Name");
+        sauceOptions.sauce().setCapturePerformance(true);
+        sauceOptions.sauce().setChromedriverVersion("71");
+        sauceOptions.sauce().setCommandTimeout(2);
+        sauceOptions.sauce().setCustomData(customData);
+        sauceOptions.sauce().setExtendedDebugging(true);
+        sauceOptions.sauce().setIdleTimeout(3);
+        sauceOptions.sauce().setIedriverVersion("3.141.0");
+        sauceOptions.sauce().setMaxDuration(300);
+        sauceOptions.sauce().setName("Test name");
+        sauceOptions.sauce().setParentTunnel("Mommy");
+        sauceOptions.sauce().setPrerun(prerun);
+        sauceOptions.sauce().setPriority(0);
+        sauceOptions.sauce().setJobVisibility(JobVisibility.TEAM);
+        sauceOptions.sauce().setRecordLogs(false);
+        sauceOptions.sauce().setRecordScreenshots(false);
+        sauceOptions.sauce().setRecordVideo(false);
+        sauceOptions.sauce().setScreenResolution("10x10");
+        sauceOptions.sauce().setSeleniumVersion("3.141.59");
+        sauceOptions.sauce().setTags(tags);
+        sauceOptions.sauce().setTimeZone("San Francisco");
+        sauceOptions.sauce().setTunnelIdentifier("tunnelname");
+        sauceOptions.sauce().setVideoUploadOnPass(false);
 
         MutableCapabilities sauceCapabilities = new MutableCapabilities();
         sauceCapabilities.setCapability("avoidProxy", true);
@@ -529,14 +561,14 @@ public class SauceOptionsTest {
         sauceOptions.setUnhandledPromptBehavior(UnhandledPromptBehavior.IGNORE);
         expectedCapabilities.setCapability("unhandledPromptBehavior", UnhandledPromptBehavior.IGNORE);
 
-        sauceOptions.setExtendedDebugging(true);
+        sauceOptions.sauce().setExtendedDebugging(true);
         sauceCapabilities.setCapability("extendedDebugging", true);
-        sauceOptions.setName("Test name");
+        sauceOptions.sauce().setName("Test name");
         sauceCapabilities.setCapability("name", "Test name");
-        sauceOptions.setParentTunnel("Mommy");
+        sauceOptions.sauce().setParentTunnel("Mommy");
         sauceCapabilities.setCapability("parentTunnel", "Mommy");
 
-        sauceOptions.setJobVisibility(JobVisibility.SHARE);
+        sauceOptions.sauce().setJobVisibility(JobVisibility.SHARE);
         sauceCapabilities.setCapability("public", JobVisibility.SHARE);
         sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
         sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
@@ -71,18 +71,6 @@ public class SauceSessionTest {
         assertEquals(expetedSauceUrl, sauceSession.getSauceUrl().toString());
     }
 
-    @Test(expected = SauceEnvironmentVariablesNotSetException.class)
-    public void startThrowsErrorWithoutUsername() {
-        doReturn(null).when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        sauceOptsSession.start();
-    }
-
-    @Test(expected = SauceEnvironmentVariablesNotSetException.class)
-    public void startThrowsErrorWithoutAccessKey() {
-        doReturn(null).when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-        sauceOptsSession.start();
-    }
-
     @Test
     public void stopCallsDriverQuitPassing() {
         sauceSession.start();

--- a/java/src/test/java/com/saucelabs/saucebindings/deprecated_options.yml
+++ b/java/src/test/java/com/saucelabs/saucebindings/deprecated_options.yml
@@ -1,0 +1,56 @@
+exampleValues:
+  browserName: 'firefox'
+  browserVersion: '68'
+  platformName: 'macOS 10.13'
+  acceptInsecureCerts: true
+  pageLoadStrategy: 'eager'
+  setWindowRect: true
+  unhandledPromptBehavior: "accept"
+  strictFileInteractability: true
+  timeouts:
+    implicit: 1
+    pageLoad: 59
+    script: 29
+  avoidProxy: true
+  build: 'Sample Build Name'
+  capturePerformance: true
+  chromedriverVersion: '71'
+  commandTimeout: 2
+  customData:
+    foo: 'foo'
+    bar: 'bar'
+  extendedDebugging: true
+  idleTimeout: 3
+  iedriverVersion: '3.141.0'
+  maxDuration: 300
+  name: 'Sample Test Name'
+  parentTunnel: 'Mommy'
+  prerun:
+    executable: "http://url.to/your/executable.exe"
+    args:
+      - --silent
+      - -a
+      - -q
+    background: false
+    timeout: 120
+  priority: 0
+  jobVisibility: 'team'
+  recordLogs: false
+  recordScreenshots: false
+  recordVideo: false
+  screenResolution: '10x10'
+  seleniumVersion: '3.141.59'
+  tags:
+    - foo
+    - bar
+    - foobar
+  timeZone: 'San Francisco'
+  tunnelIdentifier: 'tunnelname'
+  videoUploadOnPass: false
+
+badJobVisibility:
+  jobVisibility: "me"
+
+badPrerun:
+  prerun:
+    nope: ""

--- a/java/src/test/java/com/saucelabs/saucebindings/options.yml
+++ b/java/src/test/java/com/saucelabs/saucebindings/options.yml
@@ -11,42 +11,43 @@ exampleValues:
     implicit: 1
     pageLoad: 59
     script: 29
-  avoidProxy: true
-  build: 'Sample Build Name'
-  capturePerformance: true
-  chromedriverVersion: '71'
-  commandTimeout: 2
-  customData:
-    foo: 'foo'
-    bar: 'bar'
-  extendedDebugging: true
-  idleTimeout: 3
-  iedriverVersion: '3.141.0'
-  maxDuration: 300
-  name: 'Sample Test Name'
-  parentTunnel: 'Mommy'
-  prerun:
-    executable: "http://url.to/your/executable.exe"
-    args:
-      - --silent
-      - -a
-      - -q
-    background: false
-    timeout: 120
-  priority: 0
-  jobVisibility: 'team'
-  recordLogs: false
-  recordScreenshots: false
-  recordVideo: false
-  screenResolution: '10x10'
-  seleniumVersion: '3.141.59'
-  tags:
-    - foo
-    - bar
-    - foobar
-  timeZone: 'San Francisco'
-  tunnelIdentifier: 'tunnelname'
-  videoUploadOnPass: false
+  sauce:
+    avoidProxy: true
+    build: 'Sample Build Name'
+    capturePerformance: true
+    chromedriverVersion: '71'
+    commandTimeout: 2
+    customData:
+      foo: 'foo'
+      bar: 'bar'
+    extendedDebugging: true
+    idleTimeout: 3
+    iedriverVersion: '3.141.0'
+    maxDuration: 300
+    name: 'Sample Test Name'
+    parentTunnel: 'Mommy'
+    prerun:
+      executable: "http://url.to/your/executable.exe"
+      args:
+        - --silent
+        - -a
+        - -q
+      background: false
+      timeout: 120
+    priority: 0
+    jobVisibility: 'team'
+    recordLogs: false
+    recordScreenshots: false
+    recordVideo: false
+    screenResolution: '10x10'
+    seleniumVersion: '3.141.59'
+    tags:
+      - foo
+      - bar
+      - foobar
+    timeZone: 'San Francisco'
+    tunnelIdentifier: 'tunnelname'
+    videoUploadOnPass: false
 
 badBrowser:
   browserName: "netscape"
@@ -55,7 +56,8 @@ badPlatform:
   platformName: "MAC"
 
 badJobVisibility:
-  jobVisibility: "me"
+  sauce:
+    jobVisibility: "me"
 
 badPageLoad:
   browserName: "fast"
@@ -68,12 +70,19 @@ badTimeout:
     bad: 1
 
 badPrerun:
-  prerun:
-    nope: ""
+  sauce:
+    prerun:
+      nope: ""
 
 invalidOption:
   foo: "bar"
   browser_Nme: "firefox"
   browserVersion: "70"
   platformName: "MacOS 10.12"
-  recordScreenshots: false
+
+invalidSauceOption:
+  browser_Nme: "firefox"
+  browserVersion: "70"
+  platformName: "MacOS 10.12"
+  sauce:
+    foo: "bar"


### PR DESCRIPTION
Continuation of #230 so it is comparing to caps_manager branch & in Draft form

* Create Abstract Superclass called "Options"
* Breaks out Sauce Specific Options into a separate class both classes extend Options class
* Creates Deprecated, Backward compatible getters/setters on SauceOptions for supporting until 2.0
* Breaks out Tests into backward compatible / deprecated & recommended API

Only interesting thing here is that fluent pattern works slightly differently
https://github.com/saucelabs/sauce_bindings/compare/caps_manager...subclass_sauce?expand=1#diff-04ebfed2c5f642255616b935927952038b577e44c7a2b216a1edcd05248e063fR162