### PR TITLE
[java] allow configurations to be used with a browser string value

### DIFF
--- a/java/main/src/main/java/com/saucelabs/saucebindings/options/SauceOptions.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/options/SauceOptions.java
@@ -54,6 +54,51 @@ public class SauceOptions extends BaseOptions {
             "unhandledPromptBehavior");
 
     /**
+     *
+     * @param browserName the name of the browser
+     * @return instance of VDCConfigurations
+     */
+    public static VDCConfigurations buildOptionsFromBrowser(String browserName) {
+        switch(browserName) {
+        case "chrome":
+            return buildOptionsFromBrowser(browserName, new ChromeOptions());
+        case "edge":
+            return buildOptionsFromBrowser(browserName, new EdgeOptions());
+        case "firefox":
+            return buildOptionsFromBrowser(browserName, new FirefoxOptions());
+        case "ie":
+            return buildOptionsFromBrowser(browserName, new InternetExplorerOptions());
+        case "safari":
+            return buildOptionsFromBrowser(browserName, new SafariOptions());
+        default:
+            throw new IllegalArgumentException("Browser not supported: " + browserName);
+        }
+    }
+
+    /**
+     *
+     * @param browserName the name of the browser
+     * @param capabilities instance of BrowerOptions corresponding to browser name
+     * @return instance of VDCConfigurations
+     */
+    public static VDCConfigurations buildOptionsFromBrowser(String browserName, MutableCapabilities capabilities) {
+        switch(browserName) {
+        case "chrome":
+            return SauceOptions.chrome((ChromeOptions) capabilities);
+        case "edge":
+            return SauceOptions.edge((EdgeOptions) capabilities);
+        case "firefox":
+            return SauceOptions.firefox((FirefoxOptions) capabilities);
+        case "ie":
+            return SauceOptions.ie((InternetExplorerOptions) capabilities);
+        case "safari":
+            return SauceOptions.safari((SafariOptions) capabilities);
+        default:
+            throw new IllegalArgumentException("Browser not supported: " + browserName);
+        }
+    }
+
+    /**
      * This method allows building a default Sauce Options instance for Chrome
      * Call build() method on return value rather than using directly
      * @return instance of ChromeConfigurations


### PR DESCRIPTION
I don't know how I feel about this. People doing parameterized platform execution can not currently use the new syntax. This would allow them to do it, but I'm not sure if it is feature creep. 

Somewhat tangentially I'm now wondering if we should have put all the methods into `SauceOptionsBuilder` class instead of having them on `SauceOptions` directly. I can't remember if we considered this and rejected it or just overlooked it:

```java
SauceOptions options = SauceOptionsBuilder.chrome().setChromeThingOne().setChromeThingTwo().build();
SauceOptions options = SauceOptionsBuilder.usingBrowser("chrome").setChromeThingOne().setChromeThingTwo().build();
```