### PR TITLE
[java] move sauce specific options into their own class

### DIFF
--- a/java/src/main/java/com/saucelabs/saucebindings/InvalidSauceOptionsArgumentException.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/InvalidSauceOptionsArgumentException.java
@@ -1,7 +1,0 @@
-package com.saucelabs.saucebindings;
-
-class InvalidSauceOptionsArgumentException extends RuntimeException {
-    public InvalidSauceOptionsArgumentException(String message) {
-        super(message);
-    }
-}

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -1,5 +1,6 @@
 package com.saucelabs.saucebindings;
 
+import com.saucelabs.saucebindings.options.BaseOptions;
 import com.saucelabs.saucebindings.options.CapabilityManager;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -7,6 +8,10 @@ import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.ie.InternetExplorerOptions;
 import org.openqa.selenium.safari.SafariOptions;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
 
 public class SauceOptions extends com.saucelabs.saucebindings.options.SauceOptions {
 
@@ -73,5 +78,480 @@ public class SauceOptions extends com.saucelabs.saucebindings.options.SauceOptio
     @Deprecated
     public MutableCapabilities getSeleniumCapabilities() {
         return capabilities;
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param avoidProxy
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setAvoidProxy(Boolean avoidProxy) {
+        return sauce().setAvoidProxy(avoidProxy);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param build
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setBuild(String build) {
+        return sauce().setBuild(build);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param capturePerformance
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setCapturePerformance(Boolean capturePerformance) {
+        return sauce().setCapturePerformance(capturePerformance);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param chromedriverVersion
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setChromedriverVersion(String chromedriverVersion) {
+        return sauce().setChromedriverVersion(chromedriverVersion);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param commandTimeout
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setCommandTimeout(Integer commandTimeout) {
+        return sauce().setCommandTimeout(commandTimeout);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param customData
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setCustomData(Map<String, Object> customData) {
+        return sauce().setCustomData(customData);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param extendedDebugging
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setExtendedDebugging(Boolean extendedDebugging) {
+        return sauce().setExtendedDebugging(extendedDebugging);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param idleTimeout
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setIdleTimeout(Integer idleTimeout) {
+        return sauce().setIdleTimeout(idleTimeout);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param iedriverVersion
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setIedriverVersion(String iedriverVersion) {
+        return sauce().setIedriverVersion(iedriverVersion);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param maxDuration
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setMaxDuration(Integer maxDuration) {
+        return sauce().setMaxDuration(maxDuration);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param name
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setName(String name) {
+        return sauce().setName(name);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param parentTunnel
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setParentTunnel(String parentTunnel) {
+        return sauce().setParentTunnel(parentTunnel);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param prerun
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setPrerun(Map<Prerun, Object> prerun) {
+        return sauce().setPrerun(prerun);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param prerunUrl
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setPrerunUrl(URL prerunUrl) {
+        return sauce().setPrerunUrl(prerunUrl);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param priority
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setPriority(Integer priority) {
+        return sauce().setPriority(priority);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param jobVisibility
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setJobVisibility(JobVisibility jobVisibility) {
+        return sauce().setJobVisibility(jobVisibility);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param recordLogs
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setRecordLogs(Boolean recordLogs) {
+        return sauce().setRecordLogs(recordLogs);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param recordScreenshots
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setRecordScreenshots(Boolean recordScreenshots) {
+        return sauce().setRecordScreenshots(recordScreenshots);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param recordVideo
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setRecordVideo(Boolean recordVideo) {
+        return sauce().setRecordVideo(recordVideo);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param screenResolution
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setScreenResolution(String screenResolution) {
+        return sauce().setScreenResolution(screenResolution);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param seleniumVersion
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setSeleniumVersion(String seleniumVersion) {
+        return sauce().setSeleniumVersion(seleniumVersion);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param tags
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setTags(List<String> tags) {
+        return sauce().setTags(tags);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param timeZone
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setTimeZone(String timeZone) {
+        return sauce().setTimeZone(timeZone);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param tunnelIdentifier
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setTunnelIdentifier (String tunnelIdentifier) {
+        return sauce().setTunnelIdentifier(tunnelIdentifier);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param videoUploadOnPass
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setVideoUploadOnPass(Boolean videoUploadOnPass) {
+        return sauce().setVideoUploadOnPass(videoUploadOnPass);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getAvoidProxy() {
+        return sauce().getAvoidProxy();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getBuild() {
+        return sauce().getBuild();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getCapturePerformance() {
+        return sauce().getCapturePerformance();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getChromedriverVersion() {
+        return sauce().getChromedriverVersion();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Integer getCommandTimeout() {
+        return sauce().getCommandTimeout();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Map<String, Object> getCustomData() {
+        return sauce().getCustomData();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getExtendedDebugging() {
+        return sauce().getExtendedDebugging();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Integer getIdleTimeout() {
+        return sauce().getIdleTimeout();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getIedriverVersion() {
+        return sauce().getIedriverVersion();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Integer getMaxDuration() {
+        return sauce().getMaxDuration();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getName() {
+        return sauce().getName();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getParentTunnel() {
+        return sauce().getParentTunnel();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Map<Prerun, Object> getPrerun() {
+        return sauce().getPrerun();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public URL getPrerunUrl() {
+        return sauce().getPrerunUrl();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Integer getPriority() {
+        return sauce().getPriority();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public JobVisibility getJobVisibility() {
+        return sauce().getJobVisibility();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getRecordLogs() {
+        return sauce().getRecordLogs();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getRecordScreenshots() {
+        return sauce().getRecordScreenshots();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getRecordVideo() {
+        return sauce().getRecordVideo();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getScreenResolution() {
+        return sauce().getScreenResolution();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getSeleniumVersion() {
+        return sauce().getSeleniumVersion();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public List<String> getTags() {
+        return sauce().getTags();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getTimeZone() {
+        return sauce().getTimeZone();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getTunnelIdentifier () {
+        return sauce().getTunnelIdentifier();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getVideoUploadOnPass() {
+        return sauce().getVideoUploadOnPass();
     }
 }

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -1,147 +1,61 @@
 package com.saucelabs.saucebindings;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
+import com.saucelabs.saucebindings.options.CapabilityManager;
 import org.openqa.selenium.MutableCapabilities;
-import org.openqa.selenium.Proxy;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.ie.InternetExplorerOptions;
 import org.openqa.selenium.safari.SafariOptions;
 
-import java.net.URL;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+public class SauceOptions extends com.saucelabs.saucebindings.options.SauceOptions {
 
-@Accessors(chain = true)
-@Setter @Getter
-public class SauceOptions {
-    @Setter(AccessLevel.NONE) private MutableCapabilities capabilities;
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) private CapabilityManager capabilityManager;
-    public TimeoutStore timeout = new TimeoutStore();
-
-    // w3c Settings
-    private Browser browserName = Browser.CHROME;
-    private String browserVersion = "latest";
-    private SaucePlatform platformName = SaucePlatform.WINDOWS_10;
-    private PageLoadStrategy pageLoadStrategy;
-    private Boolean acceptInsecureCerts = null;
-    private Proxy proxy;
-    private Boolean setWindowRect = null;
-    @Getter(AccessLevel.NONE) private Map<Timeouts, Integer> timeouts;
-    private Boolean strictFileInteractability = null;
-    private UnhandledPromptBehavior unhandledPromptBehavior;
-
-    // Sauce Settings
-    private Boolean avoidProxy = null;
-    private String build;
-    private Boolean capturePerformance = null;
-    private String chromedriverVersion;
-    private Integer commandTimeout = null;
-    private Map<String, Object> customData = null;
-    private Boolean extendedDebugging = null;
-    private Integer idleTimeout = null;
-    private String iedriverVersion;
-    private Integer maxDuration = null;
-    private String name;
-    private String parentTunnel;
-    private Map<Prerun, Object> prerun;
-    private URL prerunUrl;
-    private Integer priority = null;
-    private JobVisibility jobVisibility; // the actual key for this is a Java reserved keyword "public"
-    private Boolean recordLogs = null;
-    private Boolean recordScreenshots = null;
-    private Boolean recordVideo = null;
-    private String screenResolution;
-    private String seleniumVersion;
-    private List<String> tags = null;
-    private String timeZone;
-    private String tunnelIdentifier;
-    private Boolean videoUploadOnPass = null;
-
-    public static final List<String> w3cDefinedOptions = Arrays.asList(
-            "browserName",
-            "browserVersion",
-            "platformName",
-            "pageLoadStrategy",
-            "acceptInsecureCerts",
-            "proxy",
-            "setWindowRect",
-            "timeouts",
-            "strictFileInteractability",
-            "unhandledPromptBehavior");
-
-    public static final List<String> sauceDefinedOptions = Arrays.asList(
-            "avoidProxy",
-            "build",
-            "capturePerformance",
-            "chromedriverVersion",
-            "commandTimeout",
-            "customData",
-            "extendedDebugging",
-            "idleTimeout",
-            "iedriverVersion",
-            "maxDuration",
-            "name",
-            "parentTunnel",
-            "prerun",
-            "priority",
-            // public, do not use, reserved keyword, using jobVisibility
-            "recordLogs",
-            "recordScreenshots",
-            "recordVideo",
-            "screenResolution",
-            "seleniumVersion",
-            "tags",
-            "timeZone",
-            "tunnelIdentifier",
-            "videoUploadOnPass");
-
-    public static final Map<String, String> knownCITools;
-    static {
-        knownCITools = new HashMap<>();
-        knownCITools.put("Jenkins", "BUILD_TAG");
-        knownCITools.put("Bamboo", "bamboo_agentId");
-        knownCITools.put("Travis", "TRAVIS_JOB_ID");
-        knownCITools.put("Circle", "CIRCLE_JOB");
-        knownCITools.put("GitLab", "CI");
-        knownCITools.put("TeamCity", "TEAMCITY_PROJECT_NAME");
-    }
-
+    /**
+     * @deprecated Use com.saucelabs.saucebindings.options.SauceOptions() instead
+     */
+    @Deprecated
     public SauceOptions() {
         this(new MutableCapabilities());
     }
 
+    /**
+     * @deprecated Use com.saucelabs.saucebindings.options.SauceOptions(ChromeOptions options) instead
+     */
+    @Deprecated
     public SauceOptions(ChromeOptions options) {
         this(new MutableCapabilities(options));
     }
 
+    /**
+     * @deprecated Use com.saucelabs.saucebindings.options.SauceOptions(EdgeOptions options) instead
+     */
+    @Deprecated
     public SauceOptions(EdgeOptions options) {
         this(new MutableCapabilities(options));
     }
 
+    /**
+     * @deprecated Use com.saucelabs.saucebindings.options.SauceOptions(FirefoxOptions options) instead
+     */
+    @Deprecated
     public SauceOptions(FirefoxOptions options) {
         this(new MutableCapabilities(options));
     }
 
+    /**
+     * @deprecated Use com.saucelabs.saucebindings.options.SauceOptions(InternetExplorerOptions options) instead
+     */
+    @Deprecated
     public SauceOptions(InternetExplorerOptions options) {
         this(new MutableCapabilities(options));
     }
 
+    /**
+     * @deprecated Use com.saucelabs.saucebindings.options.SauceOptions(SafariOptions options) instead
+     */
+    @Deprecated
     public SauceOptions(SafariOptions options) {
         this(new MutableCapabilities(options));
-    }
-
-    public Map<Timeouts, Integer> getTimeouts() {
-        if (timeout.getTimeouts().isEmpty()) {
-            return timeouts;
-        }
-        return timeout.getTimeouts();
     }
 
     private SauceOptions(MutableCapabilities options) {
@@ -152,116 +66,9 @@ public class SauceOptions {
         }
     }
 
-    public MutableCapabilities toCapabilities() {
-        capabilityManager.addCapabilities(capabilities, w3cDefinedOptions);
-
-        MutableCapabilities sauceCapabilities = new MutableCapabilities();
-        sauceCapabilities.setCapability("username", getSauceUsername());
-        sauceCapabilities.setCapability("accessKey", getSauceAccessKey());
-
-        capabilityManager.addCapabilities(sauceCapabilities, sauceDefinedOptions);
-
-        Object visibilityValue = capabilityManager.getCapability("jobVisibility");
-        if (visibilityValue != null) {
-            sauceCapabilities.setCapability("public", visibilityValue);
-        }
-
-        Object prerunValue = capabilityManager.getCapability("prerunUrl");
-        if (prerunValue != null) {
-            sauceCapabilities.setCapability("prerun", prerunValue);
-        }
-
-        capabilities.setCapability("sauce:options", sauceCapabilities);
-        return capabilities;
-    }
-
-    public String getBuild() {
-        if (build != null) {
-            return build;
-        } else if (SystemManager.get(knownCITools.get("Jenkins")) != null) {
-            return SystemManager.get("BUILD_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
-        } else if (SystemManager.get(knownCITools.get("Bamboo")) != null) {
-            return SystemManager.get("bamboo_shortJobName") + ": " + SystemManager.get("bamboo_buildNumber");
-        } else if (SystemManager.get(knownCITools.get("Travis")) != null) {
-            return SystemManager.get("TRAVIS_JOB_NAME") + ": " + SystemManager.get("TRAVIS_JOB_NUMBER");
-        } else if (SystemManager.get(knownCITools.get("Circle")) != null) {
-            return SystemManager.get("CIRCLE_JOB") + ": " + SystemManager.get("CIRCLE_BUILD_NUM");
-        } else if (SystemManager.get(knownCITools.get("GitLab")) != null) {
-            return SystemManager.get("CI_JOB_NAME") + ": " + SystemManager.get("CI_JOB_ID");
-        } else if (SystemManager.get(knownCITools.get("TeamCity")) != null) {
-            return SystemManager.get("TEAMCITY_PROJECT_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
-        } else {
-            return "Build Time: " + System.currentTimeMillis();
-        }
-    }
-
-    public boolean isKnownCI() {
-        return !knownCITools.keySet().stream().allMatch((key) -> SystemManager.get(key) == null);
-    }
-
-    // Use Case is pulling serialized information from JSON/YAML, converting it to a HashMap and passing it in
-    // This is a preferred pattern as it avoids conditionals in code
-    public void mergeCapabilities(Map<String, Object> capabilities) {
-        capabilities.forEach(this::setCapability);
-    }
-
-    // Switch statement here to handle enums
-    public void setCapability(String key, Object value) {
-        switch (key) {
-            case "browserName":
-                capabilityManager.validateCapability("Browser", Browser.keys(), (String) value);
-                setBrowserName(Browser.valueOf(Browser.fromString((String) value)));
-                break;
-            case "platformName":
-                capabilityManager.validateCapability("SaucePlatform", SaucePlatform.keys(), (String) value);
-                setPlatformName(SaucePlatform.valueOf(SaucePlatform.fromString((String) value)));
-                break;
-            case "pageLoadStrategy":
-                capabilityManager.validateCapability("PageLoadStrategy", PageLoadStrategy.keys(), (String) value);
-                setPageLoadStrategy(PageLoadStrategy.valueOf(PageLoadStrategy.fromString((String) value)));
-                break;
-            case "unhandledPromptBehavior":
-                capabilityManager.validateCapability("UnhandledPromptBehavior", UnhandledPromptBehavior.keys(), (String) value);
-                setUnhandledPromptBehavior(UnhandledPromptBehavior.valueOf(UnhandledPromptBehavior.fromString((String) value)));
-                break;
-            case "timeouts":
-                Map<Timeouts, Integer> timeoutsMap = new HashMap<>();
-                ((Map) value).forEach((oldKey, val) -> {
-                    capabilityManager.validateCapability("Timeouts", Timeouts.keys(), (String) oldKey);
-                    String keyString = Timeouts.fromString((String) oldKey);
-                    timeoutsMap.put(Timeouts.valueOf(keyString), (Integer) val);
-                });
-                setTimeouts(timeoutsMap);
-                break;
-            case "jobVisibility":
-                capabilityManager.validateCapability("JobVisibility", JobVisibility.keys(), (String) value);
-                setJobVisibility(JobVisibility.valueOf(JobVisibility.fromString((String) value)));
-                break;
-            case "prerun":
-                Map<Prerun, Object> prerunMap = new HashMap<>();
-                ((Map) value).forEach((oldKey, val) -> {
-                    capabilityManager.validateCapability("Prerun", Prerun.keys(), (String) oldKey);
-                    String keyString = Prerun.fromString((String) oldKey);
-                    prerunMap.put(Prerun.valueOf(keyString), val);
-                });
-                setPrerun(prerunMap);
-                break;
-            default:
-                capabilityManager.setCapability(key, value);
-        }
-    }
-
-    protected String getSauceUsername() {
-        return SystemManager.get("SAUCE_USERNAME", "Sauce Username was not provided");
-    }
-
-    protected String getSauceAccessKey() {
-        return SystemManager.get("SAUCE_ACCESS_KEY", "Sauce Access Key was not provided");
-    }
-
     /**
      * @deprecated Use getCapabilities() instead
-     * @return
+     * @return instance capabilities that will get sent to the RemoteWebDriver
      */
     @Deprecated
     public MutableCapabilities getSeleniumCapabilities() {

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -1,5 +1,6 @@
 package com.saucelabs.saucebindings;
 
+import com.saucelabs.saucebindings.options.SauceOptions;
 import lombok.Getter;
 import lombok.Setter;
 import org.openqa.selenium.InvalidArgumentException;

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -62,7 +62,7 @@ public class SauceSession {
         // The first print statement will automatically populate links on Jenkins to Sauce
         // The second print statement will output the job link to logging/console
         if (this.driver != null) {
-            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", this.driver.getSessionId(), this.sauceOptions.getName());
+            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", this.driver.getSessionId(), this.sauceOptions.sauce().getName());
             String sauceTestLink = String.format("Test Job Link: https://app.saucelabs.com/tests/%s", this.driver.getSessionId());
             System.out.print(sauceReporter + "\n" + sauceTestLink + "\n");
         }

--- a/java/src/main/java/com/saucelabs/saucebindings/examples/BasicOptionsTest.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/examples/BasicOptionsTest.java
@@ -1,5 +1,6 @@
 package com.saucelabs.saucebindings.examples;
 
+import com.saucelabs.saucebindings.options.SauceOptions;
 import com.saucelabs.saucebindings.*;
 import org.junit.Test;
 import org.openqa.selenium.remote.RemoteWebDriver;

--- a/java/src/main/java/com/saucelabs/saucebindings/examples/BrowserOptionsTest.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/examples/BrowserOptionsTest.java
@@ -1,6 +1,7 @@
 package com.saucelabs.saucebindings.examples;
 
 import com.saucelabs.saucebindings.*;
+import com.saucelabs.saucebindings.options.SauceOptions;
 import org.junit.Test;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;

--- a/java/src/main/java/com/saucelabs/saucebindings/examples/SauceLabsOptionsTest.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/examples/SauceLabsOptionsTest.java
@@ -1,6 +1,7 @@
 package com.saucelabs.saucebindings.examples;
 
 import com.saucelabs.saucebindings.*;
+import com.saucelabs.saucebindings.options.SauceOptions;
 import org.junit.Test;
 import org.openqa.selenium.remote.RemoteWebDriver;
 

--- a/java/src/main/java/com/saucelabs/saucebindings/examples/SauceLabsOptionsTest.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/examples/SauceLabsOptionsTest.java
@@ -11,9 +11,9 @@ public class SauceLabsOptionsTest {
     public void sauceOptions() {
         // 1. Specify Sauce Specific Options
         SauceOptions sauceOptions = new SauceOptions();
-        sauceOptions.setExtendedDebugging(true);
-        sauceOptions.setIdleTimeout(100);
-        sauceOptions.setTimeZone("Alaska");
+        sauceOptions.sauce().setExtendedDebugging(true);
+        sauceOptions.sauce().setIdleTimeout(100);
+        sauceOptions.sauce().setTimeZone("Alaska");
 
         // 2. Create Session object with the Options object instance
         SauceSession session = new SauceSession(sauceOptions);

--- a/java/src/main/java/com/saucelabs/saucebindings/options/BaseOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/BaseOptions.java
@@ -1,0 +1,25 @@
+package com.saucelabs.saucebindings.options;
+
+import lombok.Getter;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.util.List;
+import java.util.Map;
+
+public abstract class BaseOptions {
+    @Getter protected MutableCapabilities capabilities = new MutableCapabilities();
+    protected CapabilityManager capabilityManager;
+    @Getter public final List<String> validOptions = null;
+
+    // Use Case is pulling serialized information from JSON/YAML, converting it to a HashMap and passing it in
+    // This is a preferred pattern as it avoids conditionals in code
+    public void mergeCapabilities(Map<String, Object> mergingCapabilities) {
+        mergingCapabilities.forEach(this::setCapability);
+    }
+
+    // This dynamically calls setter
+    // Applicable enums must override this method in subclass
+    protected void setCapability(String key, Object value) {
+        capabilityManager.setCapability(key, value);
+    };
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/options/CapabilityManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/CapabilityManager.java
@@ -1,37 +1,31 @@
 package com.saucelabs.saucebindings.options;
 
-import org.openqa.selenium.MutableCapabilities;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class CapabilityManager {
-    private final SauceOptions options;
+    private final BaseOptions options;
 
     /**
      * Class constructor created for a specific SauceOptions instance
      *
      * @param options the SauceOptions instance using this capabilities manager
      */
-    public CapabilityManager(SauceOptions options) {
+    public CapabilityManager(BaseOptions options) {
         this.options = options;
     }
 
     /**
-     * Add values of valid capabilities to the capabilities object
-     *
-     * @param capabilities the capabilities instance that valid options get added to
-     * @param validOptions the list of options matching the options being used
+     * Add values of option class's valid capabilities to the option class's capabilities object
      */
-    public void addCapabilities(MutableCapabilities capabilities, List<String> validOptions) {
-        validOptions.forEach((capability) -> {
+    public void addCapabilities() {
+        options.getValidOptions().forEach((capability) -> {
             Object value = getCapability(capability);
             if (value != null) {
-                capabilities.setCapability(capability, value);
+                options.capabilities.setCapability(capability, value);
             }
         });
     }

--- a/java/src/main/java/com/saucelabs/saucebindings/options/CapabilityManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/CapabilityManager.java
@@ -1,4 +1,4 @@
-package com.saucelabs.saucebindings;
+package com.saucelabs.saucebindings.options;
 
 import org.openqa.selenium.MutableCapabilities;
 

--- a/java/src/main/java/com/saucelabs/saucebindings/options/InvalidSauceOptionsArgumentException.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/InvalidSauceOptionsArgumentException.java
@@ -1,0 +1,7 @@
+package com.saucelabs.saucebindings.options;
+
+public class InvalidSauceOptionsArgumentException extends RuntimeException {
+    public InvalidSauceOptionsArgumentException(String message) {
+        super(message);
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/options/SauceLabsOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/SauceLabsOptions.java
@@ -1,0 +1,165 @@
+package com.saucelabs.saucebindings.options;
+
+import com.saucelabs.saucebindings.JobVisibility;
+import com.saucelabs.saucebindings.Prerun;
+import com.saucelabs.saucebindings.SystemManager;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Accessors(chain = true) @Setter @Getter
+public class SauceLabsOptions extends BaseOptions {
+    // https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+    private Boolean avoidProxy = null;
+    private String build;
+    private Boolean capturePerformance = null;
+    private String chromedriverVersion;
+    private Integer commandTimeout = null;
+    private Map<String, Object> customData = null;
+    private Boolean extendedDebugging = null;
+    private Integer idleTimeout = null;
+    private String iedriverVersion;
+    private Integer maxDuration = null;
+    private String name;
+    private String parentTunnel;
+    private Map<Prerun, Object> prerun;
+    private URL prerunUrl;
+    private Integer priority = null;
+    private JobVisibility jobVisibility; // the actual key for this is a Java reserved keyword "public"; uses enum
+    private Boolean recordLogs = null;
+    private Boolean recordScreenshots = null;
+    private Boolean recordVideo = null;
+    private String screenResolution;
+    private String seleniumVersion;
+    private List<String> tags = null;
+    private String timeZone;
+    private String tunnelIdentifier;
+    private Boolean videoUploadOnPass = null;
+
+    public final List<String> validOptions = Arrays.asList(
+            "avoidProxy",
+            "build",
+            "capturePerformance",
+            "chromedriverVersion",
+            "commandTimeout",
+            "customData",
+            "extendedDebugging",
+            "idleTimeout",
+            "iedriverVersion",
+            "jobVisibility",
+            "maxDuration",
+            "name",
+            "parentTunnel",
+            "prerun",
+            "prerunUrl",
+            "priority",
+            // public, do not use, reserved keyword, using jobVisibility with enum
+            "recordLogs",
+            "recordScreenshots",
+            "recordVideo",
+            "screenResolution",
+            "seleniumVersion",
+            "tags",
+            "timeZone",
+            "tunnelIdentifier",
+            "videoUploadOnPass");
+
+    public SauceLabsOptions() {
+        capabilityManager = new CapabilityManager(this);
+    }
+
+    public MutableCapabilities toCapabilities() {
+        capabilities.setCapability("username", getSauceUsername());
+        capabilities.setCapability("accessKey", getSauceAccessKey());
+
+        Object visibilityValue = capabilityManager.getCapability("jobVisibility");
+        if (visibilityValue != null) {
+            capabilities.setCapability("public", visibilityValue);
+            setJobVisibility(null);
+        }
+
+        Object prerunValue = capabilityManager.getCapability("prerunUrl");
+        if (prerunValue != null) {
+            capabilities.setCapability("prerun", prerunValue);
+            setPrerunUrl(null);
+        }
+
+        capabilityManager.addCapabilities();
+        return capabilities;
+    }
+
+    /**
+     * This method is to handle special cases and enums as necessary
+     *
+     * @param key   Which capability to set on this instance's Selenium MutableCapabilities instance
+     * @param value The value of the capability getting set
+     */
+    @Override
+    protected void setCapability(String key, Object value) {
+        if ("jobVisibility".equals(key)) {
+            capabilityManager.validateCapability("JobVisibility", JobVisibility.keys(), (String) value);
+            setJobVisibility(JobVisibility.valueOf(JobVisibility.fromString((String) value)));
+        } else if ("prerun".equals(key)) {
+            Map<Prerun, Object> prerunMap = new HashMap<>();
+            ((Map) value).forEach((oldKey, val) -> {
+                capabilityManager.validateCapability("Prerun", Prerun.keys(), (String) oldKey);
+                String keyString = Prerun.fromString((String) oldKey);
+                prerunMap.put(Prerun.valueOf(keyString), val);
+            });
+            setPrerun(prerunMap);
+        } else {
+            super.setCapability(key, value);
+        }
+    }
+
+    public String getBuild() {
+        if (build != null) {
+            return build;
+        } else if (SystemManager.get(knownCITools.get("Jenkins")) != null) {
+            return SystemManager.get("BUILD_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
+        } else if (SystemManager.get(knownCITools.get("Bamboo")) != null) {
+            return SystemManager.get("bamboo_shortJobName") + ": " + SystemManager.get("bamboo_buildNumber");
+        } else if (SystemManager.get(knownCITools.get("Travis")) != null) {
+            return SystemManager.get("TRAVIS_JOB_NAME") + ": " + SystemManager.get("TRAVIS_JOB_NUMBER");
+        } else if (SystemManager.get(knownCITools.get("Circle")) != null) {
+            return SystemManager.get("CIRCLE_JOB") + ": " + SystemManager.get("CIRCLE_BUILD_NUM");
+        } else if (SystemManager.get(knownCITools.get("GitLab")) != null) {
+            return SystemManager.get("CI_JOB_NAME") + ": " + SystemManager.get("CI_JOB_ID");
+        } else if (SystemManager.get(knownCITools.get("TeamCity")) != null) {
+            return SystemManager.get("TEAMCITY_PROJECT_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
+        } else {
+            return "Build Time: " + System.currentTimeMillis();
+        }
+    }
+
+    public boolean isKnownCI() {
+        return !knownCITools.keySet().stream().allMatch((key) -> SystemManager.get(key) == null);
+    }
+
+    public static final Map<String, String> knownCITools;
+
+    static {
+        knownCITools = new HashMap<>();
+        knownCITools.put("Jenkins", "BUILD_TAG");
+        knownCITools.put("Bamboo", "bamboo_agentId");
+        knownCITools.put("Travis", "TRAVIS_JOB_ID");
+        knownCITools.put("Circle", "CIRCLE_JOB");
+        knownCITools.put("GitLab", "CI");
+        knownCITools.put("TeamCity", "TEAMCITY_PROJECT_NAME");
+    }
+
+    protected String getSauceUsername() {
+        return SystemManager.get("SAUCE_USERNAME", "Sauce Username was not provided");
+    }
+
+    protected String getSauceAccessKey() {
+        return SystemManager.get("SAUCE_ACCESS_KEY", "Sauce Access Key was not provided");
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/options/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/SauceOptions.java
@@ -1,0 +1,273 @@
+package com.saucelabs.saucebindings.options;
+
+import com.saucelabs.saucebindings.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.Proxy;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.ie.InternetExplorerOptions;
+import org.openqa.selenium.safari.SafariOptions;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Accessors(chain = true)
+@Setter @Getter
+public class SauceOptions {
+    @Setter(AccessLevel.NONE) protected MutableCapabilities capabilities;
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) protected CapabilityManager capabilityManager;
+    public TimeoutStore timeout = new TimeoutStore();
+
+    // w3c Settings
+    protected Browser browserName = Browser.CHROME;
+    protected String browserVersion = "latest";
+    protected SaucePlatform platformName = SaucePlatform.WINDOWS_10;
+    protected PageLoadStrategy pageLoadStrategy;
+    protected Boolean acceptInsecureCerts = null;
+    protected Proxy proxy;
+    protected Boolean setWindowRect = null;
+    @Getter(AccessLevel.NONE) protected Map<Timeouts, Integer> timeouts;
+    protected Boolean strictFileInteractability = null;
+    protected UnhandledPromptBehavior unhandledPromptBehavior;
+
+    // Sauce Settings
+    protected Boolean avoidProxy = null;
+    protected String build;
+    protected Boolean capturePerformance = null;
+    protected String chromedriverVersion;
+    protected Integer commandTimeout = null;
+    protected Map<String, Object> customData = null;
+    protected Boolean extendedDebugging = null;
+    protected Integer idleTimeout = null;
+    protected String iedriverVersion;
+    protected Integer maxDuration = null;
+    protected String name;
+    protected String parentTunnel;
+    protected Map<Prerun, Object> prerun;
+    protected URL prerunUrl;
+    protected Integer priority = null;
+    protected JobVisibility jobVisibility; // the actual key for this is a Java reserved keyword "public"
+    protected Boolean recordLogs = null;
+    protected Boolean recordScreenshots = null;
+    protected Boolean recordVideo = null;
+    protected String screenResolution;
+    protected String seleniumVersion;
+    protected List<String> tags = null;
+    protected String timeZone;
+    protected String tunnelIdentifier;
+    protected Boolean videoUploadOnPass = null;
+
+    public static final List<String> w3cDefinedOptions = Arrays.asList(
+            "browserName",
+            "browserVersion",
+            "platformName",
+            "pageLoadStrategy",
+            "acceptInsecureCerts",
+            "proxy",
+            "setWindowRect",
+            "timeouts",
+            "strictFileInteractability",
+            "unhandledPromptBehavior");
+
+    public static final List<String> sauceDefinedOptions = Arrays.asList(
+            "avoidProxy",
+            "build",
+            "capturePerformance",
+            "chromedriverVersion",
+            "commandTimeout",
+            "customData",
+            "extendedDebugging",
+            "idleTimeout",
+            "iedriverVersion",
+            "maxDuration",
+            "name",
+            "parentTunnel",
+            "prerun",
+            "priority",
+            // public, do not use, reserved keyword, using jobVisibility
+            "recordLogs",
+            "recordScreenshots",
+            "recordVideo",
+            "screenResolution",
+            "seleniumVersion",
+            "tags",
+            "timeZone",
+            "tunnelIdentifier",
+            "videoUploadOnPass");
+
+    public static final Map<String, String> knownCITools;
+    static {
+        knownCITools = new HashMap<>();
+        knownCITools.put("Jenkins", "BUILD_TAG");
+        knownCITools.put("Bamboo", "bamboo_agentId");
+        knownCITools.put("Travis", "TRAVIS_JOB_ID");
+        knownCITools.put("Circle", "CIRCLE_JOB");
+        knownCITools.put("GitLab", "CI");
+        knownCITools.put("TeamCity", "TEAMCITY_PROJECT_NAME");
+    }
+
+    public SauceOptions() {
+        this(new MutableCapabilities());
+    }
+
+    public SauceOptions(ChromeOptions options) {
+        this(new MutableCapabilities(options));
+    }
+
+    public SauceOptions(EdgeOptions options) {
+        this(new MutableCapabilities(options));
+    }
+
+    public SauceOptions(FirefoxOptions options) {
+        this(new MutableCapabilities(options));
+    }
+
+    public SauceOptions(InternetExplorerOptions options) {
+        this(new MutableCapabilities(options));
+    }
+
+    public SauceOptions(SafariOptions options) {
+        this(new MutableCapabilities(options));
+    }
+
+    public Map<Timeouts, Integer> getTimeouts() {
+        if (timeout.getTimeouts().isEmpty()) {
+            return timeouts;
+        }
+        return timeout.getTimeouts();
+    }
+
+    private SauceOptions(MutableCapabilities options) {
+        capabilities = new MutableCapabilities(options.asMap());
+        capabilityManager = new CapabilityManager(this);
+        if (options.getCapability("browserName") != null) {
+            setCapability("browserName", options.getCapability("browserName"));
+        }
+    }
+
+    public MutableCapabilities toCapabilities() {
+        capabilityManager.addCapabilities(capabilities, w3cDefinedOptions);
+
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+        sauceCapabilities.setCapability("username", getSauceUsername());
+        sauceCapabilities.setCapability("accessKey", getSauceAccessKey());
+
+        capabilityManager.addCapabilities(sauceCapabilities, sauceDefinedOptions);
+
+        Object visibilityValue = capabilityManager.getCapability("jobVisibility");
+        if (visibilityValue != null) {
+            sauceCapabilities.setCapability("public", visibilityValue);
+        }
+
+        Object prerunValue = capabilityManager.getCapability("prerunUrl");
+        if (prerunValue != null) {
+            sauceCapabilities.setCapability("prerun", prerunValue);
+        }
+
+        capabilities.setCapability("sauce:options", sauceCapabilities);
+        return capabilities;
+    }
+
+    public String getBuild() {
+        if (build != null) {
+            return build;
+        } else if (SystemManager.get(knownCITools.get("Jenkins")) != null) {
+            return SystemManager.get("BUILD_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
+        } else if (SystemManager.get(knownCITools.get("Bamboo")) != null) {
+            return SystemManager.get("bamboo_shortJobName") + ": " + SystemManager.get("bamboo_buildNumber");
+        } else if (SystemManager.get(knownCITools.get("Travis")) != null) {
+            return SystemManager.get("TRAVIS_JOB_NAME") + ": " + SystemManager.get("TRAVIS_JOB_NUMBER");
+        } else if (SystemManager.get(knownCITools.get("Circle")) != null) {
+            return SystemManager.get("CIRCLE_JOB") + ": " + SystemManager.get("CIRCLE_BUILD_NUM");
+        } else if (SystemManager.get(knownCITools.get("GitLab")) != null) {
+            return SystemManager.get("CI_JOB_NAME") + ": " + SystemManager.get("CI_JOB_ID");
+        } else if (SystemManager.get(knownCITools.get("TeamCity")) != null) {
+            return SystemManager.get("TEAMCITY_PROJECT_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
+        } else {
+            return "Build Time: " + System.currentTimeMillis();
+        }
+    }
+
+    public boolean isKnownCI() {
+        return !knownCITools.keySet().stream().allMatch((key) -> SystemManager.get(key) == null);
+    }
+
+    /**
+     * As an alternative to using the provided methods, this allows users to merge in capabilites from a Map
+     * The primary use case is to pull information from a JSON/YAML file and convert it into a MAP
+     * This is a recommended pattern to avoid conditionals in code
+     *
+     * @param capabilities map provided to merge into resulting Selenium MutableCapabilities instance
+     */
+    public void mergeCapabilities(Map<String, Object> capabilities) {
+        capabilities.forEach(this::setCapability);
+    }
+
+    /**
+     * This method is to handle special cases and enums as necessary
+     * Default delegates responsibility to CapabilityManager
+     *
+     * @param key   Which capability to set on this instance's Selenium MutableCapabilities instance
+     * @param value The value of the capability getting set
+     */
+    public void setCapability(String key, Object value) {
+        switch (key) {
+            case "browserName":
+                capabilityManager.validateCapability("Browser", Browser.keys(), (String) value);
+                setBrowserName(Browser.valueOf(Browser.fromString((String) value)));
+                break;
+            case "platformName":
+                capabilityManager.validateCapability("SaucePlatform", SaucePlatform.keys(), (String) value);
+                setPlatformName(SaucePlatform.valueOf(SaucePlatform.fromString((String) value)));
+                break;
+            case "pageLoadStrategy":
+                capabilityManager.validateCapability("PageLoadStrategy", PageLoadStrategy.keys(), (String) value);
+                setPageLoadStrategy(PageLoadStrategy.valueOf(PageLoadStrategy.fromString((String) value)));
+                break;
+            case "unhandledPromptBehavior":
+                capabilityManager.validateCapability("UnhandledPromptBehavior", UnhandledPromptBehavior.keys(), (String) value);
+                setUnhandledPromptBehavior(UnhandledPromptBehavior.valueOf(UnhandledPromptBehavior.fromString((String) value)));
+                break;
+            case "timeouts":
+                Map<Timeouts, Integer> timeoutsMap = new HashMap<>();
+                ((Map) value).forEach((oldKey, val) -> {
+                    capabilityManager.validateCapability("Timeouts", Timeouts.keys(), (String) oldKey);
+                    String keyString = Timeouts.fromString((String) oldKey);
+                    timeoutsMap.put(Timeouts.valueOf(keyString), (Integer) val);
+                });
+                setTimeouts(timeoutsMap);
+                break;
+            case "jobVisibility":
+                capabilityManager.validateCapability("JobVisibility", JobVisibility.keys(), (String) value);
+                setJobVisibility(JobVisibility.valueOf(JobVisibility.fromString((String) value)));
+                break;
+            case "prerun":
+                Map<Prerun, Object> prerunMap = new HashMap<>();
+                ((Map) value).forEach((oldKey, val) -> {
+                    capabilityManager.validateCapability("Prerun", Prerun.keys(), (String) oldKey);
+                    String keyString = Prerun.fromString((String) oldKey);
+                    prerunMap.put(Prerun.valueOf(keyString), val);
+                });
+                setPrerun(prerunMap);
+                break;
+            default:
+                capabilityManager.setCapability(key, value);
+        }
+    }
+
+    protected String getSauceUsername() {
+        return SystemManager.get("SAUCE_USERNAME", "Sauce Username was not provided");
+    }
+
+    protected String getSauceAccessKey() {
+        return SystemManager.get("SAUCE_ACCESS_KEY", "Sauce Access Key was not provided");
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsDeprecatedTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsDeprecatedTest.java
@@ -1,7 +1,6 @@
 package com.saucelabs.saucebindings;
 
 import com.saucelabs.saucebindings.options.InvalidSauceOptionsArgumentException;
-import com.saucelabs.saucebindings.options.SauceOptions;
 import lombok.SneakyThrows;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.openqa.selenium.UnexpectedAlertBehaviour.DISMISS;
 
-public class SauceOptionsTest {
+public class SauceOptionsDeprecatedTest {
     private SauceOptions sauceOptions = new SauceOptions();
 
     @Rule
@@ -170,7 +169,7 @@ public class SauceOptionsTest {
         sauceOptions = new SauceOptions(chromeOptions);
 
         assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
-        assertEquals(chromeOptions, sauceOptions.getCapabilities());
+        assertEquals(chromeOptions, sauceOptions.getSeleniumCapabilities());
     }
 
     @Test
@@ -181,7 +180,7 @@ public class SauceOptionsTest {
         sauceOptions = new SauceOptions(edgeOptions);
 
         assertEquals(Browser.EDGE, sauceOptions.getBrowserName());
-        assertEquals(edgeOptions, sauceOptions.getCapabilities());
+        assertEquals(edgeOptions, sauceOptions.getSeleniumCapabilities());
     }
 
     @Test
@@ -194,7 +193,7 @@ public class SauceOptionsTest {
         sauceOptions = new SauceOptions(firefoxOptions);
 
         assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
-        assertEquals(firefoxOptions, sauceOptions.getCapabilities());
+        assertEquals(firefoxOptions, sauceOptions.getSeleniumCapabilities());
     }
 
     @Test
@@ -207,7 +206,7 @@ public class SauceOptionsTest {
         sauceOptions = new SauceOptions(internetExplorerOptions);
 
         assertEquals(Browser.INTERNET_EXPLORER, sauceOptions.getBrowserName());
-        assertEquals(internetExplorerOptions, sauceOptions.getCapabilities());
+        assertEquals(internetExplorerOptions, sauceOptions.getSeleniumCapabilities());
     }
 
     @Test
@@ -219,7 +218,7 @@ public class SauceOptionsTest {
         sauceOptions = new SauceOptions(safariOptions);
 
         assertEquals(Browser.SAFARI, sauceOptions.getBrowserName());
-        assertEquals(safariOptions, sauceOptions.getCapabilities());
+        assertEquals(safariOptions, sauceOptions.getSeleniumCapabilities());
     }
 
     @Test

--- a/java/src/test/java/com/saucelabs/saucebindings/deprecated_options.yml
+++ b/java/src/test/java/com/saucelabs/saucebindings/deprecated_options.yml
@@ -1,0 +1,56 @@
+exampleValues:
+  browserName: 'firefox'
+  browserVersion: '68'
+  platformName: 'macOS 10.13'
+  acceptInsecureCerts: true
+  pageLoadStrategy: 'eager'
+  setWindowRect: true
+  unhandledPromptBehavior: "accept"
+  strictFileInteractability: true
+  timeouts:
+    implicit: 1
+    pageLoad: 59
+    script: 29
+  avoidProxy: true
+  build: 'Sample Build Name'
+  capturePerformance: true
+  chromedriverVersion: '71'
+  commandTimeout: 2
+  customData:
+    foo: 'foo'
+    bar: 'bar'
+  extendedDebugging: true
+  idleTimeout: 3
+  iedriverVersion: '3.141.0'
+  maxDuration: 300
+  name: 'Sample Test Name'
+  parentTunnel: 'Mommy'
+  prerun:
+    executable: "http://url.to/your/executable.exe"
+    args:
+      - --silent
+      - -a
+      - -q
+    background: false
+    timeout: 120
+  priority: 0
+  jobVisibility: 'team'
+  recordLogs: false
+  recordScreenshots: false
+  recordVideo: false
+  screenResolution: '10x10'
+  seleniumVersion: '3.141.59'
+  tags:
+    - foo
+    - bar
+    - foobar
+  timeZone: 'San Francisco'
+  tunnelIdentifier: 'tunnelname'
+  videoUploadOnPass: false
+
+badJobVisibility:
+  jobVisibility: "me"
+
+badPrerun:
+  prerun:
+    nope: ""

--- a/java/src/test/java/com/saucelabs/saucebindings/integration/DesktopBrowserTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/integration/DesktopBrowserTest.java
@@ -1,7 +1,7 @@
 package com.saucelabs.saucebindings.integration;
 
 import com.saucelabs.saucebindings.DataCenter;
-import com.saucelabs.saucebindings.SauceOptions;
+import com.saucelabs.saucebindings.options.SauceOptions;;
 import com.saucelabs.saucebindings.SaucePlatform;
 import com.saucelabs.saucebindings.SauceSession;
 import org.junit.After;

--- a/java/src/test/java/com/saucelabs/saucebindings/options.yml
+++ b/java/src/test/java/com/saucelabs/saucebindings/options.yml
@@ -11,42 +11,43 @@ exampleValues:
     implicit: 1
     pageLoad: 59
     script: 29
-  avoidProxy: true
-  build: 'Sample Build Name'
-  capturePerformance: true
-  chromedriverVersion: '71'
-  commandTimeout: 2
-  customData:
-    foo: 'foo'
-    bar: 'bar'
-  extendedDebugging: true
-  idleTimeout: 3
-  iedriverVersion: '3.141.0'
-  maxDuration: 300
-  name: 'Sample Test Name'
-  parentTunnel: 'Mommy'
-  prerun:
-    executable: "http://url.to/your/executable.exe"
-    args:
-      - --silent
-      - -a
-      - -q
-    background: false
-    timeout: 120
-  priority: 0
-  jobVisibility: 'team'
-  recordLogs: false
-  recordScreenshots: false
-  recordVideo: false
-  screenResolution: '10x10'
-  seleniumVersion: '3.141.59'
-  tags:
-    - foo
-    - bar
-    - foobar
-  timeZone: 'San Francisco'
-  tunnelIdentifier: 'tunnelname'
-  videoUploadOnPass: false
+  sauce:
+    avoidProxy: true
+    build: 'Sample Build Name'
+    capturePerformance: true
+    chromedriverVersion: '71'
+    commandTimeout: 2
+    customData:
+      foo: 'foo'
+      bar: 'bar'
+    extendedDebugging: true
+    idleTimeout: 3
+    iedriverVersion: '3.141.0'
+    maxDuration: 300
+    name: 'Sample Test Name'
+    parentTunnel: 'Mommy'
+    prerun:
+      executable: "http://url.to/your/executable.exe"
+      args:
+        - --silent
+        - -a
+        - -q
+      background: false
+      timeout: 120
+    priority: 0
+    jobVisibility: 'team'
+    recordLogs: false
+    recordScreenshots: false
+    recordVideo: false
+    screenResolution: '10x10'
+    seleniumVersion: '3.141.59'
+    tags:
+      - foo
+      - bar
+      - foobar
+    timeZone: 'San Francisco'
+    tunnelIdentifier: 'tunnelname'
+    videoUploadOnPass: false
 
 badBrowser:
   browserName: "netscape"
@@ -55,7 +56,8 @@ badPlatform:
   platformName: "MAC"
 
 badJobVisibility:
-  jobVisibility: "me"
+  sauce:
+    jobVisibility: "me"
 
 badPageLoad:
   browserName: "fast"
@@ -68,12 +70,19 @@ badTimeout:
     bad: 1
 
 badPrerun:
-  prerun:
-    nope: ""
+  sauce:
+    prerun:
+      nope: ""
 
 invalidOption:
   foo: "bar"
   browser_Nme: "firefox"
   browserVersion: "70"
   platformName: "MacOS 10.12"
-  recordScreenshots: false
+
+invalidSauceOption:
+  browser_Nme: "firefox"
+  browserVersion: "70"
+  platformName: "MacOS 10.12"
+  sauce:
+    foo: "bar"

--- a/java/src/test/java/com/saucelabs/saucebindings/options/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/options/SauceOptionsTest.java
@@ -1,8 +1,8 @@
-package com.saucelabs.saucebindings;
+package com.saucelabs.saucebindings.options;
 
-import com.saucelabs.saucebindings.options.InvalidSauceOptionsArgumentException;
-import com.saucelabs.saucebindings.options.SauceOptions;
+import com.saucelabs.saucebindings.*;
 import lombok.SneakyThrows;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
@@ -36,8 +36,8 @@ public class SauceOptionsTest {
 
     @Test
     public void usesLatestChromeWindowsVersionsByDefault() {
-        assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
-        assertEquals(SaucePlatform.WINDOWS_10, sauceOptions.getPlatformName());
+        Assert.assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
+        Assert.assertEquals(SaucePlatform.WINDOWS_10, sauceOptions.getPlatformName());
         assertEquals("latest", sauceOptions.getBrowserVersion());
     }
 
@@ -110,55 +110,55 @@ public class SauceOptionsTest {
         tags.add("Bar");
         tags.add("Foobar");
 
-        sauceOptions.setAvoidProxy(true);
-        sauceOptions.setBuild("Sample Build Name");
-        sauceOptions.setCapturePerformance(true);
-        sauceOptions.setChromedriverVersion("71");
-        sauceOptions.setCommandTimeout(2);
-        sauceOptions.setCustomData(customData);
-        sauceOptions.setExtendedDebugging(true);
-        sauceOptions.setIdleTimeout(3);
-        sauceOptions.setIedriverVersion("3.141.0");
-        sauceOptions.setMaxDuration(300);
-        sauceOptions.setName("Test name");
-        sauceOptions.setParentTunnel("Mommy");
-        sauceOptions.setPrerun(prerun);
-        sauceOptions.setPriority(0);
-        sauceOptions.setJobVisibility(JobVisibility.TEAM);
-        sauceOptions.setRecordLogs(false);
-        sauceOptions.setRecordScreenshots(false);
-        sauceOptions.setRecordVideo(false);
-        sauceOptions.setScreenResolution("10x10");
-        sauceOptions.setSeleniumVersion("3.141.59");
-        sauceOptions.setTags(tags);
-        sauceOptions.setTimeZone("San Francisco");
-        sauceOptions.setTunnelIdentifier("tunnelname");
-        sauceOptions.setVideoUploadOnPass(false);
+        sauceOptions.sauce().setAvoidProxy(true);
+        sauceOptions.sauce().setBuild("Sample Build Name");
+        sauceOptions.sauce().setCapturePerformance(true);
+        sauceOptions.sauce().setChromedriverVersion("71");
+        sauceOptions.sauce().setCommandTimeout(2);
+        sauceOptions.sauce().setCustomData(customData);
+        sauceOptions.sauce().setExtendedDebugging(true);
+        sauceOptions.sauce().setIdleTimeout(3);
+        sauceOptions.sauce().setIedriverVersion("3.141.0");
+        sauceOptions.sauce().setMaxDuration(300);
+        sauceOptions.sauce().setName("Test name");
+        sauceOptions.sauce().setParentTunnel("Mommy");
+        sauceOptions.sauce().setPrerun(prerun);
+        sauceOptions.sauce().setPriority(0);
+        sauceOptions.sauce().setJobVisibility(JobVisibility.TEAM);
+        sauceOptions.sauce().setRecordLogs(false);
+        sauceOptions.sauce().setRecordScreenshots(false);
+        sauceOptions.sauce().setRecordVideo(false);
+        sauceOptions.sauce().setScreenResolution("10x10");
+        sauceOptions.sauce().setSeleniumVersion("3.141.59");
+        sauceOptions.sauce().setTags(tags);
+        sauceOptions.sauce().setTimeZone("San Francisco");
+        sauceOptions.sauce().setTunnelIdentifier("tunnelname");
+        sauceOptions.sauce().setVideoUploadOnPass(false);
 
-        assertEquals(true, sauceOptions.getAvoidProxy());
-        assertEquals("Sample Build Name", sauceOptions.getBuild());
-        assertEquals(true, sauceOptions.getCapturePerformance());
-        assertEquals("71", sauceOptions.getChromedriverVersion());
-        assertEquals(Integer.valueOf(2), sauceOptions.getCommandTimeout());
-        assertEquals(customData, sauceOptions.getCustomData());
-        assertEquals(true, sauceOptions.getExtendedDebugging());
-        assertEquals(Integer.valueOf(3), sauceOptions.getIdleTimeout());
-        assertEquals("3.141.0", sauceOptions.getIedriverVersion());
-        assertEquals(Integer.valueOf(300), sauceOptions.getMaxDuration());
-        assertEquals("Test name", sauceOptions.getName());
-        assertEquals("Mommy", sauceOptions.getParentTunnel());
-        assertEquals(prerun, sauceOptions.getPrerun());
-        assertEquals(Integer.valueOf(0), sauceOptions.getPriority());
-        assertEquals(JobVisibility.TEAM, sauceOptions.getJobVisibility());
-        assertEquals(false, sauceOptions.getRecordLogs());
-        assertEquals(false, sauceOptions.getRecordScreenshots());
-        assertEquals(false, sauceOptions.getRecordVideo());
-        assertEquals("10x10", sauceOptions.getScreenResolution());
-        assertEquals("3.141.59", sauceOptions.getSeleniumVersion());
-        assertEquals(tags, sauceOptions.getTags());
-        assertEquals("San Francisco", sauceOptions.getTimeZone());
-        assertEquals("tunnelname", sauceOptions.getTunnelIdentifier());
-        assertEquals(false, sauceOptions.getVideoUploadOnPass());
+        assertEquals(true, sauceOptions.sauce().getAvoidProxy());
+        assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
+        assertEquals(true, sauceOptions.sauce().getCapturePerformance());
+        assertEquals("71", sauceOptions.sauce().getChromedriverVersion());
+        assertEquals(Integer.valueOf(2), sauceOptions.sauce().getCommandTimeout());
+        assertEquals(customData, sauceOptions.sauce().getCustomData());
+        assertEquals(true, sauceOptions.sauce().getExtendedDebugging());
+        assertEquals(Integer.valueOf(3), sauceOptions.sauce().getIdleTimeout());
+        assertEquals("3.141.0", sauceOptions.sauce().getIedriverVersion());
+        assertEquals(Integer.valueOf(300), sauceOptions.sauce().getMaxDuration());
+        assertEquals("Test name", sauceOptions.sauce().getName());
+        assertEquals("Mommy", sauceOptions.sauce().getParentTunnel());
+        assertEquals(prerun, sauceOptions.sauce().getPrerun());
+        assertEquals(Integer.valueOf(0), sauceOptions.sauce().getPriority());
+        assertEquals(JobVisibility.TEAM, sauceOptions.sauce().getJobVisibility());
+        assertEquals(false, sauceOptions.sauce().getRecordLogs());
+        assertEquals(false, sauceOptions.sauce().getRecordScreenshots());
+        assertEquals(false, sauceOptions.sauce().getRecordVideo());
+        assertEquals("10x10", sauceOptions.sauce().getScreenResolution());
+        assertEquals("3.141.59", sauceOptions.sauce().getSeleniumVersion());
+        assertEquals(tags, sauceOptions.sauce().getTags());
+        assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
+        assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
+        assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());
     }
 
     @Test
@@ -224,7 +224,7 @@ public class SauceOptionsTest {
 
     @Test
     public void createsDefaultBuildName() {
-        assertNotNull(sauceOptions.getBuild());
+        assertNotNull(sauceOptions.sauce().getBuild());
     }
 
     @SneakyThrows
@@ -275,30 +275,30 @@ public class SauceOptionsTest {
         assertEquals(UnhandledPromptBehavior.ACCEPT, sauceOptions.getUnhandledPromptBehavior());
         assertEquals(true, sauceOptions.getStrictFileInteractability());
         assertEquals(timeouts, sauceOptions.getTimeouts());
-        assertEquals(true, sauceOptions.getAvoidProxy());
-        assertEquals("Sample Build Name", sauceOptions.getBuild());
-        assertEquals(true, sauceOptions.getCapturePerformance());
-        assertEquals("71", sauceOptions.getChromedriverVersion());
-        assertEquals(Integer.valueOf(2), sauceOptions.getCommandTimeout());
-        assertEquals(customData, sauceOptions.getCustomData());
-        assertEquals(true, sauceOptions.getExtendedDebugging());
-        assertEquals(Integer.valueOf(3), sauceOptions.getIdleTimeout());
-        assertEquals("3.141.0", sauceOptions.getIedriverVersion());
-        assertEquals(Integer.valueOf(300), sauceOptions.getMaxDuration());
-        assertEquals("Sample Test Name", sauceOptions.getName());
-        assertEquals("Mommy", sauceOptions.getParentTunnel());
-        assertEquals(prerun, sauceOptions.getPrerun());
-        assertEquals(Integer.valueOf(0), sauceOptions.getPriority());
-        assertEquals(JobVisibility.TEAM, sauceOptions.getJobVisibility());
-        assertEquals(false, sauceOptions.getRecordLogs());
-        assertEquals(false, sauceOptions.getRecordScreenshots());
-        assertEquals(false, sauceOptions.getRecordVideo());
-        assertEquals("10x10", sauceOptions.getScreenResolution());
-        assertEquals("3.141.59", sauceOptions.getSeleniumVersion());
-        assertEquals(tags, sauceOptions.getTags());
-        assertEquals("San Francisco", sauceOptions.getTimeZone());
-        assertEquals("tunnelname", sauceOptions.getTunnelIdentifier());
-        assertEquals(false, sauceOptions.getVideoUploadOnPass());
+        assertEquals(true, sauceOptions.sauce().getAvoidProxy());
+        assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
+        assertEquals(true, sauceOptions.sauce().getCapturePerformance());
+        assertEquals("71", sauceOptions.sauce().getChromedriverVersion());
+        assertEquals(Integer.valueOf(2), sauceOptions.sauce().getCommandTimeout());
+        assertEquals(customData, sauceOptions.sauce().getCustomData());
+        assertEquals(true, sauceOptions.sauce().getExtendedDebugging());
+        assertEquals(Integer.valueOf(3), sauceOptions.sauce().getIdleTimeout());
+        assertEquals("3.141.0", sauceOptions.sauce().getIedriverVersion());
+        assertEquals(Integer.valueOf(300), sauceOptions.sauce().getMaxDuration());
+        assertEquals("Sample Test Name", sauceOptions.sauce().getName());
+        assertEquals("Mommy", sauceOptions.sauce().getParentTunnel());
+        assertEquals(prerun, sauceOptions.sauce().getPrerun());
+        assertEquals(Integer.valueOf(0), sauceOptions.sauce().getPriority());
+        assertEquals(JobVisibility.TEAM, sauceOptions.sauce().getJobVisibility());
+        assertEquals(false, sauceOptions.sauce().getRecordLogs());
+        assertEquals(false, sauceOptions.sauce().getRecordScreenshots());
+        assertEquals(false, sauceOptions.sauce().getRecordVideo());
+        assertEquals("10x10", sauceOptions.sauce().getScreenResolution());
+        assertEquals("3.141.59", sauceOptions.sauce().getSeleniumVersion());
+        assertEquals(tags, sauceOptions.sauce().getTags());
+        assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
+        assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
+        assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());
     }
 
     @Test(expected = InvalidSauceOptionsArgumentException.class)
@@ -356,7 +356,7 @@ public class SauceOptionsTest {
         sauceOptions.timeout.setImplicitWait(1);
         sauceOptions.timeout.setPageLoad(100);
         sauceOptions.timeout.setScript(10);
-        sauceOptions.setBuild("Build Name");
+        sauceOptions.sauce().setBuild("Build Name");
 
         Map<Timeouts, Integer> timeouts = new HashMap<>();
         timeouts.put(Timeouts.IMPLICIT, 1);
@@ -406,30 +406,30 @@ public class SauceOptionsTest {
         tags.add("Bar");
         tags.add("Foobar");
 
-        sauceOptions.setAvoidProxy(true);
-        sauceOptions.setBuild("Sample Build Name");
-        sauceOptions.setCapturePerformance(true);
-        sauceOptions.setChromedriverVersion("71");
-        sauceOptions.setCommandTimeout(2);
-        sauceOptions.setCustomData(customData);
-        sauceOptions.setExtendedDebugging(true);
-        sauceOptions.setIdleTimeout(3);
-        sauceOptions.setIedriverVersion("3.141.0");
-        sauceOptions.setMaxDuration(300);
-        sauceOptions.setName("Test name");
-        sauceOptions.setParentTunnel("Mommy");
-        sauceOptions.setPrerun(prerun);
-        sauceOptions.setPriority(0);
-        sauceOptions.setJobVisibility(JobVisibility.TEAM);
-        sauceOptions.setRecordLogs(false);
-        sauceOptions.setRecordScreenshots(false);
-        sauceOptions.setRecordVideo(false);
-        sauceOptions.setScreenResolution("10x10");
-        sauceOptions.setSeleniumVersion("3.141.59");
-        sauceOptions.setTags(tags);
-        sauceOptions.setTimeZone("San Francisco");
-        sauceOptions.setTunnelIdentifier("tunnelname");
-        sauceOptions.setVideoUploadOnPass(false);
+        sauceOptions.sauce().setAvoidProxy(true);
+        sauceOptions.sauce().setBuild("Sample Build Name");
+        sauceOptions.sauce().setCapturePerformance(true);
+        sauceOptions.sauce().setChromedriverVersion("71");
+        sauceOptions.sauce().setCommandTimeout(2);
+        sauceOptions.sauce().setCustomData(customData);
+        sauceOptions.sauce().setExtendedDebugging(true);
+        sauceOptions.sauce().setIdleTimeout(3);
+        sauceOptions.sauce().setIedriverVersion("3.141.0");
+        sauceOptions.sauce().setMaxDuration(300);
+        sauceOptions.sauce().setName("Test name");
+        sauceOptions.sauce().setParentTunnel("Mommy");
+        sauceOptions.sauce().setPrerun(prerun);
+        sauceOptions.sauce().setPriority(0);
+        sauceOptions.sauce().setJobVisibility(JobVisibility.TEAM);
+        sauceOptions.sauce().setRecordLogs(false);
+        sauceOptions.sauce().setRecordScreenshots(false);
+        sauceOptions.sauce().setRecordVideo(false);
+        sauceOptions.sauce().setScreenResolution("10x10");
+        sauceOptions.sauce().setSeleniumVersion("3.141.59");
+        sauceOptions.sauce().setTags(tags);
+        sauceOptions.sauce().setTimeZone("San Francisco");
+        sauceOptions.sauce().setTunnelIdentifier("tunnelname");
+        sauceOptions.sauce().setVideoUploadOnPass(false);
 
         MutableCapabilities sauceCapabilities = new MutableCapabilities();
         sauceCapabilities.setCapability("avoidProxy", true);
@@ -479,7 +479,7 @@ public class SauceOptionsTest {
         firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
 
         sauceOptions = new SauceOptions(firefoxOptions);
-        sauceOptions.setBuild("Build Name");
+        sauceOptions.sauce().setBuild("Build Name");
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
         expectedCapabilities.setCapability("browserName", "firefox");
@@ -513,7 +513,7 @@ public class SauceOptionsTest {
         expectedCapabilities.setCapability("platformName", "Windows 10");
         expectedCapabilities.setCapability("acceptInsecureCerts", true);
 
-        sauceOptions.setBuild("CUSTOM BUILD: 12");
+        sauceOptions.sauce().setBuild("CUSTOM BUILD: 12");
         sauceCapabilities.setCapability("build", "CUSTOM BUILD: 12");
 
         sauceOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
@@ -531,14 +531,14 @@ public class SauceOptionsTest {
         sauceOptions.setUnhandledPromptBehavior(UnhandledPromptBehavior.IGNORE);
         expectedCapabilities.setCapability("unhandledPromptBehavior", UnhandledPromptBehavior.IGNORE);
 
-        sauceOptions.setExtendedDebugging(true);
+        sauceOptions.sauce().setExtendedDebugging(true);
         sauceCapabilities.setCapability("extendedDebugging", true);
-        sauceOptions.setName("Test name");
+        sauceOptions.sauce().setName("Test name");
         sauceCapabilities.setCapability("name", "Test name");
-        sauceOptions.setParentTunnel("Mommy");
+        sauceOptions.sauce().setParentTunnel("Mommy");
         sauceCapabilities.setCapability("parentTunnel", "Mommy");
 
-        sauceOptions.setJobVisibility(JobVisibility.SHARE);
+        sauceOptions.sauce().setJobVisibility(JobVisibility.SHARE);
         sauceCapabilities.setCapability("public", JobVisibility.SHARE);
         sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
         sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));


### PR DESCRIPTION
This is in DRAFT status because it relies on #230 
This supersedes PR #226 

All Sauce Labs options will be accessed with `sauce()` method instead of directly.
This is completely backward compatible, with the old setters marked as deprecated.

The idea with this is to treat capabilities differently based on how they need to go into the capabilities. 
`SauceOptions` --> top level / w3c compliant parameters
`SauceLabsOptions` --> parameters that go inside `sauce:options`

Then we'll add:
VisualOptions --> parameters that go inside `sauce:visual`
Then maybe we'll add (ideally we have users do what they do with Browsers & Selenium pass them in as constructors, but perhaps the ones we've been promoting on our site need to be able to be added directly)
AppiumOptions --> parameters prepended with `appium:`

Deprecated methods are being tested in `SauceOptionsDeprecatedTest.java`
`SauceOptionsTest.java` tests have all been updated to the new approach.