### PR TITLE
[Java] Add support for visual tests

### DIFF
--- a/java/src/main/java/com/saucelabs/saucebindings/DataCenter.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/DataCenter.java
@@ -6,7 +6,8 @@ public enum DataCenter {
     US_WEST("https://ondemand.us-west-1.saucelabs.com/wd/hub"),
     US_EAST("https://ondemand.us-east-1.saucelabs.com/wd/hub"),
     EU_CENTRAL("https://ondemand.eu-central-1.saucelabs.com/wd/hub"),
-    APAC_SOUTHEAST("https://ondemand.apac-southeast-1.saucelabs.com/wd/hub");
+    APAC_SOUTHEAST("https://ondemand.apac-southeast-1.saucelabs.com/wd/hub"),
+    VISUAL("https://hub.screener.io/wd/hub");
 
     @Getter private final String value;
 

--- a/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -1,6 +1,7 @@
 package com.saucelabs.saucebindings;
 
 import com.saucelabs.saucebindings.options.BaseConfigurations;
+import com.saucelabs.saucebindings.options.InvalidSauceOptionsArgumentException;
 import com.saucelabs.saucebindings.options.SauceOptions;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,11 +11,14 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 
 public class SauceSession {
     @Getter @Setter private DataCenter dataCenter = DataCenter.US_WEST;
     @Getter private final SauceOptions sauceOptions;
     @Setter private URL sauceUrl;
+    private VisualSession visualSession;
+    @Getter private Boolean isVisualSession = false;
 
     @Getter private RemoteWebDriver driver;
 
@@ -34,27 +38,45 @@ public class SauceSession {
 
     public SauceSession(SauceOptions options) {
         sauceOptions = options;
+        if (sauceOptions.visual() != null) {
+            isVisualSession = true;
+            visualSession = new VisualSession(sauceOptions.visual());
+        }
     }
 
     public RemoteWebDriver start() {
-        driver = createRemoteWebDriver(getSauceUrl(), sauceOptions.toCapabilities());
+        if (isVisualSession) {
+            if (sauceOptions.sauce().getName() == null) {
+                String msg = "Visual Tests Require setting a name in options: SauceOptions#setName(Name)";
+                throw new InvalidSauceOptionsArgumentException(msg);
+            } else {
+                driver = createRemoteWebDriver(visualSession.getUrl(), sauceOptions.toCapabilities());
+                visualSession.start(driver, sauceOptions.sauce().getName());
+            }
+        } else {
+            driver = createRemoteWebDriver(getSauceUrl(), sauceOptions.toCapabilities());
+        }
         return driver;
 	}
 
     public URL getSauceUrl() {
-        if (sauceUrl != null) {
-            return sauceUrl;
-        } else {
-            try {
+        try {
+            if (sauceUrl != null) {
+                return sauceUrl;
+            } else {
                 return new URL(dataCenter.getValue());
-            } catch (MalformedURLException e) {
-                throw new InvalidArgumentException("Invalid URL");
             }
+        } catch (MalformedURLException e) {
+            throw new InvalidArgumentException("Invalid URL");
         }
     }
 
     protected RemoteWebDriver createRemoteWebDriver(URL url, MutableCapabilities capabilities) {
         return new RemoteWebDriver(url, capabilities);
+    }
+
+    public VisualSession visual() {
+        return visualSession;
     }
 
     public void stop(Boolean passed) {
@@ -63,25 +85,39 @@ public class SauceSession {
     }
 
     public void stop(String result) {
-        updateResult(result);
-        stop();
+        if (this.driver != null) {
+            updateResult(result);
+            stop();
+        }
     }
 
     private void updateResult(String result) {
         getDriver().executeScript("sauce:job-result=" + result);
+
         // Add output for the Sauce OnDemand Jenkins plugin
         // The first print statement will automatically populate links on Jenkins to Sauce
         // The second print statement will output the job link to logging/console
-        if (this.driver != null) {
-            String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s", this.driver.getSessionId(), this.sauceOptions.sauce().getName());
-            String sauceTestLink = String.format("Test Job Link: https://app.saucelabs.com/tests/%s", this.driver.getSessionId());
-            System.out.print(sauceReporter + "\n" + sauceTestLink + "\n");
-        }
+        String sauceReporter = String.format("SauceOnDemandSessionID=%s job-name=%s",
+                this.driver.getSessionId(),
+                this.sauceOptions.sauce().getName());
+        String sauceTestLink = String.format("Test Job Link: https://app.saucelabs.com/tests/%s",
+                this.driver.getSessionId());
+        System.out.print(sauceReporter + "\n" + sauceTestLink + "\n");
     }
 
     private void stop() {
-        if(driver !=null) {
-            driver.quit();
+        if (isVisualSession) {
+            System.out.println("\n Visual Results: " + visual().getResults());
+        }
+
+        driver.quit();
+    }
+
+    public void sleep(Duration time) {
+        try {
+            Thread.sleep(time.toMillis());
+        } catch (InterruptedException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/SystemManager.java
@@ -1,5 +1,9 @@
 package com.saucelabs.saucebindings;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
 public class SystemManager {
 
     /**
@@ -32,6 +36,22 @@ public class SystemManager {
             return System.getenv(key);
         } else {
             return null;
+        }
+    }
+
+    public static String getCurrentGitBranch() {
+        try {
+            Process process = Runtime.getRuntime().exec("git rev-parse --abbrev-ref HEAD");
+            process.waitFor();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            String line = reader.readLine();
+            if (line.contains("fatal:")) {
+                return "default";
+            } else {
+                return line;
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/java/src/main/java/com/saucelabs/saucebindings/VisualSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/VisualSession.java
@@ -1,0 +1,46 @@
+package com.saucelabs.saucebindings;
+
+import com.saucelabs.saucebindings.options.VisualOptions;
+import lombok.Getter;
+import lombok.Setter;
+import org.openqa.selenium.InvalidArgumentException;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+public class VisualSession {
+    @Getter @Setter private DataCenter dataCenter = DataCenter.VISUAL;
+    @Getter private final VisualOptions visualOptions;
+    @Getter @Setter private RemoteWebDriver driver;
+
+    public VisualSession(VisualOptions visualOptions) {
+        this.visualOptions = visualOptions;
+    }
+
+    public void start(RemoteWebDriver driver, String name) {
+        this.driver = driver;
+        init(name);
+    }
+
+    public void init(String name) {
+        driver.executeScript("/*@visual.init*/", name);
+    }
+
+    public URL getUrl() {
+        try {
+            return new URL(dataCenter.getValue());
+        } catch (MalformedURLException e) {
+            throw new InvalidArgumentException("Invalid URL");
+        }
+    }
+
+    public Map getResults() {
+        return (Map) driver.executeScript("/*@visual.end*/");
+    }
+
+    public void takeSnapshot(String name) {
+        driver.executeScript("/*@visual.snapshot*/", name);
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/VisualSession.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/VisualSession.java
@@ -3,11 +3,8 @@ package com.saucelabs.saucebindings;
 import com.saucelabs.saucebindings.options.VisualOptions;
 import lombok.Getter;
 import lombok.Setter;
-import org.openqa.selenium.InvalidArgumentException;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Map;
 
 public class VisualSession {
@@ -26,14 +23,6 @@ public class VisualSession {
 
     public void init(String name) {
         driver.executeScript("/*@visual.init*/", name);
-    }
-
-    public URL getUrl() {
-        try {
-            return new URL(dataCenter.getValue());
-        } catch (MalformedURLException e) {
-            throw new InvalidArgumentException("Invalid URL");
-        }
     }
 
     public Map getResults() {

--- a/java/src/main/java/com/saucelabs/saucebindings/examples/VisualTest.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/examples/VisualTest.java
@@ -1,0 +1,47 @@
+package com.saucelabs.saucebindings.examples;
+
+import com.saucelabs.saucebindings.SaucePlatform;
+import com.saucelabs.saucebindings.SauceSession;
+import com.saucelabs.saucebindings.options.SauceOptions;
+import com.saucelabs.saucebindings.options.VisualOptions;
+import org.junit.Test;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.util.Map;
+
+public class VisualTest {
+
+    @Test
+    public void startSession() {
+        // 1. Create Visual Options instance
+        VisualOptions visualOptions = new VisualOptions();
+        visualOptions.setProjectName("My Project")
+                .setViewportSize("1024x768");
+
+        // 2. Use setVisualOptions() to add the visual options; Make sure setName() has a value
+        SauceOptions sauceOptions = SauceOptions.chrome()
+                .setName("My Test Name")
+                .setPlatformName(SaucePlatform.MAC_HIGH_SIERRA)
+                .setBrowserVersion("68")
+                .setVisualOptions(visualOptions)
+                .build();
+
+        // 3. Start the Session with SauceOptions
+        SauceSession session = new SauceSession(sauceOptions);
+
+        // 4. Start Session to get the Driver
+        RemoteWebDriver driver = session.start();
+
+        // 5. Use the driver in your tests just like normal
+        driver.get("https://www.saucedemo.com/");
+
+        // 6. Use the session to take a snapshot
+        session.visual().takeSnapshot("Sauce Demo Page");
+
+        // 7. Use the session to get visual results
+        Map results = session.visual().getResults();
+
+        // 8. Stop the Session with whether the test passed or failed
+        session.stop(true);
+    }
+}

--- a/java/src/main/java/com/saucelabs/saucebindings/options/BaseOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/BaseOptions.java
@@ -1,8 +1,10 @@
 package com.saucelabs.saucebindings.options;
 
+import com.saucelabs.saucebindings.SystemManager;
 import lombok.Getter;
 import org.openqa.selenium.MutableCapabilities;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,4 +31,70 @@ public abstract class BaseOptions {
     protected void setCapability(String key, Object value) {
         capabilityManager.setCapability(key, value);
     };
+
+    protected String defaultBuildName() {
+        if (SystemManager.get(knownCITools.get("Jenkins")) != null) {
+            return SystemManager.get("BUILD_NAME");
+        } else if (SystemManager.get(knownCITools.get("Bamboo")) != null) {
+            return SystemManager.get("bamboo_shortJobName");
+        } else if (SystemManager.get(knownCITools.get("Travis")) != null) {
+            return SystemManager.get("TRAVIS_JOB_NAME");
+        } else if (SystemManager.get(knownCITools.get("Circle")) != null) {
+            return SystemManager.get("CIRCLE_JOB");
+        } else if (SystemManager.get(knownCITools.get("GitLab")) != null) {
+            return SystemManager.get("CI_JOB_NAME");
+        } else if (SystemManager.get(knownCITools.get("TeamCity")) != null) {
+            return SystemManager.get("TEAMCITY_PROJECT_NAME");
+        } else if (SystemManager.get("BUILD_NAME") != null) {
+            return SystemManager.get("BUILD_NAME");
+        } else {
+            return "Build Time";
+        }
+    }
+
+    protected String defaultBuildNumber() {
+        if (SystemManager.get("BUILD_NUMBER") != null) {
+            return SystemManager.get("BUILD_NUMBER");
+        } else if (SystemManager.get(knownCITools.get("Bamboo")) != null) {
+            return SystemManager.get("bamboo_buildNumber");
+        } else if (SystemManager.get(knownCITools.get("Travis")) != null) {
+            return SystemManager.get("TRAVIS_JOB_NUMBER");
+        } else if (SystemManager.get(knownCITools.get("Circle")) != null) {
+            return SystemManager.get("CIRCLE_BUILD_NUM");
+        } else if (SystemManager.get(knownCITools.get("GitLab")) != null) {
+            return SystemManager.get("CI_JOB_ID");
+        } else if (SystemManager.get(knownCITools.get("TeamCity")) != null) {
+            return SystemManager.get("BUILD_NUMBER");
+        } else if (SystemManager.get("BUILD_NUMBER") != null) {
+            return SystemManager.get("BUILD_NUMBER");
+        } else {
+            String time = String.valueOf(System.currentTimeMillis());
+            System.setProperty("BUILD_NUMBER", time);
+            return time;
+        }
+    }
+
+    /**
+     * @deprecated This method is no longer supported
+     */
+    @Deprecated
+    public boolean isKnownCI() {
+        return !knownCITools.keySet().stream().allMatch((key) -> SystemManager.get(key) == null);
+    }
+
+    /**
+     * @deprecated This method will no longer be public
+     */
+    @Deprecated
+    public static final Map<String, String> knownCITools;
+
+    static {
+        knownCITools = new HashMap<>();
+        knownCITools.put("Jenkins", "BUILD_TAG");
+        knownCITools.put("Bamboo", "bamboo_agentId");
+        knownCITools.put("Travis", "TRAVIS_JOB_ID");
+        knownCITools.put("Circle", "CIRCLE_JOB");
+        knownCITools.put("GitLab", "CI");
+        knownCITools.put("TeamCity", "TEAMCITY_PROJECT_NAME");
+    }
 }

--- a/java/src/main/java/com/saucelabs/saucebindings/options/SauceLabsOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/SauceLabsOptions.java
@@ -138,46 +138,9 @@ public class SauceLabsOptions extends BaseOptions {
     public String getBuild() {
         if (build != null) {
             return build;
-        } else if (SystemManager.get(knownCITools.get("Jenkins")) != null) {
-            return SystemManager.get("BUILD_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
-        } else if (SystemManager.get(knownCITools.get("Bamboo")) != null) {
-            return SystemManager.get("bamboo_shortJobName") + ": " + SystemManager.get("bamboo_buildNumber");
-        } else if (SystemManager.get(knownCITools.get("Travis")) != null) {
-            return SystemManager.get("TRAVIS_JOB_NAME") + ": " + SystemManager.get("TRAVIS_JOB_NUMBER");
-        } else if (SystemManager.get(knownCITools.get("Circle")) != null) {
-            return SystemManager.get("CIRCLE_JOB") + ": " + SystemManager.get("CIRCLE_BUILD_NUM");
-        } else if (SystemManager.get(knownCITools.get("GitLab")) != null) {
-            return SystemManager.get("CI_JOB_NAME") + ": " + SystemManager.get("CI_JOB_ID");
-        } else if (SystemManager.get(knownCITools.get("TeamCity")) != null) {
-            return SystemManager.get("TEAMCITY_PROJECT_NAME") + ": " + SystemManager.get("BUILD_NUMBER");
         } else {
-            return "Build Time: " + System.currentTimeMillis();
+            return defaultBuildName() + ": " + defaultBuildNumber();
         }
-    }
-
-    /**
-     * @deprecated This method is no longer supported
-     * @return whether CI is accounted for in code
-     */
-    @Deprecated
-    public boolean isKnownCI() {
-        return !knownCITools.keySet().stream().allMatch((key) -> SystemManager.get(key) == null);
-    }
-
-    /**
-     * @deprecated This method will no longer be public
-     */
-    @Deprecated
-    public static final Map<String, String> knownCITools;
-
-    static {
-        knownCITools = new HashMap<>();
-        knownCITools.put("Jenkins", "BUILD_TAG");
-        knownCITools.put("Bamboo", "bamboo_agentId");
-        knownCITools.put("Travis", "TRAVIS_JOB_ID");
-        knownCITools.put("Circle", "CIRCLE_JOB");
-        knownCITools.put("GitLab", "CI");
-        knownCITools.put("TeamCity", "TEAMCITY_PROJECT_NAME");
     }
 
     protected String getSauceUsername() {

--- a/java/src/main/java/com/saucelabs/saucebindings/options/SauceOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/SauceOptions.java
@@ -23,6 +23,7 @@ import java.util.Map;
 @Setter @Getter
 public class SauceOptions extends BaseOptions {
     @Setter(AccessLevel.NONE) @Getter(AccessLevel.NONE) private SauceLabsOptions sauceLabsOptions = null;
+    @Getter(AccessLevel.NONE) private VisualOptions visualOptions = null;
     public TimeoutStore timeout = new TimeoutStore();
 
     // w3c Settings
@@ -176,6 +177,16 @@ public class SauceOptions extends BaseOptions {
         return sauceLabsOptions;
     }
 
+    /**
+     * This method does not need to be used if working with the static methods and the build() method
+     *
+     * @return an instance of VisualOptions if one has been created
+     * @see #setVisualOptions(VisualOptions)
+     */
+    public VisualOptions visual() {
+        return visualOptions;
+    }
+
     public SauceOptions() {
         this(new MutableCapabilities());
     }
@@ -203,7 +214,10 @@ public class SauceOptions extends BaseOptions {
      */
     public MutableCapabilities toCapabilities() {
         capabilityManager.addCapabilities();
-        capabilities.setCapability("sauce:options", sauce().toCapabilities());
+        capabilities.setCapability("sauce:options", sauceLabsOptions.toCapabilities());
+        if (visualOptions != null) {
+            capabilities.setCapability("sauce:visual", visualOptions.toCapabilities());
+        }
         return capabilities;
     }
 
@@ -243,6 +257,9 @@ public class SauceOptions extends BaseOptions {
                 break;
             case "sauce":
                 sauce().mergeCapabilities((HashMap<String, Object>) value);
+                break;
+            case "visual":
+                visual().mergeCapabilities((HashMap<String, Object>) value);
                 break;
             default:
                 if (sauce().getValidOptions().contains(key)) {

--- a/java/src/main/java/com/saucelabs/saucebindings/options/VDCConfigurations.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/VDCConfigurations.java
@@ -244,4 +244,22 @@ public abstract class VDCConfigurations<T extends VDCConfigurations<T>> extends 
         sauceOptions.sauce().setTimeZone(timeZone);
         return (T) this;
     }
+
+    /**
+     * Toggle on executing as Visual Test with default options
+     *
+     * @return instance of Configuration
+     */
+    public T setVisual() {
+        return setVisualOptions(new VisualOptions());
+    }
+
+    /**
+     * @param options specify the visual options to use with the test
+     * @return instance of Configuration
+     */
+    public T setVisualOptions(VisualOptions options) {
+        sauceOptions.setVisualOptions(options);
+        return (T) this;
+    }
 }

--- a/java/src/main/java/com/saucelabs/saucebindings/options/VisualOptions.java
+++ b/java/src/main/java/com/saucelabs/saucebindings/options/VisualOptions.java
@@ -1,0 +1,69 @@
+package com.saucelabs.saucebindings.options;
+
+import com.saucelabs.saucebindings.SauceSession;
+import com.saucelabs.saucebindings.SystemManager;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Accessors(chain = true) @Setter @Getter
+public class VisualOptions extends BaseOptions {
+    private String projectName;
+    private String viewportSize;
+    private String branch;
+    private String baseBranch;
+    private Map<String, Object> diffOptions = null;
+    private String ignore;
+    private Boolean failOnNewStates = null;
+    private Boolean alwaysAcceptBaseBranch = null;
+    private Boolean disableBranchBaseline = null;
+    private Boolean scrollAndStitchScreenshots = null;
+    private Boolean disableCORS = null;
+    private Boolean iframes = null;
+    private Map<String, Object> iframesOptions = null;
+
+    public final List<String> validOptions = Arrays.asList(
+            "projectName",
+            "viewportSize",
+            "branch",
+            "baseBranch",
+            "diffOptions",
+            "ignore",
+            "failOnNewStates",
+            "alwaysAcceptBaseBranch",
+            "disableBranchBaseline",
+            "scrollAndStitchScreenshots",
+            "disableCORS",
+            "iframes",
+            "iframesOptions");
+
+    public VisualOptions() {
+        capabilityManager = new CapabilityManager(this);
+    }
+
+    /**
+     * @return instance of MutableCapabilities representing all key value pairs set in SauceOptions
+     * @see SauceSession#start()
+     */
+    public MutableCapabilities toCapabilities() {
+        String msg = "Environment Variable or Sytem Property for 'SCREENER_API_KEY' must be provided";
+        String sauceVisualApiKey = SystemManager.get("SCREENER_API_KEY", msg);
+        capabilities.setCapability("apiKey", sauceVisualApiKey);
+
+        if (projectName == null) {
+            projectName = defaultBuildName();
+        }
+
+        if (branch == null) {
+            branch = SystemManager.getCurrentGitBranch();
+        }
+
+        capabilityManager.addCapabilities();
+        return capabilities;
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
@@ -1,5 +1,6 @@
 package com.saucelabs.saucebindings.integration;
 
+import com.saucelabs.saucebindings.DataCenter;
 import com.saucelabs.saucebindings.SauceSession;
 import com.saucelabs.saucebindings.SystemManager;
 import com.saucelabs.saucebindings.options.InvalidSauceOptionsArgumentException;
@@ -31,9 +32,20 @@ public class VisualTest {
     }
 
     @Test
-    public void usesVisualWhenSet() {
+    public void usesVisualWhenOptionSet() {
         SauceOptions options = SauceOptions.chrome().setName("Visual uses this name").setVisual().build();
         session = new SauceSession(options);
+        webDriver = session.start();
+        session.visual().takeSnapshot("Snapshot necessary to for Visual test to pass");
+        assertNotNull(webDriver);
+        assertTrue(session.getIsVisualSession());
+    }
+
+    @Test
+    public void usesVisualWhenDataCenterSet() {
+        SauceOptions options = SauceOptions.chrome().setName("Visual uses this name").build();
+        session = new SauceSession(options);
+        session.setDataCenter(DataCenter.VISUAL);
         webDriver = session.start();
         session.visual().takeSnapshot("Snapshot necessary to for Visual test to pass");
         assertNotNull(webDriver);

--- a/java/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
@@ -1,0 +1,104 @@
+package com.saucelabs.saucebindings.integration;
+
+import com.saucelabs.saucebindings.SauceSession;
+import com.saucelabs.saucebindings.SystemManager;
+import com.saucelabs.saucebindings.options.InvalidSauceOptionsArgumentException;
+import com.saucelabs.saucebindings.options.SauceOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class VisualTest {
+    private SauceSession session;
+    private RemoteWebDriver webDriver;
+
+    @Before
+    public void setup() {
+        System.setProperty("BUILD_NAME", "Sauce Bindings");
+    }
+
+    @After
+    public void cleanUp() {
+        if (session != null) {
+            session.stop(true);
+        }
+    }
+
+    @Test
+    public void usesVisualWhenSet() {
+        SauceOptions options = SauceOptions.chrome().setName("Visual uses this name").setVisual().build();
+        session = new SauceSession(options);
+        webDriver = session.start();
+        session.visual().takeSnapshot("Snapshot necessary to for Visual test to pass");
+        assertNotNull(webDriver);
+        assertTrue(session.getIsVisualSession());
+    }
+
+    @Test
+    public void acceptsNameForInit() {
+        SauceOptions options = SauceOptions.chrome().setName("Visual does not use this name").setVisual().build();
+        session = new SauceSession(options);
+        webDriver = session.start();
+        session.visual().init("Visual uses this name instead");
+        session.visual().takeSnapshot("Snapshot necessary to for Visual test to pass");
+        Map results = session.visual().getResults();
+        Map snapshot = (Map) ((List) results.get("states")).get(0);
+        assertEquals("Visual uses this name instead", snapshot.get("groupName"));
+    }
+
+    @Test
+    public void takesSnapshot() {
+        SauceOptions options = SauceOptions.chrome().setName("Takes Sauce Snapshot").setVisual().build();
+        session = new SauceSession(options);
+        webDriver = session.start();
+        session.visual().takeSnapshot("Name of Snapshot");
+        Map results = session.visual().getResults();
+        Map snapshot = (Map) ((List) results.get("states")).get(0);
+        assertEquals("Name of Snapshot", snapshot.get("name"));
+    }
+
+    @Test
+    public void providesTestResults() {
+        SauceOptions options = SauceOptions.chrome().setName("Provides Test Results").setVisual().build();
+        session = new SauceSession(options);
+        webDriver = session.start();
+        session.visual().takeSnapshot("Name-of-Snapshot");
+        Map results = session.visual().getResults();
+        assertTrue((Boolean) results.get("passed"));
+        assertEquals("success", results.get("status"));
+        assertNull(results.get("message"));
+        assertEquals(1, ((List) results.get("states")).size());
+        Map totals = (Map) results.get("totals");
+        assertEquals(0L, totals.get("new"));
+        assertEquals(0L, totals.get("changed"));
+        assertEquals(1L, totals.get("accepted"));
+        assertEquals(0L, totals.get("rejected"));
+        assertEquals(1L, totals.get("all"));
+        Map snapshot = (Map) ((List) results.get("states")).get(0);
+        assertEquals("Name-of-Snapshot", snapshot.get("name"));
+        assertEquals("Provides Test Results", snapshot.get("groupName"));
+        assertEquals("accepted", snapshot.get("status"));
+        String url = (String) snapshot.get("url");
+        assertTrue(url.contains(SystemManager.getCurrentGitBranch()));
+        assertTrue(url.contains("Name-of-Snapshot"));
+        assertTrue(url.contains("Windows%2010"));
+    }
+
+    @Test
+    public void errorsWithoutTestName() {
+        SauceOptions options = SauceOptions.chrome().setVisual().build();
+        try {
+            new SauceSession(options).start();
+            fail("Expected InvalidSauceOptionsArgumentException exception");
+        } catch (InvalidSauceOptionsArgumentException exception) {
+            String msg = "Visual Tests Require setting a name in options: SauceOptions#setName(Name)";
+            assertEquals(msg, exception.getMessage());
+        }
+    }
+}

--- a/java/src/test/java/com/saucelabs/saucebindings/options/VisualOptionsTest.java
+++ b/java/src/test/java/com/saucelabs/saucebindings/options/VisualOptionsTest.java
@@ -1,0 +1,140 @@
+package com.saucelabs.saucebindings.options;
+
+import com.saucelabs.saucebindings.SaucePlatform;
+import com.saucelabs.saucebindings.SystemManager;
+import org.junit.Test;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class VisualOptionsTest {
+    @Test
+    public void defaultsNoVisualOptions() {
+        SauceOptions sauceOptions = SauceOptions.chrome().build();
+        assertNull(sauceOptions.visual());
+    }
+
+    @Test
+    public void createsVisualOptions() {
+        SauceOptions sauceOptions = SauceOptions.chrome().setVisual().build();
+        assertNotNull(sauceOptions.visual());
+    }
+
+    @Test
+    public void acceptsVisualOptions() {
+        Map<String, Object> diffOptions = new HashMap<>();
+        diffOptions.put("structure", true);
+        diffOptions.put("layout", true);
+        diffOptions.put("style", true);
+        diffOptions.put("content", true);
+        diffOptions.put("minLayoutPosition", 4);
+        diffOptions.put("minLayoutDimension", 10);
+
+        Map<String, Object> iframesOptions = new HashMap<>();
+        iframesOptions.put("maxFrames", "Infinity");
+
+        VisualOptions visualOptions = new VisualOptions();
+        visualOptions
+                .setProjectName("My Project")
+                .setViewportSize("1024x768")
+                .setBranch("branch")
+                .setBaseBranch("baseBranch")
+                .setDiffOptions(diffOptions)
+                .setIgnore("#some-id, .some-selector")
+                .setFailOnNewStates(true)
+                .setAlwaysAcceptBaseBranch(true)
+                .setDisableBranchBaseline(true)
+                .setScrollAndStitchScreenshots(true)
+                .setDisableCORS(true)
+                .setIframes(true)
+                .setIframesOptions(iframesOptions);
+
+        SauceOptions sauceOptions = SauceOptions.chrome()
+                .setPlatformName(SaucePlatform.MAC_HIGH_SIERRA)
+                .setBrowserVersion("68")
+                .setVisualOptions(visualOptions)
+                .build();
+
+        assertEquals("My Project", sauceOptions.visual().getProjectName());
+        assertEquals("1024x768", sauceOptions.visual().getViewportSize());
+        assertEquals("baseBranch", sauceOptions.visual().getBaseBranch());
+        assertEquals(diffOptions, sauceOptions.visual().getDiffOptions());
+        assertEquals("#some-id, .some-selector", sauceOptions.visual().getIgnore());
+        assertTrue(sauceOptions.visual().getFailOnNewStates());
+        assertTrue(sauceOptions.visual().getAlwaysAcceptBaseBranch());
+        assertTrue(sauceOptions.visual().getDisableBranchBaseline());
+        assertTrue(sauceOptions.visual().getScrollAndStitchScreenshots());
+        assertTrue(sauceOptions.visual().getDisableCORS());
+        assertTrue(sauceOptions.visual().getIframes());
+        assertEquals(iframesOptions, sauceOptions.visual().getIframesOptions());
+    }
+
+    @Test
+    public void createsDefaultVisualValues() {
+        SauceOptions sauceOptions = SauceOptions.chrome().setVisual().build();
+
+        MutableCapabilities visualCapabilities = new MutableCapabilities();
+        visualCapabilities.setCapability("apiKey", System.getenv("SCREENER_API_KEY"));
+        visualCapabilities.setCapability("branch", SystemManager.getCurrentGitBranch());
+        visualCapabilities.setCapability("projectName", sauceOptions.defaultBuildName());
+
+        assertEquals(visualCapabilities, sauceOptions.toCapabilities().getCapability("sauce:visual"));
+    }
+
+    @Test
+    public void parsesCapabilitiesFromVisualValues() {
+        Map<String, Object> diffOptions = new HashMap<>();
+        diffOptions.put("structure", true);
+        diffOptions.put("layout", true);
+        diffOptions.put("style", true);
+        diffOptions.put("content", true);
+        diffOptions.put("minLayoutPosition", 4);
+        diffOptions.put("minLayoutDimension", 10);
+
+        Map<String, Object> iframesOptions = new HashMap<>();
+        iframesOptions.put("maxFrames", "Infinity");
+
+        VisualOptions visualOptions = new VisualOptions();
+        visualOptions
+                .setProjectName("My Project")
+                .setViewportSize("1024x768")
+                .setBranch("branch")
+                .setBaseBranch("baseBranch")
+                .setDiffOptions(diffOptions)
+                .setIgnore("#some-id, .some-selector")
+                .setFailOnNewStates(true)
+                .setAlwaysAcceptBaseBranch(true)
+                .setDisableBranchBaseline(true)
+                .setScrollAndStitchScreenshots(true)
+                .setDisableCORS(true)
+                .setIframes(true)
+                .setIframesOptions(iframesOptions);
+
+        SauceOptions sauceOptions = SauceOptions.chrome()
+                .setPlatformName(SaucePlatform.MAC_HIGH_SIERRA)
+                .setBrowserVersion("68")
+                .setVisualOptions(visualOptions)
+                .build();
+
+        MutableCapabilities visualCapabilities = new MutableCapabilities();
+        visualCapabilities.setCapability("projectName", "My Project");
+        visualCapabilities.setCapability("viewportSize", "1024x768");
+        visualCapabilities.setCapability("branch", "branch");
+        visualCapabilities.setCapability("baseBranch", "baseBranch");
+        visualCapabilities.setCapability("diffOptions", diffOptions);
+        visualCapabilities.setCapability("ignore", "#some-id, .some-selector");
+        visualCapabilities.setCapability("failOnNewStates", true);
+        visualCapabilities.setCapability("alwaysAcceptBaseBranch", true);
+        visualCapabilities.setCapability("disableBranchBaseline", true);
+        visualCapabilities.setCapability("scrollAndStitchScreenshots", true);
+        visualCapabilities.setCapability("disableCORS", true);
+        visualCapabilities.setCapability("iframes", true);
+        visualCapabilities.setCapability("iframesOptions", iframesOptions);
+        visualCapabilities.setCapability("apiKey", System.getenv("SCREENER_API_KEY"));
+
+        assertEquals(visualCapabilities, sauceOptions.toCapabilities().getCapability("sauce:visual"));
+    }
+}


### PR DESCRIPTION
Update: PR is now comparing against Main branch and is ready for final review.

Anyone have any issues with using `setVisualOptions()` instead of putting these methods directly in the `Config` classes like we're doing with `sauce:options` values? There are a few other ways this could be implemented, but the code in this PR is closest to what we're doing in `SauceOptions` class for easy maintenance. Mobile shouldn't have this issue since it won't be using the browser static methods.

~Next step is adding Session functionality.~

The goal here is to make it as simple as possible to do the most expected things, while still allowing users flexibility to override things as needed.

The main limitation is that `setName()` must be used with options, because I couldn't figure out a way to create a reasonable default. if we ever create JUnit/TestNG specific jars we might be able to do something easier.

* So minimum to get a visual test is either:

1. Use `setVisual()`
```java
SauceOptions sauceOptions = SauceOptions.chrome().setName("Test Name").setVisual().build();
SauceSession sauceSession = new SauceSession(sauceOptions);
RemoteWebDriver driver = sauceSession.start();
```

2. Use `SauceSession#setDataCenter()`
```java
SauceOptions sauceOptions = SauceOptions.chrome().setName("Test Name").build();
SauceSession sauceSession = new SauceSession(sauceOptions);
sauceSession.setDataCenter(DataCenter.VISUAL);
RemoteWebDriver driver = sauceSession.start();
```

* To specify additional Visual Options, use `setVisualOptions()`:
```java
VisualOptions visualOptions = new VisualOptions();
visualOptions.setViewportSize("1024x768");

SauceOptions sauceOptions = SauceOptions.chrome()
    .setName("Test Name")
    .setVisualOptions(visualOptions)
    .build();
```

* `projectName` defaults to `build` value, but can be overridden in visual options with `visualOptions.setProjectName("Project Name")`
* `@visual.init` defaults to `name` value, which is required, but can also be changed as necessary with `session.visual().init("Test Name")`
* If `branch` is not set in `VisualOptions`, we check for actual git branch; if git is not detected, it defaults to `"default"` (not `"(default)"`) to ensure link in stdout works.
* Snapshots are taken by `session.visual().takeSnapshot("Snapshot Name")`
* Results are printed to stdout at the end of the test, but may also be obtained with: `Map results = session.visual().getResults()`
