### PR TITLE
[java] implement visual options as a subclass

### DIFF
--- a/java/src/main/java/com/saucelabs/saucebindings/BaseOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/BaseOptions.java
@@ -1,0 +1,25 @@
+package com.saucelabs.saucebindings;
+
+import lombok.Getter;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.util.List;
+import java.util.Map;
+
+public abstract class BaseOptions {
+    @Getter protected MutableCapabilities capabilities = new MutableCapabilities();
+    protected CapabilityManager capabilityManager;
+    @Getter public final List<String> validOptions = null;
+
+    // Use Case is pulling serialized information from JSON/YAML, converting it to a HashMap and passing it in
+    // This is a preferred pattern as it avoids conditionals in code
+    public void mergeCapabilities(Map<String, Object> mergingCapabilities) {
+        mergingCapabilities.forEach(this::setCapability);
+    }
+
+    // This dynamically calls setter
+    // Applicable enums must override this method in subclass
+    protected void setCapability(String key, Object value) {
+        capabilityManager.setCapability(key, value);
+    };
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/CapabilityManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/CapabilityManager.java
@@ -1,27 +1,23 @@
 package com.saucelabs.saucebindings;
 
-import org.openqa.selenium.MutableCapabilities;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.List;
 import java.util.Set;
 
 public class CapabilityManager {
-    private final SauceOptions options;
+    private final BaseOptions options;
 
-    public CapabilityManager(SauceOptions options) {
+    public CapabilityManager(BaseOptions options) {
         this.options = options;
     }
 
-    public MutableCapabilities addCapabilities(MutableCapabilities capabilities, List<String> validOptions) {
-        validOptions.forEach((capability) -> {
+    public void addCapabilities() {
+        options.getValidOptions().forEach((capability) -> {
             Object value = getCapability(capability);
             if (value != null) {
-                capabilities.setCapability(capability, value);
+                options.capabilities.setCapability(capability, value);
             }
         });
-        return capabilities;
     }
 
     public void setCapability(String key, Object value) {

--- a/java/src/main/java/com/saucelabs/saucebindings/CapabilityManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/CapabilityManager.java
@@ -1,0 +1,57 @@
+package com.saucelabs.saucebindings;
+
+import org.openqa.selenium.MutableCapabilities;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Set;
+
+public class CapabilityManager {
+    private final SauceOptions options;
+
+    public CapabilityManager(SauceOptions options) {
+        this.options = options;
+    }
+
+    public MutableCapabilities addCapabilities(MutableCapabilities capabilities, List<String> validOptions) {
+        validOptions.forEach((capability) -> {
+            Object value = getCapability(capability);
+            if (value != null) {
+                capabilities.setCapability(capability, value);
+            }
+        });
+        return capabilities;
+    }
+
+    public void setCapability(String key, Object value) {
+        try {
+            Class<?> type = options.getClass().getDeclaredField(key).getType();
+            String setter = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
+            Method method = options.getClass().getDeclaredMethod(setter, type);
+            method.invoke(options, value);
+        } catch (NoSuchFieldException e) {
+            throw new InvalidSauceOptionsArgumentException(key + " is not a valid configuration value");
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public Object getCapability(String capability) {
+        try {
+            String getter = "get" + capability.substring(0, 1).toUpperCase() + capability.substring(1);
+            Method method = options.getClass().getDeclaredMethod(getter);
+            return method.invoke(options);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public void validateCapability(String name, Set values, String value) {
+        if (!values.contains(value)) {
+            String message = value + " is not a valid " + name + ", please choose from: " + values;
+            throw new InvalidSauceOptionsArgumentException(message);
+        }
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/InvalidSauceOptionsArgumentException.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/InvalidSauceOptionsArgumentException.java
@@ -1,6 +1,6 @@
 package com.saucelabs.saucebindings;
 
-class InvalidSauceOptionsArgumentException extends RuntimeException {
+public class InvalidSauceOptionsArgumentException extends RuntimeException {
     public InvalidSauceOptionsArgumentException(String message) {
         super(message);
     }

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceLabsOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceLabsOptions.java
@@ -1,0 +1,156 @@
+package com.saucelabs.saucebindings;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Accessors(chain = true) @Setter @Getter
+public class SauceLabsOptions extends BaseOptions {
+    // https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+    private Boolean avoidProxy = null;
+    private String build;
+    private Boolean capturePerformance = null;
+    private String chromedriverVersion;
+    private Integer commandTimeout = null;
+    private Map<String, Object> customData = null;
+    private Boolean extendedDebugging = null;
+    private Integer idleTimeout = null;
+    private String iedriverVersion;
+    private Integer maxDuration = null;
+    private String name;
+    private String parentTunnel;
+    private Map<Prerun, Object> prerun;
+    private URL prerunUrl;
+    private Integer priority = null;
+    private JobVisibility jobVisibility; // the actual key for this is a Java reserved keyword "public"; uses enum
+    private Boolean recordLogs = null;
+    private Boolean recordScreenshots = null;
+    private Boolean recordVideo = null;
+    private String screenResolution;
+    private String seleniumVersion;
+    private List<String> tags = null;
+    private String timeZone;
+    private String tunnelIdentifier;
+    private Boolean videoUploadOnPass = null;
+
+    public final List<String> validOptions = Arrays.asList(
+            "avoidProxy",
+            "build",
+            "capturePerformance",
+            "chromedriverVersion",
+            "commandTimeout",
+            "customData",
+            "extendedDebugging",
+            "idleTimeout",
+            "iedriverVersion",
+            "jobVisibility",
+            "maxDuration",
+            "name",
+            "parentTunnel",
+            "prerun",
+            "prerunUrl",
+            "priority",
+            // public, do not use, reserved keyword, using jobVisibility with enum
+            "recordLogs",
+            "recordScreenshots",
+            "recordVideo",
+            "screenResolution",
+            "seleniumVersion",
+            "tags",
+            "timeZone",
+            "tunnelIdentifier",
+            "videoUploadOnPass");
+
+    public SauceLabsOptions() {
+        capabilityManager = new CapabilityManager(this);
+    }
+
+    public MutableCapabilities toCapabilities() {
+        capabilities.setCapability("username", getSauceUsername());
+        capabilities.setCapability("accessKey", getSauceAccessKey());
+
+        Object visibilityValue = capabilityManager.getCapability("jobVisibility");
+        if (visibilityValue != null) {
+            capabilities.setCapability("public", visibilityValue);
+            setJobVisibility(null);
+        }
+
+        Object prerunValue = capabilityManager.getCapability("prerunUrl");
+        if (prerunValue != null) {
+            capabilities.setCapability("prerun", prerunValue);
+            setPrerunUrl(null);
+        }
+
+        capabilityManager.addCapabilities();
+        return capabilities;
+    }
+
+    @Override
+    protected void setCapability(String key, Object value) {
+        if ("jobVisibility".equals(key)) {
+            capabilityManager.validateCapability("JobVisibility", JobVisibility.keys(), (String) value);
+            setJobVisibility(JobVisibility.valueOf(JobVisibility.fromString((String) value)));
+        } else if ("prerun".equals(key)) {
+            Map<Prerun, Object> prerunMap = new HashMap<>();
+            ((Map) value).forEach((oldKey, val) -> {
+                capabilityManager.validateCapability("Prerun", Prerun.keys(), (String) oldKey);
+                String keyString = Prerun.fromString((String) oldKey);
+                prerunMap.put(Prerun.valueOf(keyString), val);
+            });
+            setPrerun(prerunMap);
+        } else {
+            super.setCapability(key, value);
+        }
+    }
+
+    public String getBuild() {
+        if (build != null) {
+            return build;
+        } else if (SystemManager.getEnv(knownCITools.get("Jenkins")) != null) {
+            return SystemManager.getEnv("BUILD_NAME") + ": " + SystemManager.getEnv("BUILD_NUMBER");
+        } else if (SystemManager.getEnv(knownCITools.get("Bamboo")) != null) {
+            return SystemManager.getEnv("bamboo_shortJobName") + ": " + SystemManager.getEnv("bamboo_buildNumber");
+        } else if (SystemManager.getEnv(knownCITools.get("Travis")) != null) {
+            return SystemManager.getEnv("TRAVIS_JOB_NAME") + ": " + SystemManager.getEnv("TRAVIS_JOB_NUMBER");
+        } else if (SystemManager.getEnv(knownCITools.get("Circle")) != null) {
+            return SystemManager.getEnv("CIRCLE_JOB") + ": " + SystemManager.getEnv("CIRCLE_BUILD_NUM");
+        } else if (SystemManager.getEnv(knownCITools.get("GitLab")) != null) {
+            return SystemManager.getEnv("CI_JOB_NAME") + ": " + SystemManager.getEnv("CI_JOB_ID");
+        } else if (SystemManager.getEnv(knownCITools.get("TeamCity")) != null) {
+            return SystemManager.getEnv("TEAMCITY_PROJECT_NAME") + ": " + SystemManager.getEnv("BUILD_NUMBER");
+        } else {
+            return "Build Time: " + System.currentTimeMillis();
+        }
+    }
+
+    public boolean isKnownCI() {
+        return !knownCITools.keySet().stream().allMatch((key) -> SystemManager.getEnv(key) == null);
+    }
+
+    public static final Map<String, String> knownCITools;
+
+    static {
+        knownCITools = new HashMap<>();
+        knownCITools.put("Jenkins", "BUILD_TAG");
+        knownCITools.put("Bamboo", "bamboo_agentId");
+        knownCITools.put("Travis", "TRAVIS_JOB_ID");
+        knownCITools.put("Circle", "CIRCLE_JOB");
+        knownCITools.put("GitLab", "CI");
+        knownCITools.put("TeamCity", "TEAMCITY_PROJECT_NAME");
+    }
+
+    protected String getSauceUsername() {
+        return SystemManager.get("SAUCE_USERNAME", "Sauce Username was not provided");
+    }
+
+    protected String getSauceAccessKey() {
+        return SystemManager.get("SAUCE_ACCESS_KEY", "Sauce Access Key was not provided");
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -22,6 +22,7 @@ import java.util.Map;
 @Setter @Getter
 public class SauceOptions extends BaseOptions {
     @Setter(AccessLevel.NONE) @Getter(AccessLevel.NONE) private SauceLabsOptions sauceLabsOptions = null;
+    @Setter(AccessLevel.NONE) @Getter(AccessLevel.NONE) private VisualOptions visualOptions = null;
     public TimeoutStore timeout = new TimeoutStore();
 
     // w3c Settings
@@ -50,6 +51,13 @@ public class SauceOptions extends BaseOptions {
 
     public SauceLabsOptions sauce() {
         return sauceLabsOptions;
+    }
+
+    public VisualOptions visual() {
+        if (visualOptions == null) {
+            visualOptions = new VisualOptions();
+        }
+        return visualOptions;
     }
 
     public SauceOptions() {
@@ -95,6 +103,9 @@ public class SauceOptions extends BaseOptions {
     public MutableCapabilities toCapabilities() {
         capabilityManager.addCapabilities();
         capabilities.setCapability("sauce:options", sauce().toCapabilities());
+        if (visualOptions != null) {
+            capabilities.setCapability("sauce:visual", visualOptions.toCapabilities());
+        }
         return capabilities;
     }
 
@@ -123,6 +134,8 @@ public class SauceOptions extends BaseOptions {
             setTimeouts(timeoutsMap);
         } else if ("sauce".equals(key)) {
             sauce().mergeCapabilities((HashMap<String, Object>) value);
+        } else if ("visual".equals(key)) {
+            visual().mergeCapabilities((HashMap<String, Object>) value);
         } else if (sauce().getValidOptions().contains(key)) {
             deprecatedSetCapability(key, value);
         } else {

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -12,8 +12,6 @@ import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.ie.InternetExplorerOptions;
 import org.openqa.selenium.safari.SafariOptions;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -22,9 +20,8 @@ import java.util.Map;
 
 @Accessors(chain = true)
 @Setter @Getter
-public class SauceOptions {
-    @Setter(AccessLevel.NONE) private MutableCapabilities capabilities;
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) private CapabilityManager capabilityManager;
+public class SauceOptions extends BaseOptions {
+    @Setter(AccessLevel.NONE) @Getter(AccessLevel.NONE) private SauceLabsOptions sauceLabsOptions = null;
     public TimeoutStore timeout = new TimeoutStore();
 
     // w3c Settings
@@ -39,34 +36,7 @@ public class SauceOptions {
     private Boolean strictFileInteractability = null;
     private UnhandledPromptBehavior unhandledPromptBehavior;
 
-    // Sauce Settings
-    private Boolean avoidProxy = null;
-    private String build;
-    private Boolean capturePerformance = null;
-    private String chromedriverVersion;
-    private Integer commandTimeout = null;
-    private Map<String, Object> customData = null;
-    private Boolean extendedDebugging = null;
-    private Integer idleTimeout = null;
-    private String iedriverVersion;
-    private Integer maxDuration = null;
-    private String name;
-    private String parentTunnel;
-    private Map<Prerun, Object> prerun;
-    private URL prerunUrl;
-    private Integer priority = null;
-    private JobVisibility jobVisibility; // the actual key for this is a Java reserved keyword "public"
-    private Boolean recordLogs = null;
-    private Boolean recordScreenshots = null;
-    private Boolean recordVideo = null;
-    private String screenResolution;
-    private String seleniumVersion;
-    private List<String> tags = null;
-    private String timeZone;
-    private String tunnelIdentifier;
-    private Boolean videoUploadOnPass = null;
-
-    public static final List<String> w3cDefinedOptions = Arrays.asList(
+    public final List<String> validOptions = Arrays.asList(
             "browserName",
             "browserVersion",
             "platformName",
@@ -78,41 +48,8 @@ public class SauceOptions {
             "strictFileInteractability",
             "unhandledPromptBehavior");
 
-    public static final List<String> sauceDefinedOptions = Arrays.asList(
-            "avoidProxy",
-            "build",
-            "capturePerformance",
-            "chromedriverVersion",
-            "commandTimeout",
-            "customData",
-            "extendedDebugging",
-            "idleTimeout",
-            "iedriverVersion",
-            "maxDuration",
-            "name",
-            "parentTunnel",
-            "prerun",
-            "priority",
-            // public, do not use, reserved keyword, using jobVisibility
-            "recordLogs",
-            "recordScreenshots",
-            "recordVideo",
-            "screenResolution",
-            "seleniumVersion",
-            "tags",
-            "timeZone",
-            "tunnelIdentifier",
-            "videoUploadOnPass");
-
-    public static final Map<String, String> knownCITools;
-    static {
-        knownCITools = new HashMap<>();
-        knownCITools.put("Jenkins", "BUILD_TAG");
-        knownCITools.put("Bamboo", "bamboo_agentId");
-        knownCITools.put("Travis", "TRAVIS_JOB_ID");
-        knownCITools.put("Circle", "CIRCLE_JOB");
-        knownCITools.put("GitLab", "CI");
-        knownCITools.put("TeamCity", "TEAMCITY_PROJECT_NAME");
+    public SauceLabsOptions sauce() {
+        return sauceLabsOptions;
     }
 
     public SauceOptions() {
@@ -149,65 +86,21 @@ public class SauceOptions {
     private SauceOptions(MutableCapabilities options) {
         capabilities = new MutableCapabilities(options.asMap());
         capabilityManager = new CapabilityManager(this);
+        sauceLabsOptions = new SauceLabsOptions();
         if (options.getCapability("browserName") != null) {
             setCapability("browserName", options.getCapability("browserName"));
         }
     }
 
     public MutableCapabilities toCapabilities() {
-        capabilityManager.addCapabilities(capabilities, w3cDefinedOptions);
-
-        MutableCapabilities sauceCapabilities = new MutableCapabilities();
-        sauceCapabilities.setCapability("username", getSauceUsername());
-        sauceCapabilities.setCapability("accessKey", getSauceAccessKey());
-
-        capabilityManager.addCapabilities(sauceCapabilities, sauceDefinedOptions);
-
-        Object visibilityValue = capabilityManager.getCapability("jobVisibility");
-        if (visibilityValue != null) {
-            sauceCapabilities.setCapability("public", visibilityValue);
-        }
-
-        Object prerunValue = capabilityManager.getCapability("prerunUrl");
-        if (prerunValue != null) {
-            sauceCapabilities.setCapability("prerun", prerunValue);
-        }
-
-        capabilities.setCapability("sauce:options", sauceCapabilities);
+        capabilityManager.addCapabilities();
+        capabilities.setCapability("sauce:options", sauce().toCapabilities());
         return capabilities;
     }
 
-    public String getBuild() {
-        if (build != null) {
-            return build;
-        } else if (SystemManager.get(knownCITools.get("Jenkins")) != null) {
-            return SystemManager.get("BUILD_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
-        } else if (SystemManager.get(knownCITools.get("Bamboo")) != null) {
-            return SystemManager.get("bamboo_shortJobName") + ": " + SystemManager.get("bamboo_buildNumber");
-        } else if (SystemManager.get(knownCITools.get("Travis")) != null) {
-            return SystemManager.get("TRAVIS_JOB_NAME") + ": " + SystemManager.get("TRAVIS_JOB_NUMBER");
-        } else if (SystemManager.get(knownCITools.get("Circle")) != null) {
-            return SystemManager.get("CIRCLE_JOB") + ": " + SystemManager.get("CIRCLE_BUILD_NUM");
-        } else if (SystemManager.get(knownCITools.get("GitLab")) != null) {
-            return SystemManager.get("CI_JOB_NAME") + ": " + SystemManager.get("CI_JOB_ID");
-        } else if (SystemManager.get(knownCITools.get("TeamCity")) != null) {
-            return SystemManager.get("TEAMCITY_PROJECT_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
-        } else {
-            return "Build Time: " + System.currentTimeMillis();
-        }
-    }
-
-    public boolean isKnownCI() {
-        return !knownCITools.keySet().stream().allMatch((key) -> SystemManager.get(key) == null);
-    }
-
-    // Use Case is pulling serialized information from JSON/YAML, converting it to a HashMap and passing it in
-    // This is a preferred pattern as it avoids conditionals in code
-    public void mergeCapabilities(Map<String, Object> capabilities) {
-        capabilities.forEach(this::setCapability);
-    }
-
-    public void setCapability(String key, Object value) {
+    // This will convert string value to an enum if necessary
+    @Override
+    protected void setCapability(String key, Object value) {
         if ("browserName".equals(key)) {
             capabilityManager.validateCapability("Browser", Browser.keys(), (String) value);
             setBrowserName(Browser.valueOf(Browser.fromString((String) value)));
@@ -228,35 +121,504 @@ public class SauceOptions {
                 timeoutsMap.put(Timeouts.valueOf(keyString), (Integer) val);
             });
             setTimeouts(timeoutsMap);
-        } else if ("jobVisibility".equals(key)) {
-            capabilityManager.validateCapability("JobVisibility", JobVisibility.keys(), (String) value);
-            setJobVisibility(JobVisibility.valueOf(JobVisibility.fromString((String) value)));
-        } else if ("prerun".equals(key)) {
-            Map<Prerun, Object> prerunMap = new HashMap<>();
-            ((Map) value).forEach((oldKey, val) -> {
-                capabilityManager.validateCapability("Prerun", Prerun.keys(), (String) oldKey);
-                String keyString = Prerun.fromString((String) oldKey);
-                prerunMap.put(Prerun.valueOf(keyString), val);
-            });
-            setPrerun(prerunMap);
+        } else if ("sauce".equals(key)) {
+            sauce().mergeCapabilities((HashMap<String, Object>) value);
+        } else if (sauce().getValidOptions().contains(key)) {
+            deprecatedSetCapability(key, value);
         } else {
-            try {
-                Class<?> type = SauceOptions.class.getDeclaredField(key).getType();
-                String setter = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
-                Method method = SauceOptions.class.getDeclaredMethod(setter, type);
-                method.invoke(this, value);
-            } catch (NoSuchFieldException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-                e.printStackTrace();
-            }
+            capabilityManager.setCapability(key, value);
         }
     }
 
-    protected String getSauceUsername() {
-        return SystemManager.get("SAUCE_USERNAME", "Sauce Username was not provided");
+    @Deprecated
+    private void deprecatedSetCapability(String key, Object value) {
+        System.out.println("WARNING: using merge() of Map with value of (" + key + ") is DEPRECATED");
+        System.out.println("place this value inside a nested Map with the keyword 'sauce'");
+        sauce().setCapability(key, value);
     }
 
-    protected String getSauceAccessKey() {
-        return SystemManager.get("SAUCE_ACCESS_KEY", "Sauce Access Key was not provided");
+    /**
+     * @deprecated No longer supported
+     * @return
+     */
+    @Deprecated
+    public boolean isKnownCI() {
+        return sauce().isKnownCI();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param avoidProxy
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setAvoidProxy(Boolean avoidProxy) {
+        return sauce().setAvoidProxy(avoidProxy);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param build
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setBuild(String build) {
+        return sauce().setBuild(build);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param capturePerformance
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setCapturePerformance(Boolean capturePerformance) {
+        return sauce().setCapturePerformance(capturePerformance);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param chromedriverVersion
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setChromedriverVersion(String chromedriverVersion) {
+        return sauce().setChromedriverVersion(chromedriverVersion);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param commandTimeout
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setCommandTimeout(Integer commandTimeout) {
+        return sauce().setCommandTimeout(commandTimeout);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param customData
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setCustomData(Map<String, Object> customData) {
+        return sauce().setCustomData(customData);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param extendedDebugging
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setExtendedDebugging(Boolean extendedDebugging) {
+        return sauce().setExtendedDebugging(extendedDebugging);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param idleTimeout
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setIdleTimeout(Integer idleTimeout) {
+        return sauce().setIdleTimeout(idleTimeout);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param iedriverVersion
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setIedriverVersion(String iedriverVersion) {
+        return sauce().setIedriverVersion(iedriverVersion);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param maxDuration
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setMaxDuration(Integer maxDuration) {
+        return sauce().setMaxDuration(maxDuration);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param name
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setName(String name) {
+        return sauce().setName(name);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param parentTunnel
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setParentTunnel(String parentTunnel) {
+        return sauce().setParentTunnel(parentTunnel);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param prerun
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setPrerun(Map<Prerun, Object> prerun) {
+        return sauce().setPrerun(prerun);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param prerunUrl
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setPrerunUrl(URL prerunUrl) {
+        return sauce().setPrerunUrl(prerunUrl);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param priority
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setPriority(Integer priority) {
+        return sauce().setPriority(priority);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param jobVisibility
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setJobVisibility(JobVisibility jobVisibility) {
+        return sauce().setJobVisibility(jobVisibility);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param recordLogs
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setRecordLogs(Boolean recordLogs) {
+        return sauce().setRecordLogs(recordLogs);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param recordScreenshots
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setRecordScreenshots(Boolean recordScreenshots) {
+        return sauce().setRecordScreenshots(recordScreenshots);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param recordVideo
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setRecordVideo(Boolean recordVideo) {
+        return sauce().setRecordVideo(recordVideo);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param screenResolution
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setScreenResolution(String screenResolution) {
+        return sauce().setScreenResolution(screenResolution);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param seleniumVersion
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setSeleniumVersion(String seleniumVersion) {
+        return sauce().setSeleniumVersion(seleniumVersion);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param tags
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setTags(List<String> tags) {
+        return sauce().setTags(tags);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param timeZone
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setTimeZone(String timeZone) {
+        return sauce().setTimeZone(timeZone);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param tunnelIdentifier
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setTunnelIdentifier (String tunnelIdentifier) {
+        return sauce().setTunnelIdentifier(tunnelIdentifier);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @param videoUploadOnPass
+     * @return
+     */
+    @Deprecated
+    public BaseOptions setVideoUploadOnPass(Boolean videoUploadOnPass) {
+        return sauce().setVideoUploadOnPass(videoUploadOnPass);
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getAvoidProxy() {
+        return sauce().getAvoidProxy();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getBuild() {
+        return sauce().getBuild();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getCapturePerformance() {
+        return sauce().getCapturePerformance();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getChromedriverVersion() {
+        return sauce().getChromedriverVersion();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Integer getCommandTimeout() {
+        return sauce().getCommandTimeout();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Map<String, Object> getCustomData() {
+        return sauce().getCustomData();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getExtendedDebugging() {
+        return sauce().getExtendedDebugging();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Integer getIdleTimeout() {
+        return sauce().getIdleTimeout();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getIedriverVersion() {
+        return sauce().getIedriverVersion();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Integer getMaxDuration() {
+        return sauce().getMaxDuration();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getName() {
+        return sauce().getName();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getParentTunnel() {
+        return sauce().getParentTunnel();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Map<Prerun, Object> getPrerun() {
+        return sauce().getPrerun();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public URL getPrerunUrl() {
+        return sauce().getPrerunUrl();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Integer getPriority() {
+        return sauce().getPriority();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public JobVisibility getJobVisibility() {
+        return sauce().getJobVisibility();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getRecordLogs() {
+        return sauce().getRecordLogs();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getRecordScreenshots() {
+        return sauce().getRecordScreenshots();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getRecordVideo() {
+        return sauce().getRecordVideo();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getScreenResolution() {
+        return sauce().getScreenResolution();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getSeleniumVersion() {
+        return sauce().getSeleniumVersion();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public List<String> getTags() {
+        return sauce().getTags();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getTimeZone() {
+        return sauce().getTimeZone();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public String getTunnelIdentifier () {
+        return sauce().getTunnelIdentifier();
+    }
+
+    /**
+     * @deprecated Use with sauce() instead
+     * @return
+     */
+    @Deprecated
+    public Boolean getVideoUploadOnPass() {
+        return sauce().getVideoUploadOnPass();
     }
 
     /**

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -61,7 +61,7 @@ public class SauceSession {
         // The first print statement will automatically populate links on Jenkins to Sauce
         // The second print statement will output the job link to logging/console
         if (this.driver != null) {
-            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", this.driver.getSessionId(), this.sauceOptions.getName());
+            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", this.driver.getSessionId(), this.sauceOptions.sauce().getName());
             String sauceTestLink = String.format("Test Job Link: https://app.saucelabs.com/tests/%s", this.driver.getSessionId());
             System.out.print(sauceReporter + "\n" + sauceTestLink + "\n");
         }

--- a/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
@@ -1,0 +1,29 @@
+package com.saucelabs.saucebindings;
+
+public class SystemManager {
+    protected static String get(String key, String errorMessage) {
+        try {
+            return get(key);
+        } catch (Exception e) {
+            throw new SauceEnvironmentVariablesNotSetException(errorMessage);
+        }
+    }
+
+    public static String get(String key) {
+        if (getProperty(key) != null) {
+            return getProperty(key);
+        } else if (getEnv(key) != null) {
+            return getEnv(key);
+        } else {
+            return getProperty(key);
+        }
+    }
+
+    protected static String getProperty(String key) {
+        return System.getProperty(key);
+    }
+
+    protected static String getEnv(String key) {
+        return System.getenv(key);
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
@@ -1,7 +1,7 @@
 package com.saucelabs.saucebindings;
 
 public class SystemManager {
-    protected static String get(String key, String errorMessage) {
+    public static String get(String key, String errorMessage) {
         try {
             return get(key);
         } catch (Exception e) {
@@ -23,7 +23,7 @@ public class SystemManager {
         return System.getProperty(key);
     }
 
-    protected static String getEnv(String key) {
+    public static String getEnv(String key) {
         return System.getenv(key);
     }
 }

--- a/java/src/main/java/com/saucelabs/saucebindings/VisualOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/VisualOptions.java
@@ -1,0 +1,56 @@
+package com.saucelabs.saucebindings;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Accessors(chain = true) @Setter @Getter
+public class VisualOptions extends BaseOptions {
+
+    // Sauce Visual Settings
+    // https://screener.io/v2/docs/visual-e2e/visual-options
+    private String projectName = "Default Project Name";
+    private String viewportSize;
+    private String branch;
+    private String baseBranch;
+    private Map<String, Object> diffOptions = null;
+    private String ignore = null;   // This probably should be a List not a String, but conversions, ugh
+    private Boolean failOnNewStates = null;
+    private Boolean alwaysAcceptBaseBranch = null;
+    private Boolean disableBranchBaseline = null;
+    private Boolean scrollAndStitchScreenshots = null;
+    private Boolean disableCORS = null;
+
+    public final List<String> validOptions = Arrays.asList(
+            "projectName",
+            "viewportSize",
+            "branch",
+            "baseBranch",
+            "diffOptions",
+            "ignore",
+            "failOnNewStates",
+            "alwaysAcceptBaseBranch",
+            "disableBranchBaseline",
+            "scrollAndStitchScreenshots",
+            "disableCORS");
+
+    public VisualOptions() {
+        capabilityManager = new CapabilityManager(this);
+    }
+
+    public MutableCapabilities toCapabilities() {
+        capabilities.setCapability("apiKey", getScreenerApiKey());
+        capabilityManager.addCapabilities();
+        return capabilities;
+    }
+
+    protected String getScreenerApiKey() {
+        String error = "Screener Access Key was not set in your env variables. Please set SCREENER_API_KEY value.";
+        return SystemManager.get("SCREENER_API_KEY", error);
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/examples/BasicOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/examples/BasicOptions.java
@@ -1,6 +1,9 @@
 package com.saucelabs.saucebindings.examples;
 
 import com.saucelabs.saucebindings.*;
+import com.saucelabs.saucebindings.SauceOptions;
+import com.saucelabs.saucebindings.Browser;
+import com.saucelabs.saucebindings.SaucePlatform;
 import org.junit.Test;
 import org.openqa.selenium.remote.RemoteWebDriver;
 

--- a/java/src/main/java/com/saucelabs/saucebindings/examples/BrowserOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/examples/BrowserOptions.java
@@ -1,6 +1,7 @@
 package com.saucelabs.saucebindings.examples;
 
 import com.saucelabs.saucebindings.*;
+import com.saucelabs.saucebindings.SauceOptions;
 import org.junit.Test;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;

--- a/java/src/main/java/com/saucelabs/saucebindings/examples/SauceSpecificOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/examples/SauceSpecificOptions.java
@@ -1,6 +1,7 @@
 package com.saucelabs.saucebindings.examples;
 
 import com.saucelabs.saucebindings.*;
+import com.saucelabs.saucebindings.SauceOptions;
 import org.junit.Test;
 import org.openqa.selenium.remote.RemoteWebDriver;
 

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsDeprecatedTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsDeprecatedTest.java
@@ -1,0 +1,326 @@
+package com.saucelabs.saucebindings;
+
+import lombok.SneakyThrows;
+import org.junit.Test;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.openqa.selenium.UnexpectedAlertBehaviour.DISMISS;
+
+public class SauceOptionsDeprecatedTest {
+    private SauceOptions sauceOptions = new SauceOptions();
+
+    @Test
+    public void acceptsSauceLabsSettings() {
+        Map<String, Object> customData = new HashMap<>();
+        customData.put("foo", "foo");
+        customData.put("bar", "bar");
+
+        List<String> args = new ArrayList<>();
+        args.add("--silent");
+        args.add("-a");
+        args.add("-q");
+
+        Map<Prerun, Object> prerun = new HashMap<>();
+        prerun.put(Prerun.EXECUTABLE, "http://url.to/your/executable.exe");
+        prerun.put(Prerun.ARGS, args);
+        prerun.put(Prerun.BACKGROUND, false);
+        prerun.put(Prerun.TIMEOUT, 120);
+
+        List<String> tags = new ArrayList<>();
+        tags.add("Foo");
+        tags.add("Bar");
+        tags.add("Foobar");
+
+        sauceOptions.setAvoidProxy(true);
+        sauceOptions.setBuild("Sample Build Name");
+        sauceOptions.setCapturePerformance(true);
+        sauceOptions.setChromedriverVersion("71");
+        sauceOptions.setCommandTimeout(2);
+        sauceOptions.setCustomData(customData);
+        sauceOptions.setExtendedDebugging(true);
+        sauceOptions.setIdleTimeout(3);
+        sauceOptions.setIedriverVersion("3.141.0");
+        sauceOptions.setMaxDuration(300);
+        sauceOptions.setName("Test name");
+        sauceOptions.setParentTunnel("Mommy");
+        sauceOptions.setPrerun(prerun);
+        sauceOptions.setPriority(0);
+        sauceOptions.setJobVisibility(JobVisibility.TEAM);
+        sauceOptions.setRecordLogs(false);
+        sauceOptions.setRecordScreenshots(false);
+        sauceOptions.setRecordVideo(false);
+        sauceOptions.setScreenResolution("10x10");
+        sauceOptions.setSeleniumVersion("3.141.59");
+        sauceOptions.setTags(tags);
+        sauceOptions.setTimeZone("San Francisco");
+        sauceOptions.setTunnelIdentifier("tunnelname");
+        sauceOptions.setVideoUploadOnPass(false);
+
+        assertEquals(true, sauceOptions.getAvoidProxy());
+        assertEquals("Sample Build Name", sauceOptions.getBuild());
+        assertEquals(true, sauceOptions.getCapturePerformance());
+        assertEquals("71", sauceOptions.getChromedriverVersion());
+        assertEquals(Integer.valueOf(2), sauceOptions.getCommandTimeout());
+        assertEquals(customData, sauceOptions.getCustomData());
+        assertEquals(true, sauceOptions.getExtendedDebugging());
+        assertEquals(Integer.valueOf(3), sauceOptions.getIdleTimeout());
+        assertEquals("3.141.0", sauceOptions.getIedriverVersion());
+        assertEquals(Integer.valueOf(300), sauceOptions.getMaxDuration());
+        assertEquals("Test name", sauceOptions.getName());
+        assertEquals("Mommy", sauceOptions.getParentTunnel());
+        assertEquals(prerun, sauceOptions.getPrerun());
+        assertEquals(Integer.valueOf(0), sauceOptions.getPriority());
+        assertEquals(JobVisibility.TEAM, sauceOptions.getJobVisibility());
+        assertEquals(false, sauceOptions.getRecordLogs());
+        assertEquals(false, sauceOptions.getRecordScreenshots());
+        assertEquals(false, sauceOptions.getRecordVideo());
+        assertEquals("10x10", sauceOptions.getScreenResolution());
+        assertEquals("3.141.59", sauceOptions.getSeleniumVersion());
+        assertEquals(tags, sauceOptions.getTags());
+        assertEquals("San Francisco", sauceOptions.getTimeZone());
+        assertEquals("tunnelname", sauceOptions.getTunnelIdentifier());
+        assertEquals(false, sauceOptions.getVideoUploadOnPass());
+    }
+
+    @Test
+    public void createsDefaultBuildName() {
+        assertNotNull(sauceOptions.getBuild());
+    }
+
+    @SneakyThrows
+    public Map<String, Object> serialize(String key) {
+        InputStream input = new FileInputStream(new File("src/test/java/com/saucelabs/saucebindings/deprecated_options.yml"));
+        Yaml yaml = new Yaml();
+        Map<String, Object> data = yaml.load(input);
+        return (Map<String, Object>) data.get(key);
+    }
+
+    @Test
+    public void setsCapabilitiesFromMap() {
+        Map<String, Object> map = serialize("exampleValues");
+
+        sauceOptions.mergeCapabilities(map);
+
+        Map<String, Object> customData = new HashMap<>();
+        customData.put("foo", "foo");
+        customData.put("bar", "bar");
+
+        List<String> args = new ArrayList<>();
+        args.add("--silent");
+        args.add("-a");
+        args.add("-q");
+
+        Map<Prerun, Object> prerun = new HashMap<>();
+        prerun.put(Prerun.EXECUTABLE, "http://url.to/your/executable.exe");
+        prerun.put(Prerun.ARGS, args);
+        prerun.put(Prerun.BACKGROUND, false);
+        prerun.put(Prerun.TIMEOUT, 120);
+
+        List<String> tags = new ArrayList<>();
+        tags.add("foo");
+        tags.add("bar");
+        tags.add("foobar");
+
+        Map<Timeouts, Integer> timeouts = new HashMap<>();
+        timeouts.put(Timeouts.IMPLICIT, 1);
+        timeouts.put(Timeouts.PAGE_LOAD, 59);
+        timeouts.put(Timeouts.SCRIPT, 29);
+
+        assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals("68", sauceOptions.getBrowserVersion());
+        assertEquals(SaucePlatform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
+        assertEquals(true, sauceOptions.getAcceptInsecureCerts());
+        assertEquals(PageLoadStrategy.EAGER, sauceOptions.getPageLoadStrategy());
+        assertEquals(true, sauceOptions.getSetWindowRect());
+        assertEquals(UnhandledPromptBehavior.ACCEPT, sauceOptions.getUnhandledPromptBehavior());
+        assertEquals(true, sauceOptions.getStrictFileInteractability());
+        assertEquals(timeouts, sauceOptions.getTimeouts());
+        assertEquals(true, sauceOptions.getAvoidProxy());
+        assertEquals("Sample Build Name", sauceOptions.getBuild());
+        assertEquals(true, sauceOptions.getCapturePerformance());
+        assertEquals("71", sauceOptions.getChromedriverVersion());
+        assertEquals(Integer.valueOf(2), sauceOptions.getCommandTimeout());
+        assertEquals(customData, sauceOptions.getCustomData());
+        assertEquals(true, sauceOptions.getExtendedDebugging());
+        assertEquals(Integer.valueOf(3), sauceOptions.getIdleTimeout());
+        assertEquals("3.141.0", sauceOptions.getIedriverVersion());
+        assertEquals(Integer.valueOf(300), sauceOptions.getMaxDuration());
+        assertEquals("Sample Test Name", sauceOptions.getName());
+        assertEquals("Mommy", sauceOptions.getParentTunnel());
+        assertEquals(prerun, sauceOptions.getPrerun());
+        assertEquals(Integer.valueOf(0), sauceOptions.getPriority());
+        assertEquals(JobVisibility.TEAM, sauceOptions.getJobVisibility());
+        assertEquals(false, sauceOptions.getRecordLogs());
+        assertEquals(false, sauceOptions.getRecordScreenshots());
+        assertEquals(false, sauceOptions.getRecordVideo());
+        assertEquals("10x10", sauceOptions.getScreenResolution());
+        assertEquals("3.141.59", sauceOptions.getSeleniumVersion());
+        assertEquals(tags, sauceOptions.getTags());
+        assertEquals("San Francisco", sauceOptions.getTimeZone());
+        assertEquals("tunnelname", sauceOptions.getTunnelIdentifier());
+        assertEquals(false, sauceOptions.getVideoUploadOnPass());
+    }
+
+    @Test(expected = InvalidSauceOptionsArgumentException.class)
+    public void setsBadJobVisibilityFromMap() {
+        Map<String, Object> map = serialize("badJobVisibility");
+        sauceOptions.mergeCapabilities(map);
+    }
+
+    @Test(expected = InvalidSauceOptionsArgumentException.class)
+    public void setsBadPrerunFromMap() {
+        Map<String, Object> map = serialize("badPrerun");
+        sauceOptions.mergeCapabilities(map);
+    }
+
+    @Test
+    public void parsesCapabilitiesFromSauceValues() {
+        Map<String, Object> customData = new HashMap<>();
+        customData.put("foo", "foo");
+        customData.put("bar", "bar");
+
+        List<String> args = new ArrayList<>();
+        args.add("--silent");
+        args.add("-a");
+        args.add("-q");
+
+        Map<Prerun, Object> prerun = new HashMap<>();
+        prerun.put(Prerun.EXECUTABLE, "http://url.to/your/executable.exe");
+        prerun.put(Prerun.ARGS, args);
+        prerun.put(Prerun.BACKGROUND, false);
+        prerun.put(Prerun.TIMEOUT, 120);
+
+        List<String> tags = new ArrayList<>();
+        tags.add("Foo");
+        tags.add("Bar");
+        tags.add("Foobar");
+
+        sauceOptions.setAvoidProxy(true);
+        sauceOptions.setBuild("Sample Build Name");
+        sauceOptions.setCapturePerformance(true);
+        sauceOptions.setChromedriverVersion("71");
+        sauceOptions.setCommandTimeout(2);
+        sauceOptions.setCustomData(customData);
+        sauceOptions.setExtendedDebugging(true);
+        sauceOptions.setIdleTimeout(3);
+        sauceOptions.setIedriverVersion("3.141.0");
+        sauceOptions.setMaxDuration(300);
+        sauceOptions.setName("Test name");
+        sauceOptions.setParentTunnel("Mommy");
+        sauceOptions.setPrerun(prerun);
+        sauceOptions.setPriority(0);
+        sauceOptions.setJobVisibility(JobVisibility.TEAM);
+        sauceOptions.setRecordLogs(false);
+        sauceOptions.setRecordScreenshots(false);
+        sauceOptions.setRecordVideo(false);
+        sauceOptions.setScreenResolution("10x10");
+        sauceOptions.setSeleniumVersion("3.141.59");
+        sauceOptions.setTags(tags);
+        sauceOptions.setTimeZone("San Francisco");
+        sauceOptions.setTunnelIdentifier("tunnelname");
+        sauceOptions.setVideoUploadOnPass(false);
+
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+        sauceCapabilities.setCapability("avoidProxy", true);
+        sauceCapabilities.setCapability("build", "Sample Build Name");
+        sauceCapabilities.setCapability("capturePerformance", true);
+        sauceCapabilities.setCapability("chromedriverVersion", "71");
+        sauceCapabilities.setCapability("commandTimeout", 2);
+        sauceCapabilities.setCapability("customData", customData);
+        sauceCapabilities.setCapability("extendedDebugging", true);
+        sauceCapabilities.setCapability("idleTimeout", 3);
+        sauceCapabilities.setCapability("iedriverVersion", "3.141.0");
+        sauceCapabilities.setCapability("maxDuration", 300);
+        sauceCapabilities.setCapability("name", "Test name");
+        sauceCapabilities.setCapability("parentTunnel", "Mommy");
+        sauceCapabilities.setCapability("prerun", prerun);
+        sauceCapabilities.setCapability("priority", 0);
+        sauceCapabilities.setCapability("public", "team");
+        sauceCapabilities.setCapability("recordLogs", false);
+        sauceCapabilities.setCapability("recordScreenshots", false);
+        sauceCapabilities.setCapability("recordVideo", false);
+        sauceCapabilities.setCapability("screenResolution", "10x10");
+        sauceCapabilities.setCapability("seleniumVersion", "3.141.59");
+        sauceCapabilities.setCapability("tags", tags);
+        sauceCapabilities.setCapability("timeZone", "San Francisco");
+        sauceCapabilities.setCapability("tunnelIdentifier", "tunnelname");
+        sauceCapabilities.setCapability("videoUploadOnPass", false);
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
+
+        MutableCapabilities expectedCapabilities = new MutableCapabilities();
+        expectedCapabilities.setCapability("browserName", "chrome");
+        expectedCapabilities.setCapability("browserVersion", "latest");
+        expectedCapabilities.setCapability("platformName", "Windows 10");
+
+        expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
+        MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
+
+        // toString() serializes the enums
+        assertEquals(expectedCapabilities.asMap().toString(), actualCapabilities.asMap().toString());
+    }
+
+    @Test
+    public void parsesW3CAndSauceAndSeleniumSettings() {
+        MutableCapabilities expectedCapabilities = new MutableCapabilities();
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+
+        FirefoxOptions firefoxOptions = new FirefoxOptions();
+        firefoxOptions.addArguments("--foo");
+        firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
+
+        sauceOptions = new SauceOptions(firefoxOptions);
+
+        expectedCapabilities.merge(firefoxOptions);
+        expectedCapabilities.setCapability("browserVersion", "latest");
+        expectedCapabilities.setCapability("platformName", "Windows 10");
+        expectedCapabilities.setCapability("acceptInsecureCerts", true);
+
+        sauceOptions.setBuild("CUSTOM BUILD: 12");
+        sauceCapabilities.setCapability("build", "CUSTOM BUILD: 12");
+
+        sauceOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
+        expectedCapabilities.setCapability("pageLoadStrategy", PageLoadStrategy.EAGER);
+        sauceOptions.setAcceptInsecureCerts(true);
+        expectedCapabilities.setCapability("acceptInsecureCerts", true);
+        sauceOptions.timeout.setImplicitWait(1)
+                .setPageLoad(100)
+                .setScript(10);
+        Map<Timeouts, Integer> timeouts = new HashMap<>();
+        timeouts.put(Timeouts.IMPLICIT, 1);
+        timeouts.put(Timeouts.SCRIPT, 10);
+        timeouts.put(Timeouts.PAGE_LOAD, 100);
+        expectedCapabilities.setCapability("timeouts", timeouts);
+        sauceOptions.setUnhandledPromptBehavior(UnhandledPromptBehavior.IGNORE);
+        expectedCapabilities.setCapability("unhandledPromptBehavior", UnhandledPromptBehavior.IGNORE);
+
+        sauceOptions.setExtendedDebugging(true);
+        sauceCapabilities.setCapability("extendedDebugging", true);
+        sauceOptions.setName("Test name");
+        sauceCapabilities.setCapability("name", "Test name");
+        sauceOptions.setParentTunnel("Mommy");
+        sauceCapabilities.setCapability("parentTunnel", "Mommy");
+
+        sauceOptions.setJobVisibility(JobVisibility.SHARE);
+        sauceCapabilities.setCapability("public", JobVisibility.SHARE);
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
+
+        expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
+        MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
+
+        assertEquals(expectedCapabilities.asMap().toString(), actualCapabilities.asMap().toString());
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
@@ -23,12 +23,11 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
+import static org.junit.Assert.assertNotNull;
 import static org.openqa.selenium.UnexpectedAlertBehaviour.DISMISS;
 
 public class SauceOptionsTest {
-    private SauceOptions sauceOptions = spy(new SauceOptions());
+    private SauceOptions sauceOptions = new SauceOptions();
 
     @Rule
     public MockitoRule initRule = MockitoJUnit.rule();
@@ -223,11 +222,7 @@ public class SauceOptionsTest {
 
     @Test
     public void createsDefaultBuildName() {
-        doReturn("Not Empty").when(sauceOptions).getEnvironmentVariable("BUILD_TAG");
-        doReturn("TEMP BUILD").when(sauceOptions).getEnvironmentVariable("BUILD_NAME");
-        doReturn("11").when(sauceOptions).getEnvironmentVariable("BUILD_NUMBER");
-
-        assertEquals("TEMP BUILD: 11", sauceOptions.getBuild());
+        assertNotNull(sauceOptions.getBuild());
     }
 
     @SneakyThrows
@@ -348,9 +343,6 @@ public class SauceOptionsTest {
 
     @Test
     public void parsesCapabilitiesFromW3CValues() {
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-
         sauceOptions.setBrowserName(Browser.FIREFOX);
         sauceOptions.setPlatformName(SaucePlatform.MAC_HIGH_SIERRA);
         sauceOptions.setBrowserVersion("77");
@@ -382,8 +374,8 @@ public class SauceOptionsTest {
 
         MutableCapabilities sauceCapabilities = new MutableCapabilities();
         sauceCapabilities.setCapability("build", "Build Name");
-        sauceCapabilities.setCapability("username", "test-name");
-        sauceCapabilities.setCapability("accessKey", "test-accesskey");
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
         MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
 
@@ -392,9 +384,6 @@ public class SauceOptionsTest {
 
     @Test
     public void parsesCapabilitiesFromSauceValues() {
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-
         Map<String, Object> customData = new HashMap<>();
         customData.put("foo", "foo");
         customData.put("bar", "bar");
@@ -465,8 +454,8 @@ public class SauceOptionsTest {
         sauceCapabilities.setCapability("timeZone", "San Francisco");
         sauceCapabilities.setCapability("tunnelIdentifier", "tunnelname");
         sauceCapabilities.setCapability("videoUploadOnPass", false);
-        sauceCapabilities.setCapability("username", "test-name");
-        sauceCapabilities.setCapability("accessKey", "test-accesskey");
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
         expectedCapabilities.setCapability("browserName", "chrome");
@@ -487,10 +476,7 @@ public class SauceOptionsTest {
         firefoxOptions.addPreference("foo", "bar");
         firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
 
-        sauceOptions = spy(new SauceOptions(firefoxOptions));
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-
+        sauceOptions = new SauceOptions(firefoxOptions);
         sauceOptions.setBuild("Build Name");
 
         MutableCapabilities expectedCapabilities = new MutableCapabilities();
@@ -501,8 +487,8 @@ public class SauceOptionsTest {
 
         MutableCapabilities sauceCapabilities = new MutableCapabilities();
         sauceCapabilities.setCapability("build", "Build Name");
-        sauceCapabilities.setCapability("username", "test-name");
-        sauceCapabilities.setCapability("accessKey", "test-accesskey");
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
         MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
 
@@ -518,10 +504,7 @@ public class SauceOptionsTest {
         firefoxOptions.addArguments("--foo");
         firefoxOptions.setUnhandledPromptBehaviour(DISMISS);
 
-        sauceOptions = spy(new SauceOptions(firefoxOptions));
-
-        doReturn("test-name").when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        doReturn("test-accesskey").when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
+        sauceOptions = new SauceOptions(firefoxOptions);
 
         expectedCapabilities.merge(firefoxOptions);
         expectedCapabilities.setCapability("browserVersion", "latest");
@@ -555,8 +538,8 @@ public class SauceOptionsTest {
 
         sauceOptions.setJobVisibility(JobVisibility.SHARE);
         sauceCapabilities.setCapability("public", JobVisibility.SHARE);
-        sauceCapabilities.setCapability("username", "test-name");
-        sauceCapabilities.setCapability("accessKey", "test-accesskey");
+        sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
 
         expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
         MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceOptionsTest.java
@@ -15,7 +15,6 @@ import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -108,55 +107,76 @@ public class SauceOptionsTest {
         tags.add("Bar");
         tags.add("Foobar");
 
-        sauceOptions.setAvoidProxy(true);
-        sauceOptions.setBuild("Sample Build Name");
-        sauceOptions.setCapturePerformance(true);
-        sauceOptions.setChromedriverVersion("71");
-        sauceOptions.setCommandTimeout(2);
-        sauceOptions.setCustomData(customData);
-        sauceOptions.setExtendedDebugging(true);
-        sauceOptions.setIdleTimeout(3);
-        sauceOptions.setIedriverVersion("3.141.0");
-        sauceOptions.setMaxDuration(300);
-        sauceOptions.setName("Test name");
-        sauceOptions.setParentTunnel("Mommy");
-        sauceOptions.setPrerun(prerun);
-        sauceOptions.setPriority(0);
-        sauceOptions.setJobVisibility(JobVisibility.TEAM);
-        sauceOptions.setRecordLogs(false);
-        sauceOptions.setRecordScreenshots(false);
-        sauceOptions.setRecordVideo(false);
-        sauceOptions.setScreenResolution("10x10");
-        sauceOptions.setSeleniumVersion("3.141.59");
-        sauceOptions.setTags(tags);
-        sauceOptions.setTimeZone("San Francisco");
-        sauceOptions.setTunnelIdentifier("tunnelname");
-        sauceOptions.setVideoUploadOnPass(false);
+        sauceOptions.sauce().setAvoidProxy(true);
+        sauceOptions.sauce().setBuild("Sample Build Name");
+        sauceOptions.sauce().setCapturePerformance(true);
+        sauceOptions.sauce().setChromedriverVersion("71");
+        sauceOptions.sauce().setCommandTimeout(2);
+        sauceOptions.sauce().setCustomData(customData);
+        sauceOptions.sauce().setExtendedDebugging(true);
+        sauceOptions.sauce().setIdleTimeout(3);
+        sauceOptions.sauce().setIedriverVersion("3.141.0");
+        sauceOptions.sauce().setMaxDuration(300);
+        sauceOptions.sauce().setName("Test name");
+        sauceOptions.sauce().setParentTunnel("Mommy");
+        sauceOptions.sauce().setPrerun(prerun);
+        sauceOptions.sauce().setPriority(0);
+        sauceOptions.sauce().setJobVisibility(JobVisibility.TEAM);
+        sauceOptions.sauce().setRecordLogs(false);
+        sauceOptions.sauce().setRecordScreenshots(false);
+        sauceOptions.sauce().setRecordVideo(false);
+        sauceOptions.sauce().setScreenResolution("10x10");
+        sauceOptions.sauce().setSeleniumVersion("3.141.59");
+        sauceOptions.sauce().setTags(tags);
+        sauceOptions.sauce().setTimeZone("San Francisco");
+        sauceOptions.sauce().setTunnelIdentifier("tunnelname");
+        sauceOptions.sauce().setVideoUploadOnPass(false);
 
-        assertEquals(true, sauceOptions.getAvoidProxy());
-        assertEquals("Sample Build Name", sauceOptions.getBuild());
-        assertEquals(true, sauceOptions.getCapturePerformance());
-        assertEquals("71", sauceOptions.getChromedriverVersion());
-        assertEquals(Integer.valueOf(2), sauceOptions.getCommandTimeout());
-        assertEquals(customData, sauceOptions.getCustomData());
-        assertEquals(true, sauceOptions.getExtendedDebugging());
-        assertEquals(Integer.valueOf(3), sauceOptions.getIdleTimeout());
-        assertEquals("3.141.0", sauceOptions.getIedriverVersion());
-        assertEquals(Integer.valueOf(300), sauceOptions.getMaxDuration());
-        assertEquals("Test name", sauceOptions.getName());
-        assertEquals("Mommy", sauceOptions.getParentTunnel());
-        assertEquals(prerun, sauceOptions.getPrerun());
-        assertEquals(Integer.valueOf(0), sauceOptions.getPriority());
-        assertEquals(JobVisibility.TEAM, sauceOptions.getJobVisibility());
-        assertEquals(false, sauceOptions.getRecordLogs());
-        assertEquals(false, sauceOptions.getRecordScreenshots());
-        assertEquals(false, sauceOptions.getRecordVideo());
-        assertEquals("10x10", sauceOptions.getScreenResolution());
-        assertEquals("3.141.59", sauceOptions.getSeleniumVersion());
-        assertEquals(tags, sauceOptions.getTags());
-        assertEquals("San Francisco", sauceOptions.getTimeZone());
-        assertEquals("tunnelname", sauceOptions.getTunnelIdentifier());
-        assertEquals(false, sauceOptions.getVideoUploadOnPass());
+        assertEquals(true, sauceOptions.sauce().getAvoidProxy());
+        assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
+        assertEquals(true, sauceOptions.sauce().getCapturePerformance());
+        assertEquals("71", sauceOptions.sauce().getChromedriverVersion());
+        assertEquals(Integer.valueOf(2), sauceOptions.sauce().getCommandTimeout());
+        assertEquals(customData, sauceOptions.sauce().getCustomData());
+        assertEquals(true, sauceOptions.sauce().getExtendedDebugging());
+        assertEquals(Integer.valueOf(3), sauceOptions.sauce().getIdleTimeout());
+        assertEquals("3.141.0", sauceOptions.sauce().getIedriverVersion());
+        assertEquals(Integer.valueOf(300), sauceOptions.sauce().getMaxDuration());
+        assertEquals("Test name", sauceOptions.sauce().getName());
+        assertEquals("Mommy", sauceOptions.sauce().getParentTunnel());
+        assertEquals(prerun, sauceOptions.sauce().getPrerun());
+        assertEquals(Integer.valueOf(0), sauceOptions.sauce().getPriority());
+        assertEquals(JobVisibility.TEAM, sauceOptions.sauce().getJobVisibility());
+        assertEquals(false, sauceOptions.sauce().getRecordLogs());
+        assertEquals(false, sauceOptions.sauce().getRecordScreenshots());
+        assertEquals(false, sauceOptions.sauce().getRecordVideo());
+        assertEquals("10x10", sauceOptions.sauce().getScreenResolution());
+        assertEquals("3.141.59", sauceOptions.sauce().getSeleniumVersion());
+        assertEquals(tags, sauceOptions.sauce().getTags());
+        assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
+        assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
+        assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());
+    }
+
+    @Test
+    public void fluentPatternWorksSauce() {
+        sauceOptions.setBrowserName(Browser.FIREFOX)
+                .setBrowserVersion("68")
+                .setPlatformName(SaucePlatform.MAC_HIGH_SIERRA)
+                .sauce().setAvoidProxy(true)
+                        .setBuild("Sample Build Name")
+                        .setCapturePerformance(true)
+                        .setChromedriverVersion("71")
+                        .setCommandTimeout(2);
+
+        assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals("68", sauceOptions.getBrowserVersion());
+        assertEquals(SaucePlatform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
+        assertEquals(true, sauceOptions.sauce().getAvoidProxy());
+        assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
+        assertEquals(true, sauceOptions.sauce().getCapturePerformance());
+        assertEquals("71", sauceOptions.sauce().getChromedriverVersion());
+        assertEquals(Integer.valueOf(2), sauceOptions.sauce().getCommandTimeout());
     }
 
     @Test
@@ -222,7 +242,7 @@ public class SauceOptionsTest {
 
     @Test
     public void createsDefaultBuildName() {
-        assertNotNull(sauceOptions.getBuild());
+        assertNotNull(sauceOptions.sauce().getBuild());
     }
 
     @SneakyThrows
@@ -234,7 +254,7 @@ public class SauceOptionsTest {
     }
 
     @Test
-    public void setsCapabilitiesFromMap() throws FileNotFoundException {
+    public void setsCapabilitiesFromMap() {
         Map<String, Object> map = serialize("exampleValues");
 
         sauceOptions.mergeCapabilities(map);
@@ -273,30 +293,30 @@ public class SauceOptionsTest {
         assertEquals(UnhandledPromptBehavior.ACCEPT, sauceOptions.getUnhandledPromptBehavior());
         assertEquals(true, sauceOptions.getStrictFileInteractability());
         assertEquals(timeouts, sauceOptions.getTimeouts());
-        assertEquals(true, sauceOptions.getAvoidProxy());
-        assertEquals("Sample Build Name", sauceOptions.getBuild());
-        assertEquals(true, sauceOptions.getCapturePerformance());
-        assertEquals("71", sauceOptions.getChromedriverVersion());
-        assertEquals(Integer.valueOf(2), sauceOptions.getCommandTimeout());
-        assertEquals(customData, sauceOptions.getCustomData());
-        assertEquals(true, sauceOptions.getExtendedDebugging());
-        assertEquals(Integer.valueOf(3), sauceOptions.getIdleTimeout());
-        assertEquals("3.141.0", sauceOptions.getIedriverVersion());
-        assertEquals(Integer.valueOf(300), sauceOptions.getMaxDuration());
-        assertEquals("Sample Test Name", sauceOptions.getName());
-        assertEquals("Mommy", sauceOptions.getParentTunnel());
-        assertEquals(prerun, sauceOptions.getPrerun());
-        assertEquals(Integer.valueOf(0), sauceOptions.getPriority());
-        assertEquals(JobVisibility.TEAM, sauceOptions.getJobVisibility());
-        assertEquals(false, sauceOptions.getRecordLogs());
-        assertEquals(false, sauceOptions.getRecordScreenshots());
-        assertEquals(false, sauceOptions.getRecordVideo());
-        assertEquals("10x10", sauceOptions.getScreenResolution());
-        assertEquals("3.141.59", sauceOptions.getSeleniumVersion());
-        assertEquals(tags, sauceOptions.getTags());
-        assertEquals("San Francisco", sauceOptions.getTimeZone());
-        assertEquals("tunnelname", sauceOptions.getTunnelIdentifier());
-        assertEquals(false, sauceOptions.getVideoUploadOnPass());
+        assertEquals(true, sauceOptions.sauce().getAvoidProxy());
+        assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
+        assertEquals(true, sauceOptions.sauce().getCapturePerformance());
+        assertEquals("71", sauceOptions.sauce().getChromedriverVersion());
+        assertEquals(Integer.valueOf(2), sauceOptions.sauce().getCommandTimeout());
+        assertEquals(customData, sauceOptions.sauce().getCustomData());
+        assertEquals(true, sauceOptions.sauce().getExtendedDebugging());
+        assertEquals(Integer.valueOf(3), sauceOptions.sauce().getIdleTimeout());
+        assertEquals("3.141.0", sauceOptions.sauce().getIedriverVersion());
+        assertEquals(Integer.valueOf(300), sauceOptions.sauce().getMaxDuration());
+        assertEquals("Sample Test Name", sauceOptions.sauce().getName());
+        assertEquals("Mommy", sauceOptions.sauce().getParentTunnel());
+        assertEquals(prerun, sauceOptions.sauce().getPrerun());
+        assertEquals(Integer.valueOf(0), sauceOptions.sauce().getPriority());
+        assertEquals(JobVisibility.TEAM, sauceOptions.sauce().getJobVisibility());
+        assertEquals(false, sauceOptions.sauce().getRecordLogs());
+        assertEquals(false, sauceOptions.sauce().getRecordScreenshots());
+        assertEquals(false, sauceOptions.sauce().getRecordVideo());
+        assertEquals("10x10", sauceOptions.sauce().getScreenResolution());
+        assertEquals("3.141.59", sauceOptions.sauce().getSeleniumVersion());
+        assertEquals(tags, sauceOptions.sauce().getTags());
+        assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
+        assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
+        assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());
     }
 
     @Test(expected = InvalidSauceOptionsArgumentException.class)
@@ -338,6 +358,18 @@ public class SauceOptionsTest {
     @Test(expected = InvalidSauceOptionsArgumentException.class)
     public void setsBadPageLoadFromMap() {
         Map<String, Object> map = serialize("badPageLoad");
+        sauceOptions.mergeCapabilities(map);
+    }
+
+    @Test(expected = InvalidSauceOptionsArgumentException.class)
+    public void setsInvalidOptionFromMap() {
+        Map<String, Object> map = serialize("invalidOption");
+        sauceOptions.mergeCapabilities(map);
+    }
+
+    @Test(expected = InvalidSauceOptionsArgumentException.class)
+    public void setsInvalidSauceOptionFromMap() {
+        Map<String, Object> map = serialize("invalidSauceOption");
         sauceOptions.mergeCapabilities(map);
     }
 
@@ -404,30 +436,30 @@ public class SauceOptionsTest {
         tags.add("Bar");
         tags.add("Foobar");
 
-        sauceOptions.setAvoidProxy(true);
-        sauceOptions.setBuild("Sample Build Name");
-        sauceOptions.setCapturePerformance(true);
-        sauceOptions.setChromedriverVersion("71");
-        sauceOptions.setCommandTimeout(2);
-        sauceOptions.setCustomData(customData);
-        sauceOptions.setExtendedDebugging(true);
-        sauceOptions.setIdleTimeout(3);
-        sauceOptions.setIedriverVersion("3.141.0");
-        sauceOptions.setMaxDuration(300);
-        sauceOptions.setName("Test name");
-        sauceOptions.setParentTunnel("Mommy");
-        sauceOptions.setPrerun(prerun);
-        sauceOptions.setPriority(0);
-        sauceOptions.setJobVisibility(JobVisibility.TEAM);
-        sauceOptions.setRecordLogs(false);
-        sauceOptions.setRecordScreenshots(false);
-        sauceOptions.setRecordVideo(false);
-        sauceOptions.setScreenResolution("10x10");
-        sauceOptions.setSeleniumVersion("3.141.59");
-        sauceOptions.setTags(tags);
-        sauceOptions.setTimeZone("San Francisco");
-        sauceOptions.setTunnelIdentifier("tunnelname");
-        sauceOptions.setVideoUploadOnPass(false);
+        sauceOptions.sauce().setAvoidProxy(true);
+        sauceOptions.sauce().setBuild("Sample Build Name");
+        sauceOptions.sauce().setCapturePerformance(true);
+        sauceOptions.sauce().setChromedriverVersion("71");
+        sauceOptions.sauce().setCommandTimeout(2);
+        sauceOptions.sauce().setCustomData(customData);
+        sauceOptions.sauce().setExtendedDebugging(true);
+        sauceOptions.sauce().setIdleTimeout(3);
+        sauceOptions.sauce().setIedriverVersion("3.141.0");
+        sauceOptions.sauce().setMaxDuration(300);
+        sauceOptions.sauce().setName("Test name");
+        sauceOptions.sauce().setParentTunnel("Mommy");
+        sauceOptions.sauce().setPrerun(prerun);
+        sauceOptions.sauce().setPriority(0);
+        sauceOptions.sauce().setJobVisibility(JobVisibility.TEAM);
+        sauceOptions.sauce().setRecordLogs(false);
+        sauceOptions.sauce().setRecordScreenshots(false);
+        sauceOptions.sauce().setRecordVideo(false);
+        sauceOptions.sauce().setScreenResolution("10x10");
+        sauceOptions.sauce().setSeleniumVersion("3.141.59");
+        sauceOptions.sauce().setTags(tags);
+        sauceOptions.sauce().setTimeZone("San Francisco");
+        sauceOptions.sauce().setTunnelIdentifier("tunnelname");
+        sauceOptions.sauce().setVideoUploadOnPass(false);
 
         MutableCapabilities sauceCapabilities = new MutableCapabilities();
         sauceCapabilities.setCapability("avoidProxy", true);
@@ -529,14 +561,14 @@ public class SauceOptionsTest {
         sauceOptions.setUnhandledPromptBehavior(UnhandledPromptBehavior.IGNORE);
         expectedCapabilities.setCapability("unhandledPromptBehavior", UnhandledPromptBehavior.IGNORE);
 
-        sauceOptions.setExtendedDebugging(true);
+        sauceOptions.sauce().setExtendedDebugging(true);
         sauceCapabilities.setCapability("extendedDebugging", true);
-        sauceOptions.setName("Test name");
+        sauceOptions.sauce().setName("Test name");
         sauceCapabilities.setCapability("name", "Test name");
-        sauceOptions.setParentTunnel("Mommy");
+        sauceOptions.sauce().setParentTunnel("Mommy");
         sauceCapabilities.setCapability("parentTunnel", "Mommy");
 
-        sauceOptions.setJobVisibility(JobVisibility.SHARE);
+        sauceOptions.sauce().setJobVisibility(JobVisibility.SHARE);
         sauceCapabilities.setCapability("public", JobVisibility.SHARE);
         sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
         sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));

--- a/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
@@ -71,18 +71,6 @@ public class SauceSessionTest {
         assertEquals(expetedSauceUrl, sauceSession.getSauceUrl().toString());
     }
 
-    @Test(expected = SauceEnvironmentVariablesNotSetException.class)
-    public void startThrowsErrorWithoutUsername() {
-        doReturn(null).when(sauceOptions).getEnvironmentVariable("SAUCE_USERNAME");
-        sauceOptsSession.start();
-    }
-
-    @Test(expected = SauceEnvironmentVariablesNotSetException.class)
-    public void startThrowsErrorWithoutAccessKey() {
-        doReturn(null).when(sauceOptions).getEnvironmentVariable("SAUCE_ACCESS_KEY");
-        sauceOptsSession.start();
-    }
-
     @Test
     public void stopCallsDriverQuitPassing() {
         sauceSession.start();

--- a/java/src/test/java/com/saucelabs/saucebindings/VisualOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/VisualOptionsTest.java
@@ -1,0 +1,119 @@
+package com.saucelabs.saucebindings;
+
+import lombok.SneakyThrows;
+import org.junit.Test;
+import org.openqa.selenium.MutableCapabilities;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class VisualOptionsTest {
+    @Test
+    public void setsProjectNameByDefault() {
+        SauceOptions sauceOptions = new SauceOptions();
+
+        assertEquals("Default Project Name", sauceOptions.visual().getProjectName());
+    }
+
+    @Test
+    public void setsVisualValues() {
+        Map<String, Object> diffMap = new HashMap<>();
+        diffMap.put("structure", false);
+        diffMap.put("layout", false);
+        diffMap.put("style", false);
+        diffMap.put("content", false);
+        diffMap.put("minLayoutPosition", 5);
+        diffMap.put("minLayoutDimension", 9);
+
+        SauceOptions sauceOptions = new SauceOptions();
+        sauceOptions.sauce().setBuild("Build Name");
+        sauceOptions.visual().setProjectName("setsVisualValues");
+        sauceOptions.visual().setViewportSize("1900x1200");
+        sauceOptions.visual().setBranch("my-branch");
+        sauceOptions.visual().setBaseBranch("base-branch");
+        sauceOptions.visual().setIgnore("#some-id, .some-class");
+        sauceOptions.visual().setFailOnNewStates(true);
+        sauceOptions.visual().setAlwaysAcceptBaseBranch(true);
+        sauceOptions.visual().setDisableBranchBaseline(true);
+        sauceOptions.visual().setScrollAndStitchScreenshots(true);
+        sauceOptions.visual().setDisableCORS(true);
+        sauceOptions.visual().setDiffOptions(diffMap);
+
+        MutableCapabilities expectedCapabilities = new MutableCapabilities();
+        expectedCapabilities.setCapability("browserName", "chrome");
+        expectedCapabilities.setCapability("browserVersion", "latest");
+        expectedCapabilities.setCapability("platformName", "Windows 10");
+
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+        sauceCapabilities.setCapability("build", "Build Name");
+        sauceCapabilities.setCapability("username", SystemManager.getEnv("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.getEnv("SAUCE_ACCESS_KEY"));
+        expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
+
+        MutableCapabilities visualCapabilities = new MutableCapabilities();
+        visualCapabilities.setCapability("apiKey", System.getenv("SCREENER_API_KEY"));
+
+        visualCapabilities.setCapability("projectName", "setsVisualValues");
+        visualCapabilities.setCapability("viewportSize", "1900x1200");
+        visualCapabilities.setCapability("branch", "my-branch");
+        visualCapabilities.setCapability("baseBranch", "base-branch");
+
+        visualCapabilities.setCapability("diffOptions", diffMap);
+        visualCapabilities.setCapability("ignore", "#some-id, .some-class");
+
+        visualCapabilities.setCapability("failOnNewStates", true);
+        visualCapabilities.setCapability("alwaysAcceptBaseBranch", true);
+        visualCapabilities.setCapability("disableBranchBaseline", true);
+        visualCapabilities.setCapability("scrollAndStitchScreenshots", true);
+        visualCapabilities.setCapability("disableCORS", true);
+
+        expectedCapabilities.setCapability("sauce:visual", visualCapabilities);
+
+        MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
+        // toString() serializes the enums
+        assertEquals(expectedCapabilities.asMap().toString(), actualCapabilities.asMap().toString());
+    }
+
+    @SneakyThrows
+    public Map<String, Object> serialize(String key) {
+        InputStream input = new FileInputStream(new File("src/test/java/com/saucelabs/saucebindings/options.yml"));
+        Yaml yaml = new Yaml();
+        Map<String, Object> data = yaml.load(input);
+        return (Map<String, Object>) data.get(key);
+    }
+
+    @Test
+    public void setsVisualCapabilitiesFromMap() {
+        SauceOptions sauceOptions = new SauceOptions();
+
+        Map<String, Object> map = serialize("visualValues");
+        sauceOptions.mergeCapabilities(map);
+
+        Map<String, Object> diffMap = new HashMap<>();
+        diffMap.put("structure", true);
+        diffMap.put("layout", true);
+        diffMap.put("style", true);
+        diffMap.put("content", true);
+        diffMap.put("minLayoutPosition", 3);
+        diffMap.put("minLayoutDimension", 12);
+
+        assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals("68", sauceOptions.getBrowserVersion());
+        assertEquals(SaucePlatform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
+        assertEquals("Sample Build Name", sauceOptions.getBuild());
+        assertEquals("fromYAML", sauceOptions.visual().getProjectName());
+        assertEquals("1280x1024", sauceOptions.visual().getViewportSize());
+        assertEquals(diffMap, sauceOptions.visual().getDiffOptions());
+        assertEquals("#foo, .bar", sauceOptions.visual().getIgnore());
+        assertTrue(sauceOptions.visual().getFailOnNewStates());
+        assertTrue(sauceOptions.visual().getScrollAndStitchScreenshots());
+        assertTrue(sauceOptions.visual().getDisableCORS());
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/deprecated_options.yml
+++ b/java/src/test/java/com/saucelabs/saucebindings/deprecated_options.yml
@@ -1,0 +1,56 @@
+exampleValues:
+  browserName: 'firefox'
+  browserVersion: '68'
+  platformName: 'macOS 10.13'
+  acceptInsecureCerts: true
+  pageLoadStrategy: 'eager'
+  setWindowRect: true
+  unhandledPromptBehavior: "accept"
+  strictFileInteractability: true
+  timeouts:
+    implicit: 1
+    pageLoad: 59
+    script: 29
+  avoidProxy: true
+  build: 'Sample Build Name'
+  capturePerformance: true
+  chromedriverVersion: '71'
+  commandTimeout: 2
+  customData:
+    foo: 'foo'
+    bar: 'bar'
+  extendedDebugging: true
+  idleTimeout: 3
+  iedriverVersion: '3.141.0'
+  maxDuration: 300
+  name: 'Sample Test Name'
+  parentTunnel: 'Mommy'
+  prerun:
+    executable: "http://url.to/your/executable.exe"
+    args:
+      - --silent
+      - -a
+      - -q
+    background: false
+    timeout: 120
+  priority: 0
+  jobVisibility: 'team'
+  recordLogs: false
+  recordScreenshots: false
+  recordVideo: false
+  screenResolution: '10x10'
+  seleniumVersion: '3.141.59'
+  tags:
+    - foo
+    - bar
+    - foobar
+  timeZone: 'San Francisco'
+  tunnelIdentifier: 'tunnelname'
+  videoUploadOnPass: false
+
+badJobVisibility:
+  jobVisibility: "me"
+
+badPrerun:
+  prerun:
+    nope: ""

--- a/java/src/test/java/com/saucelabs/saucebindings/options.yml
+++ b/java/src/test/java/com/saucelabs/saucebindings/options.yml
@@ -86,3 +86,24 @@ invalidSauceOption:
   platformName: "MacOS 10.12"
   sauce:
     foo: "bar"
+
+visualValues:
+  browserName: 'firefox'
+  browserVersion: '68'
+  platformName: 'macOS 10.13'
+  sauce:
+    build: 'Sample Build Name'
+  visual:
+    projectName: 'fromYAML'
+    viewportSize: '1280x1024'
+    diffOptions:
+      structure: true
+      layout: true
+      style: true
+      content: true
+      minLayoutPosition: 3
+      minLayoutDimension: 12
+    ignore: '#foo, .bar'
+    failOnNewStates: true
+    scrollAndStitchScreenshots: true
+    disableCORS: true

--- a/java/src/test/java/com/saucelabs/saucebindings/options.yml
+++ b/java/src/test/java/com/saucelabs/saucebindings/options.yml
@@ -11,42 +11,43 @@ exampleValues:
     implicit: 1
     pageLoad: 59
     script: 29
-  avoidProxy: true
-  build: 'Sample Build Name'
-  capturePerformance: true
-  chromedriverVersion: '71'
-  commandTimeout: 2
-  customData:
-    foo: 'foo'
-    bar: 'bar'
-  extendedDebugging: true
-  idleTimeout: 3
-  iedriverVersion: '3.141.0'
-  maxDuration: 300
-  name: 'Sample Test Name'
-  parentTunnel: 'Mommy'
-  prerun:
-    executable: "http://url.to/your/executable.exe"
-    args:
-      - --silent
-      - -a
-      - -q
-    background: false
-    timeout: 120
-  priority: 0
-  jobVisibility: 'team'
-  recordLogs: false
-  recordScreenshots: false
-  recordVideo: false
-  screenResolution: '10x10'
-  seleniumVersion: '3.141.59'
-  tags:
-    - foo
-    - bar
-    - foobar
-  timeZone: 'San Francisco'
-  tunnelIdentifier: 'tunnelname'
-  videoUploadOnPass: false
+  sauce:
+    avoidProxy: true
+    build: 'Sample Build Name'
+    capturePerformance: true
+    chromedriverVersion: '71'
+    commandTimeout: 2
+    customData:
+      foo: 'foo'
+      bar: 'bar'
+    extendedDebugging: true
+    idleTimeout: 3
+    iedriverVersion: '3.141.0'
+    maxDuration: 300
+    name: 'Sample Test Name'
+    parentTunnel: 'Mommy'
+    prerun:
+      executable: "http://url.to/your/executable.exe"
+      args:
+        - --silent
+        - -a
+        - -q
+      background: false
+      timeout: 120
+    priority: 0
+    jobVisibility: 'team'
+    recordLogs: false
+    recordScreenshots: false
+    recordVideo: false
+    screenResolution: '10x10'
+    seleniumVersion: '3.141.59'
+    tags:
+      - foo
+      - bar
+      - foobar
+    timeZone: 'San Francisco'
+    tunnelIdentifier: 'tunnelname'
+    videoUploadOnPass: false
 
 badBrowser:
   browserName: "netscape"
@@ -55,7 +56,8 @@ badPlatform:
   platformName: "MAC"
 
 badJobVisibility:
-  jobVisibility: "me"
+  sauce:
+    jobVisibility: "me"
 
 badPageLoad:
   browserName: "fast"
@@ -68,12 +70,19 @@ badTimeout:
     bad: 1
 
 badPrerun:
-  prerun:
-    nope: ""
+  sauce:
+    prerun:
+      nope: ""
 
 invalidOption:
   foo: "bar"
   browser_Nme: "firefox"
   browserVersion: "70"
   platformName: "MacOS 10.12"
-  recordScreenshots: false
+
+invalidSauceOption:
+  browser_Nme: "firefox"
+  browserVersion: "70"
+  platformName: "MacOS 10.12"
+  sauce:
+    foo: "bar"


### PR DESCRIPTION
(This is in DRAFT because it relies on #237)

This is a simple extension of what was done to the Sauce Labs Options class.

direct methods are w3c fields
methods accessed via `sauce()` are the ones using `sauce:options`
methods accessed via `visual()` are the ones using `sauce:visual`

```
 SauceOptions sauceOptions = new SauceOptions();
        sauceOptions.setBrowserVersion("77");
        sauceOptions.sauce().setBuild("Build Name");
        sauceOptions.visual().setProjectName("setsVisualValues");
        sauceOptions.visual().setViewportSize("1900x1200");
```