### PR TITLE
Visual builder

### DIFF
--- a/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceOptions.java
@@ -2,6 +2,7 @@ package com.saucelabs.saucebindings;
 
 import com.saucelabs.saucebindings.options.BaseOptions;
 import com.saucelabs.saucebindings.options.SauceLabsOptions;
+import com.saucelabs.saucebindings.options.VisualOptions;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -24,6 +25,7 @@ import java.util.Map;
 @Setter @Getter
 public class SauceOptions extends BaseOptions {
     @Setter(AccessLevel.NONE) @Getter(AccessLevel.NONE) private SauceLabsOptions sauceLabsOptions = null;
+    @Setter(AccessLevel.NONE) @Getter(AccessLevel.NONE) private VisualOptions visualOptions = null;
     public TimeoutStore timeout = new TimeoutStore();
 
     // w3c Settings
@@ -52,6 +54,13 @@ public class SauceOptions extends BaseOptions {
 
     public SauceLabsOptions sauce() {
         return sauceLabsOptions;
+    }
+
+    public VisualOptions visual() {
+        if (visualOptions == null) {
+            visualOptions = new VisualOptions();
+        }
+        return visualOptions;
     }
 
     public SauceOptions() {
@@ -97,6 +106,9 @@ public class SauceOptions extends BaseOptions {
     public MutableCapabilities toCapabilities() {
         capabilityManager.addCapabilities();
         capabilities.setCapability("sauce:options", sauce().toCapabilities());
+        if (visualOptions != null) {
+            capabilities.setCapability("sauce:visual", visualOptions.toCapabilities());
+        }
         return capabilities;
     }
 
@@ -125,6 +137,8 @@ public class SauceOptions extends BaseOptions {
             setTimeouts(timeoutsMap);
         } else if ("sauce".equals(key)) {
             sauce().mergeCapabilities((HashMap<String, Object>) value);
+        } else if ("visual".equals(key)) {
+            visual().mergeCapabilities((HashMap<String, Object>) value);
         } else if (sauce().getValidOptions().contains(key)) {
             deprecatedSetCapability(key, value);
         } else {

--- a/java/src/main/java/com/saucelabs/saucebindings/options/VisualOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/VisualOptions.java
@@ -2,6 +2,7 @@ package com.saucelabs.saucebindings.options;
 
 import com.saucelabs.saucebindings.CapabilityManager;
 import com.saucelabs.saucebindings.SystemManager;
+import com.saucelabs.saucebindings.options.builders.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -12,7 +13,8 @@ import java.util.List;
 import java.util.Map;
 
 @Accessors(chain = true) @Setter @Getter
-public class VisualOptions extends BaseOptions {
+public class VisualOptions<T extends Builder> extends BaseOptions {
+    private T builder = null;
 
     // Sauce Visual Settings
     // https://screener.io/v2/docs/visual-e2e/visual-options
@@ -43,6 +45,24 @@ public class VisualOptions extends BaseOptions {
 
     public VisualOptions() {
         capabilityManager = new CapabilityManager(this);
+    }
+
+    public VisualOptions(T builder) {
+        this();
+        this.builder = builder;
+    }
+
+    public T build() {
+        CapabilityManager builderManager = new CapabilityManager(this);
+        CapabilityManager visualOptionsManager = new CapabilityManager(builder.getSauceOptions().visual());
+
+        getValidOptions().forEach((capability) -> {
+            Object value = builderManager.getCapability(capability);
+            if (value != null) {
+                visualOptionsManager.setCapability(capability, value);
+            }
+        });
+        return (T) builder;
     }
 
     public MutableCapabilities toCapabilities() {

--- a/java/src/main/java/com/saucelabs/saucebindings/options/VisualOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/VisualOptions.java
@@ -1,0 +1,58 @@
+package com.saucelabs.saucebindings.options;
+
+import com.saucelabs.saucebindings.CapabilityManager;
+import com.saucelabs.saucebindings.SystemManager;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Accessors(chain = true) @Setter @Getter
+public class VisualOptions extends BaseOptions {
+
+    // Sauce Visual Settings
+    // https://screener.io/v2/docs/visual-e2e/visual-options
+    private String projectName = "Default Project Name";
+    private String viewportSize;
+    private String branch;
+    private String baseBranch;
+    private Map<String, Object> diffOptions = null;
+    private String ignore = null;   // This probably should be a List not a String, but conversions, ugh
+    private Boolean failOnNewStates = null;
+    private Boolean alwaysAcceptBaseBranch = null;
+    private Boolean disableBranchBaseline = null;
+    private Boolean scrollAndStitchScreenshots = null;
+    private Boolean disableCORS = null;
+
+    public final List<String> validOptions = Arrays.asList(
+            "projectName",
+            "viewportSize",
+            "branch",
+            "baseBranch",
+            "diffOptions",
+            "ignore",
+            "failOnNewStates",
+            "alwaysAcceptBaseBranch",
+            "disableBranchBaseline",
+            "scrollAndStitchScreenshots",
+            "disableCORS");
+
+    public VisualOptions() {
+        capabilityManager = new CapabilityManager(this);
+    }
+
+    public MutableCapabilities toCapabilities() {
+        capabilities.setCapability("apiKey", getScreenerApiKey());
+        capabilityManager.addCapabilities();
+        return capabilities;
+    }
+
+    protected String getScreenerApiKey() {
+        String error = "Screener Access Key was not set in your env variables. Please set SCREENER_API_KEY value.";
+        return SystemManager.get("SCREENER_API_KEY", error);
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/options/builders/Builder.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/builders/Builder.java
@@ -1,0 +1,12 @@
+package com.saucelabs.saucebindings.options.builders;
+
+import com.saucelabs.saucebindings.SauceOptions;
+import com.saucelabs.saucebindings.options.VisualOptions;
+
+public interface Builder<T extends Builder> {
+    SauceOptions getSauceOptions();
+
+    public default VisualOptions<T> visual() {
+        return new VisualOptions(this);
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/options/builders/SauceChromeBuilder.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/builders/SauceChromeBuilder.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 @Accessors(chain = true) @Setter @Getter
-public class SauceChromeBuilder extends BaseOptions {
+public class SauceChromeBuilder extends BaseOptions implements Builder<SauceChromeBuilder> {
     public SauceOptions sauceOptions;
 
     private Browser browserName = Browser.CHROME;

--- a/java/src/main/java/com/saucelabs/saucebindings/options/builders/SauceEdgeBuilder.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/builders/SauceEdgeBuilder.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 @Accessors(chain = true) @Setter @Getter
-public class SauceEdgeBuilder extends BaseOptions {
+public class SauceEdgeBuilder extends BaseOptions implements Builder<SauceEdgeBuilder> {
     public SauceOptions sauceOptions;
 
     private Browser browserName = Browser.EDGE;

--- a/java/src/main/java/com/saucelabs/saucebindings/options/builders/SauceFirefoxBuilder.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/builders/SauceFirefoxBuilder.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 @Accessors(chain = true) @Setter @Getter
-public class SauceFirefoxBuilder extends BaseOptions {
+public class SauceFirefoxBuilder extends BaseOptions implements Builder<SauceFirefoxBuilder> {
     public SauceOptions sauceOptions;
 
     private Browser browserName = Browser.FIREFOX;

--- a/java/src/main/java/com/saucelabs/saucebindings/options/builders/SauceIEBuilder.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/builders/SauceIEBuilder.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 @Accessors(chain = true) @Setter @Getter
-public class SauceIEBuilder extends BaseOptions {
+public class SauceIEBuilder extends BaseOptions implements Builder<SauceIEBuilder> {
     public SauceOptions sauceOptions;
 
     private Browser browserName = Browser.INTERNET_EXPLORER;

--- a/java/src/main/java/com/saucelabs/saucebindings/options/builders/SauceSafariBuilder.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/builders/SauceSafariBuilder.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 @Accessors(chain = true) @Setter @Getter
-public class SauceSafariBuilder extends BaseOptions {
+public class SauceSafariBuilder extends BaseOptions implements Builder<SauceSafariBuilder> {
     public SauceOptions sauceOptions;
 
     private Browser browserName = Browser.SAFARI;

--- a/java/src/test/java/com/saucelabs/saucebindings/VisualOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/VisualOptionsTest.java
@@ -1,0 +1,119 @@
+package com.saucelabs.saucebindings;
+
+import lombok.SneakyThrows;
+import org.junit.Test;
+import org.openqa.selenium.MutableCapabilities;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class VisualOptionsTest {
+    @Test
+    public void setsProjectNameByDefault() {
+        SauceOptions sauceOptions = new SauceOptions();
+
+        assertEquals("Default Project Name", sauceOptions.visual().getProjectName());
+    }
+
+    @Test
+    public void setsVisualValues() {
+        Map<String, Object> diffMap = new HashMap<>();
+        diffMap.put("structure", false);
+        diffMap.put("layout", false);
+        diffMap.put("style", false);
+        diffMap.put("content", false);
+        diffMap.put("minLayoutPosition", 5);
+        diffMap.put("minLayoutDimension", 9);
+
+        SauceOptions sauceOptions = new SauceOptions();
+        sauceOptions.sauce().setBuild("Build Name");
+        sauceOptions.visual().setProjectName("setsVisualValues");
+        sauceOptions.visual().setViewportSize("1900x1200");
+        sauceOptions.visual().setBranch("my-branch");
+        sauceOptions.visual().setBaseBranch("base-branch");
+        sauceOptions.visual().setIgnore("#some-id, .some-class");
+        sauceOptions.visual().setFailOnNewStates(true);
+        sauceOptions.visual().setAlwaysAcceptBaseBranch(true);
+        sauceOptions.visual().setDisableBranchBaseline(true);
+        sauceOptions.visual().setScrollAndStitchScreenshots(true);
+        sauceOptions.visual().setDisableCORS(true);
+        sauceOptions.visual().setDiffOptions(diffMap);
+
+        MutableCapabilities expectedCapabilities = new MutableCapabilities();
+        expectedCapabilities.setCapability("browserName", "chrome");
+        expectedCapabilities.setCapability("browserVersion", "latest");
+        expectedCapabilities.setCapability("platformName", "Windows 10");
+
+        MutableCapabilities sauceCapabilities = new MutableCapabilities();
+        sauceCapabilities.setCapability("build", "Build Name");
+        sauceCapabilities.setCapability("username", SystemManager.getEnv("SAUCE_USERNAME"));
+        sauceCapabilities.setCapability("accessKey", SystemManager.getEnv("SAUCE_ACCESS_KEY"));
+        expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
+
+        MutableCapabilities visualCapabilities = new MutableCapabilities();
+        visualCapabilities.setCapability("apiKey", System.getenv("SCREENER_API_KEY"));
+
+        visualCapabilities.setCapability("projectName", "setsVisualValues");
+        visualCapabilities.setCapability("viewportSize", "1900x1200");
+        visualCapabilities.setCapability("branch", "my-branch");
+        visualCapabilities.setCapability("baseBranch", "base-branch");
+
+        visualCapabilities.setCapability("diffOptions", diffMap);
+        visualCapabilities.setCapability("ignore", "#some-id, .some-class");
+
+        visualCapabilities.setCapability("failOnNewStates", true);
+        visualCapabilities.setCapability("alwaysAcceptBaseBranch", true);
+        visualCapabilities.setCapability("disableBranchBaseline", true);
+        visualCapabilities.setCapability("scrollAndStitchScreenshots", true);
+        visualCapabilities.setCapability("disableCORS", true);
+
+        expectedCapabilities.setCapability("sauce:visual", visualCapabilities);
+
+        MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
+        // toString() serializes the enums
+        assertEquals(expectedCapabilities.asMap().toString(), actualCapabilities.asMap().toString());
+    }
+
+    @SneakyThrows
+    public Map<String, Object> serialize(String key) {
+        InputStream input = new FileInputStream(new File("src/test/java/com/saucelabs/saucebindings/options.yml"));
+        Yaml yaml = new Yaml();
+        Map<String, Object> data = yaml.load(input);
+        return (Map<String, Object>) data.get(key);
+    }
+
+    @Test
+    public void setsVisualCapabilitiesFromMap() {
+        SauceOptions sauceOptions = new SauceOptions();
+
+        Map<String, Object> map = serialize("visualValues");
+        sauceOptions.mergeCapabilities(map);
+
+        Map<String, Object> diffMap = new HashMap<>();
+        diffMap.put("structure", true);
+        diffMap.put("layout", true);
+        diffMap.put("style", true);
+        diffMap.put("content", true);
+        diffMap.put("minLayoutPosition", 3);
+        diffMap.put("minLayoutDimension", 12);
+
+        assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals("68", sauceOptions.getBrowserVersion());
+        assertEquals(SaucePlatform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
+        assertEquals("Sample Build Name", sauceOptions.getBuild());
+        assertEquals("fromYAML", sauceOptions.visual().getProjectName());
+        assertEquals("1280x1024", sauceOptions.visual().getViewportSize());
+        assertEquals(diffMap, sauceOptions.visual().getDiffOptions());
+        assertEquals("#foo, .bar", sauceOptions.visual().getIgnore());
+        assertTrue(sauceOptions.visual().getFailOnNewStates());
+        assertTrue(sauceOptions.visual().getScrollAndStitchScreenshots());
+        assertTrue(sauceOptions.visual().getDisableCORS());
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/configs/SauceChromeConfigsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/configs/SauceChromeConfigsTest.java
@@ -138,4 +138,19 @@ public class SauceChromeConfigsTest {
         assertEquals("77", sauceOptions.getBrowserVersion());
         assertEquals(chromeOptions, sauceOptions.getCapabilities());
     }
+
+    @Test
+    public void createsVisualValues() {
+        SauceOptions sauceOptions = SauceOptionsFactory.chrome()
+                .visual()
+                    .setProjectName("Project Name")
+                    .build()
+                .sauce()
+                    .setBuild("My Build")
+                    .build()
+                .build();
+        assertEquals("Project Name", sauceOptions.visual().getProjectName());
+        assertEquals("My Build", sauceOptions.sauce().getBuild());
+        assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
+    }
 }

--- a/java/src/test/java/com/saucelabs/saucebindings/configs/SauceEdgeConfigsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/configs/SauceEdgeConfigsTest.java
@@ -132,4 +132,19 @@ public class SauceEdgeConfigsTest {
         assertEquals("77", sauceOptions.getBrowserVersion());
         assertEquals(edgeOptions, sauceOptions.getCapabilities());
     }
+
+    @Test
+    public void createsVisualValues() {
+        SauceOptions sauceOptions = SauceOptionsFactory.edge()
+                .visual()
+                    .setProjectName("Project Name")
+                    .build()
+                .sauce()
+                    .setBuild("My Build")
+                    .build()
+                .build();
+        assertEquals("Project Name", sauceOptions.visual().getProjectName());
+        assertEquals("My Build", sauceOptions.sauce().getBuild());
+        assertEquals(Browser.EDGE, sauceOptions.getBrowserName());
+    }
 }

--- a/java/src/test/java/com/saucelabs/saucebindings/configs/SauceFirefoxConfigsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/configs/SauceFirefoxConfigsTest.java
@@ -136,4 +136,19 @@ public class SauceFirefoxConfigsTest {
         assertEquals("77", sauceOptions.getBrowserVersion());
         assertEquals(firefoxOptions, sauceOptions.getCapabilities());
     }
+
+    @Test
+    public void createsVisualValues() {
+        SauceOptions sauceOptions = SauceOptionsFactory.firefox()
+                .visual()
+                    .setProjectName("Project Name")
+                    .build()
+                .sauce()
+                    .setBuild("My Build")
+                    .build()
+                .build();
+        assertEquals("Project Name", sauceOptions.visual().getProjectName());
+        assertEquals("My Build", sauceOptions.sauce().getBuild());
+        assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
+    }
 }

--- a/java/src/test/java/com/saucelabs/saucebindings/configs/SauceIEConfigsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/configs/SauceIEConfigsTest.java
@@ -136,4 +136,19 @@ public class SauceIEConfigsTest {
         assertEquals("77", sauceOptions.getBrowserVersion());
         assertEquals(internetExplorerOptions, sauceOptions.getCapabilities());
     }
+
+    @Test
+    public void createsVisualValues() {
+        SauceOptions sauceOptions = SauceOptionsFactory.internetExplorer()
+                .visual()
+                    .setProjectName("Project Name")
+                    .build()
+                .sauce()
+                    .setBuild("My Build")
+                    .build()
+                .build();
+        assertEquals("Project Name", sauceOptions.visual().getProjectName());
+        assertEquals("My Build", sauceOptions.sauce().getBuild());
+        assertEquals(Browser.INTERNET_EXPLORER, sauceOptions.getBrowserName());
+    }
 }

--- a/java/src/test/java/com/saucelabs/saucebindings/configs/SauceSafariConfigsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/configs/SauceSafariConfigsTest.java
@@ -134,4 +134,19 @@ public class SauceSafariConfigsTest {
         assertEquals("77", sauceOptions.getBrowserVersion());
         assertEquals(safariOptions, sauceOptions.getCapabilities());
     }
+
+    @Test
+    public void createsVisualValues() {
+        SauceOptions sauceOptions = SauceOptionsFactory.safari()
+                .visual()
+                    .setProjectName("Project Name")
+                    .build()
+                .sauce()
+                    .setBuild("My Build")
+                    .build()
+                .build();
+        assertEquals("Project Name", sauceOptions.visual().getProjectName());
+        assertEquals("My Build", sauceOptions.sauce().getBuild());
+        assertEquals(Browser.SAFARI, sauceOptions.getBrowserName());
+    }
 }

--- a/java/src/test/java/com/saucelabs/saucebindings/options.yml
+++ b/java/src/test/java/com/saucelabs/saucebindings/options.yml
@@ -86,3 +86,24 @@ invalidSauceOption:
   platformName: "MacOS 10.12"
   sauce:
     foo: "bar"
+
+visualValues:
+  browserName: 'firefox'
+  browserVersion: '68'
+  platformName: 'macOS 10.13'
+  sauce:
+    build: 'Sample Build Name'
+  visual:
+    projectName: 'fromYAML'
+    viewportSize: '1280x1024'
+    diffOptions:
+      structure: true
+      layout: true
+      style: true
+      content: true
+      minLayoutPosition: 3
+      minLayoutDimension: 12
+    ignore: '#foo, .bar'
+    failOnNewStates: true
+    scrollAndStitchScreenshots: true
+    disableCORS: true


### PR DESCRIPTION
(DRAFT because it is a mix of #238 & #239 with the addition of visual builder functionality)

We can now do:
```
SauceOptions sauceOptions = SauceOptionsFactory.chrome()
                .setBrowserVersion("80")
                .visual()
                    .setProjectName("Project Name")
                    .build()
                .sauce()
                    .setBuild("My Build")
                    .build()
                .build();
```

VisualOptions is less complicated because everything is supported on all the platforms.
I'm not sure exactly how this looks when combined with mobile?

Also, tbh, I'm not certain what I'm doing with the default method on the interface, but it seems to work, so ¯\\_(ツ)_/¯
