### PR TITLE
[java] validate capturePerformance requirements in build() 

### DIFF
--- a/java/main/src/main/java/com/saucelabs/saucebindings/options/ChromeConfigurations.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/options/ChromeConfigurations.java
@@ -15,9 +15,6 @@ public class ChromeConfigurations extends VDCConfigurations<ChromeConfigurations
     public ChromeConfigurations setCapturePerformance() {
         sauceOptions.sauce().setExtendedDebugging(true);
         sauceOptions.sauce().setCapturePerformance(true);
-        if (sauceOptions.sauce().getName() == null) {
-            throw new InvalidSauceOptionsArgumentException("Need to call `setName()` before `setCapturePerformance`");
-        }
         return this;
     }
 
@@ -42,5 +39,13 @@ public class ChromeConfigurations extends VDCConfigurations<ChromeConfigurations
     public ChromeConfigurations setExtendedDebugging() {
         sauceOptions.sauce().setExtendedDebugging(true);
         return this;
+    }
+
+    @Override
+    public SauceOptions build() {
+        if (sauceOptions.sauce().getCapturePerformance() && sauceOptions.sauce().getName() == null) {
+            throw new InvalidSauceOptionsArgumentException("Unable to setCapturePerformance() without also doing setName()");
+        }
+        return super.build();
     }
 }


### PR DESCRIPTION
This addresses #267 
This should be a good pattern going forward of addressing incompatibilities in the overridden build() method.