### PR TITLE
[java] implement performance support in session

### DIFF
--- a/java/main/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -3,7 +3,9 @@ package com.saucelabs.saucebindings;
 import com.deque.html.axecore.results.Results;
 import com.deque.html.axecore.selenium.AxeBuilder;
 import com.saucelabs.saucebindings.options.BaseConfigurations;
+import com.saucelabs.saucebindings.options.InvalidSauceOptionsArgumentException;
 import com.saucelabs.saucebindings.options.SauceOptions;
+import com.saucelabs.saucebindings.performance.Performance;
 import lombok.Getter;
 import lombok.Setter;
 import org.openqa.selenium.InvalidArgumentException;
@@ -73,6 +75,13 @@ public class SauceSession {
 
     public Results getAccessibilityResults(AxeBuilder builder) {
         return builder.analyze(driver);
+    }
+
+    public Performance performance() {
+        if (!sauceOptions.sauce().getCapturePerformance()) {
+            throw new InvalidSauceOptionsArgumentException("Can not use performance methods without using `setCapturePerformance()`");
+        }
+        return new Performance(driver, sauceOptions.sauce().getName());
     }
 
     public void stop(Boolean passed) {

--- a/java/main/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -81,7 +81,7 @@ public class SauceSession {
         if (!sauceOptions.sauce().getCapturePerformance()) {
             throw new InvalidSauceOptionsArgumentException("Can not use performance methods without using `setCapturePerformance()`");
         }
-        return new Performance(driver, sauceOptions.sauce().getName());
+        return new Performance(this);
     }
 
     public void stop(Boolean passed) {

--- a/java/main/src/main/java/com/saucelabs/saucebindings/performance/JankinessResults.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/performance/JankinessResults.java
@@ -1,0 +1,22 @@
+package com.saucelabs.saucebindings.performance;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class JankinessResults {
+    private final String url;
+    private final Map<String, Object> metrics;
+    private final Map<String, Object> diagnostics;
+    private final Double score;
+    private final String type;
+
+    public JankinessResults(Map<String, Object> jankiness) {
+        this.url = (String) jankiness.get("url");
+        this.metrics = (Map) jankiness.get("metrics");
+        this.diagnostics = (Map) jankiness.get("diagnostics");
+        this.score = (Double) jankiness.get("score");
+        this.type = (String) jankiness.get("type");
+    }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/performance/JankinessResults.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/performance/JankinessResults.java
@@ -12,6 +12,10 @@ public class JankinessResults {
     private final Double score;
     private final String type;
 
+    /**
+     * @param jankiness Map of the raw results from Sauce Labs when executing Jankiness Check
+     * @see <a href="https://docs.saucelabs.com/performance/motion">Measuring On-Page Motion Effects</a>
+     */
     public JankinessResults(Map<String, Object> jankiness) {
         this.url = (String) jankiness.get("url");
         this.metrics = (Map) jankiness.get("metrics");

--- a/java/main/src/main/java/com/saucelabs/saucebindings/performance/Performance.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/performance/Performance.java
@@ -58,4 +58,25 @@ public class Performance {
         driver.executeScript("sauce:performanceDisable");
     }
 
+    // https://docs.saucelabs.com/performance/transitions#defining-a-performance-budget
+    // Can pull this from yaml or json
+    public Map<String, Object> getBudgetFailures(Map<String, Map<String, Object>> budget) {
+        Map<String, Object> violations = new HashMap<>();
+
+        budget.forEach((url, values) -> {
+            driver.get(url);
+            PerformanceMetrics metrics = getMetrics();
+            values.forEach((metric, value) -> {
+                if ("score".equals(metric)) {
+                    Double score = (Double) metrics.getRawData().get(metric);
+                    if (score < (Double) value) {
+                        violations.put(metric, value);
+                    }
+                } else if (((Number) metrics.getRawData().get(metric)).longValue() > ((Number) value).longValue()) {
+                    violations.put(metric, value);
+                }
+            });
+        });
+        return violations;
+    }
 }

--- a/java/main/src/main/java/com/saucelabs/saucebindings/performance/Performance.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/performance/Performance.java
@@ -1,6 +1,6 @@
 package com.saucelabs.saucebindings.performance;
 
-import org.openqa.selenium.remote.RemoteWebDriver;
+import com.saucelabs.saucebindings.SauceSession;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -8,63 +8,112 @@ import java.util.List;
 import java.util.Map;
 
 public class Performance {
-    private final RemoteWebDriver driver;
-    private final String testName;
+    private final SauceSession session;
 
-    public Performance(RemoteWebDriver driver, String testName) {
-        this.testName = testName;
-        this.driver = driver;
+    /**
+     * This class is intended to be initialized via `SauceSession.performance()`
+     *
+     * @param session
+     * @see SauceSession#performance()
+     */
+    public Performance(SauceSession session) {
+        this.session = session;
     }
 
+    /**
+     * This measures the performance output against a baseline of previously accepted performance values
+     *
+     * @return PerformanceResults is a wrapper of the HashMap results to make it easier to work with them
+     * @see <a href="https://docs.saucelabs.com/performance/transitions#implementing-the-performance-command-assertion">Implementing the Performance Command Assertion</a>
+     */
     public PerformanceResults getResults() {
         HashMap<String, Object> perf = new HashMap<>();
-        perf.put("name", testName);
-        Map<String, Object> performance = (Map<String, Object>) driver.executeScript("sauce:performance", perf);
+        perf.put("name", session.getSauceOptions().sauce().getName());
+        Map<String, Object> performance = (Map<String, Object>) session.getDriver().executeScript("sauce:performance", perf);
         return new PerformanceResults(performance);
     }
 
+    /**
+     * This measures the performance output of a specific metric against a baseline of previously accepted performance values
+     *
+     * @param metric A String value for which performance metrics to evaluate
+     * @return PerformanceResults is a wrapper of the HashMap results to make it easier to work with them
+     * @see <a href="https://docs.saucelabs.com/performance/transitions#implementing-the-performance-command-assertion">Implementing the Performance Command Assertion</a>
+     * @see <a href="https://docs.saucelabs.com/performance/one-page/index.html#metric-values">Metric Values</a>
+     */
     public PerformanceResults getResults(String metric) {
         List<String> metrics = new ArrayList<>();
         metrics.add(metric);
         return getResults(metrics);
     }
 
+    /**
+     * This measures the performance output of a specific list of metrics against a baseline of previously accepted performance values
+     *
+     * @param metrics A List of values for which performance metrics to evaluate
+     * @return PerformanceResults is a wrapper of the HashMap results to make it easier to work with them
+     * @see <a href="https://docs.saucelabs.com/performance/transitions#implementing-the-performance-command-assertion">Implementing the Performance Command Assertion</a>
+     * @see <a href="https://docs.saucelabs.com/performance/one-page/index.html#metric-values">Metric Values</a>
+     */
     public PerformanceResults getResults(List<String> metrics) {
         HashMap<String, Object> perf = new HashMap<>();
-        perf.put("name", testName);
+        perf.put("name", session.getSauceOptions().sauce().getName());
         perf.put("metrics", metrics);
-        Map<String, Object> performance = (Map<String, Object>) driver.executeScript("sauce:performance", perf);
+        Map<String, Object> performance = (Map<String, Object>) session.getDriver().executeScript("sauce:performance", perf);
         return new PerformanceResults(performance);
     }
 
+    /**
+     * @return JenkinsResults is a wrapper of the HashMap results to make it easier to work with them
+     * @see <a href="https://docs.saucelabs.com/performance/motion">Measuring On-Page Motion Effects</a>
+     */
     public JankinessResults getJankinessResults() {
-        Map<String, Object> jankiness = (Map<String, Object>) driver.executeScript("sauce:jankinessCheck");
+        Map<String, Object> jankiness = (Map<String, Object>) session.getDriver().executeScript("sauce:jankinessCheck");
         return new JankinessResults(jankiness);
     }
 
+    /**
+     * This obtains information on all of the collected metrics to allow making assertions on one or more values
+     *
+     * @return PerformanceMetrics is a wrapper of the HashMap results to make it easier to work with them
+     * @see <a href="https://docs.saucelabs.com/performance/transitions#logging-performance-results">Logging Performance Results</a>
+     */
     public PerformanceMetrics getMetrics() {
         HashMap<String, Object> metricsLog = new HashMap<>();
         metricsLog.put("type", "sauce:performance");
 
-        Map<String, Object> metrics = (Map<String, Object>) driver.executeScript("sauce:log", metricsLog);
+        Map<String, Object> metrics = (Map<String, Object>) session.getDriver().executeScript("sauce:log", metricsLog);
         return new PerformanceMetrics(metrics);
     }
 
+    /**
+     * Turn on recording of metrics during session
+     * @see <a href="https://docs.saucelabs.com/performance/transitions#target-specific-urls-in-a-script">Target Specific URLs in a Script</a>
+     */
     public void enable() {
-        driver.executeScript("sauce:performanceEnable");
+        session.getDriver().executeScript("sauce:performanceEnable");
     }
 
+    /**
+     * Turn off recording of metrics during session
+     * @see <a href="https://docs.saucelabs.com/performance/transitions#target-specific-urls-in-a-script">Target Specific URLs in a Script</a>
+     */
     public void disable() {
-        driver.executeScript("sauce:performanceDisable");
+        session.getDriver().executeScript("sauce:performanceDisable");
     }
 
-    // https://docs.saucelabs.com/performance/transitions#defining-a-performance-budget
-    // Can pull this from yaml or json
+    /**
+     * The map used as input will typically be converted from serialized information stored in a yaml or JSON file
+     * @param budget Map of Maps with the URL as the keys of outer maps, the metric as the keys of the nested maps and the maximum value
+     *               of the metric as its value
+     * @return A Map of failures if any, including the failing metric and its value
+     * @see <a href="https://docs.saucelabs.com/performance/transitions#defining-a-performance-budget">Defining a Performance Budget</a>
+     */
     public Map<String, Object> getBudgetFailures(Map<String, Map<String, Object>> budget) {
         Map<String, Object> violations = new HashMap<>();
 
         budget.forEach((url, values) -> {
-            driver.get(url);
+            session.getDriver().get(url);
             PerformanceMetrics metrics = getMetrics();
             values.forEach((metric, value) -> {
                 if ("score".equals(metric)) {

--- a/java/main/src/main/java/com/saucelabs/saucebindings/performance/Performance.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/performance/Performance.java
@@ -2,12 +2,14 @@ package com.saucelabs.saucebindings.performance;
 
 import org.openqa.selenium.remote.RemoteWebDriver;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class Performance {
-    private RemoteWebDriver driver;
-    private String testName;
+    private final RemoteWebDriver driver;
+    private final String testName;
 
     public Performance(RemoteWebDriver driver, String testName) {
         this.testName = testName;
@@ -17,6 +19,20 @@ public class Performance {
     public PerformanceResults getResults() {
         HashMap<String, Object> perf = new HashMap<>();
         perf.put("name", testName);
+        Map<String, Object> performance = (Map<String, Object>) driver.executeScript("sauce:performance", perf);
+        return new PerformanceResults(performance);
+    }
+
+    public PerformanceResults getResults(String metric) {
+        List<String> metrics = new ArrayList<>();
+        metrics.add(metric);
+        return getResults(metrics);
+    }
+
+    public PerformanceResults getResults(List<String> metrics) {
+        HashMap<String, Object> perf = new HashMap<>();
+        perf.put("name", testName);
+        perf.put("metrics", metrics);
         Map<String, Object> performance = (Map<String, Object>) driver.executeScript("sauce:performance", perf);
         return new PerformanceResults(performance);
     }

--- a/java/main/src/main/java/com/saucelabs/saucebindings/performance/Performance.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/performance/Performance.java
@@ -37,6 +37,11 @@ public class Performance {
         return new PerformanceResults(performance);
     }
 
+    public JankinessResults getJankinessResults() {
+        Map<String, Object> jankiness = (Map<String, Object>) driver.executeScript("sauce:jankinessCheck");
+        return new JankinessResults(jankiness);
+    }
+
     public PerformanceMetrics getMetrics() {
         HashMap<String, Object> metricsLog = new HashMap<>();
         metricsLog.put("type", "sauce:performance");

--- a/java/main/src/main/java/com/saucelabs/saucebindings/performance/Performance.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/performance/Performance.java
@@ -1,0 +1,40 @@
+package com.saucelabs.saucebindings.performance;
+
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Performance {
+    private RemoteWebDriver driver;
+    private String testName;
+
+    public Performance(RemoteWebDriver driver, String testName) {
+        this.testName = testName;
+        this.driver = driver;
+    }
+
+    public PerformanceResults getResults() {
+        HashMap<String, Object> perf = new HashMap<>();
+        perf.put("name", testName);
+        Map<String, Object> performance = (Map<String, Object>) driver.executeScript("sauce:performance", perf);
+        return new PerformanceResults(performance);
+    }
+
+    public PerformanceMetrics getMetrics() {
+        HashMap<String, Object> metricsLog = new HashMap<>();
+        metricsLog.put("type", "sauce:performance");
+
+        Map<String, Object> metrics = (Map<String, Object>) driver.executeScript("sauce:log", metricsLog);
+        return new PerformanceMetrics(metrics);
+    }
+
+    public void enable() {
+        driver.executeScript("sauce:performanceEnable");
+    }
+
+    public void disable() {
+        driver.executeScript("sauce:performanceDisable");
+    }
+
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/performance/PerformanceMetrics.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/performance/PerformanceMetrics.java
@@ -18,13 +18,15 @@ public class PerformanceMetrics {
     private final Long estimatedInputLatency;
     private final Long firstContentfulPaint;
     private final Long totalBlockingTime;
-    private final Long score;
+    private final Double score;
     private final Long domContentLoaded;
     private final Long cumulativeLayoutShift;
     private final Long serverResponseTime;
     private final Long largestContentfulPaint;
+    private final Map<String, Object> rawData;
 
     public PerformanceMetrics(Map<String, Object> performance) {
+        this.rawData = performance;
         this.load = (Long) performance.get("load");
         this.speedIndex = (Long) performance.get("speedIndex");
         this.firstInteractive = (Long) performance.get("firstInteractive");
@@ -37,10 +39,15 @@ public class PerformanceMetrics {
         this.estimatedInputLatency = (Long) performance.get("estimatedInputLatency");
         this.firstContentfulPaint = (Long) performance.get("firstContentfulPaint");
         this.totalBlockingTime = (Long) performance.get("totalBlockingTime");
-        this.score = (Long) performance.get("score");
         this.domContentLoaded = (Long) performance.get("domContentLoaded");
         this.cumulativeLayoutShift = (Long) performance.get("cumulativeLayoutShift");
         this.serverResponseTime = (Long) performance.get("serverResponseTime");
         this.largestContentfulPaint = (Long) performance.get("largestContentfulPaint");
+
+        if (performance.get("score").getClass().equals(Long.class)) {
+            this.score = ((Long) performance.get("score")).doubleValue();
+        } else {
+            this.score = (Double) performance.get("score");
+        }
     }
 }

--- a/java/main/src/main/java/com/saucelabs/saucebindings/performance/PerformanceMetrics.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/performance/PerformanceMetrics.java
@@ -25,6 +25,9 @@ public class PerformanceMetrics {
     private final Long largestContentfulPaint;
     private final Map<String, Object> rawData;
 
+    /**
+     * @param performance Map of the raw results from Sauce Labs when obtaining log of performance metrics
+     */
     public PerformanceMetrics(Map<String, Object> performance) {
         this.rawData = performance;
         this.load = (Long) performance.get("load");

--- a/java/main/src/main/java/com/saucelabs/saucebindings/performance/PerformanceMetrics.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/performance/PerformanceMetrics.java
@@ -1,0 +1,46 @@
+package com.saucelabs.saucebindings.performance;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class PerformanceMetrics {
+    private final Long load;
+    private final Long speedIndex;
+    private final Long firstInteractive;
+    private final Long firstVisualChange;
+    private final Long lastVisualChange;
+    private final Long firstMeaningfulPaint;
+    private final Long firstCPUIdle;
+    private final Long timeToFirstByte;
+    private final Long firstPaint;
+    private final Long estimatedInputLatency;
+    private final Long firstContentfulPaint;
+    private final Long totalBlockingTime;
+    private final Long score;
+    private final Long domContentLoaded;
+    private final Long cumulativeLayoutShift;
+    private final Long serverResponseTime;
+    private final Long largestContentfulPaint;
+
+    public PerformanceMetrics(Map<String, Object> performance) {
+        this.load = (Long) performance.get("load");
+        this.speedIndex = (Long) performance.get("speedIndex");
+        this.firstInteractive = (Long) performance.get("firstInteractive");
+        this.firstVisualChange = (Long) performance.get("firstVisualChange");
+        this.lastVisualChange = (Long) performance.get("lastVisualChange");
+        this.firstMeaningfulPaint = (Long) performance.get("firstMeaningfulPaint");
+        this.firstCPUIdle = (Long) performance.get("firstCPUIdle");
+        this.timeToFirstByte = (Long) performance.get("timeToFirstByte");
+        this.firstPaint = (Long) performance.get("firstPaint");
+        this.estimatedInputLatency = (Long) performance.get("estimatedInputLatency");
+        this.firstContentfulPaint = (Long) performance.get("firstContentfulPaint");
+        this.totalBlockingTime = (Long) performance.get("totalBlockingTime");
+        this.score = (Long) performance.get("score");
+        this.domContentLoaded = (Long) performance.get("domContentLoaded");
+        this.cumulativeLayoutShift = (Long) performance.get("cumulativeLayoutShift");
+        this.serverResponseTime = (Long) performance.get("serverResponseTime");
+        this.largestContentfulPaint = (Long) performance.get("largestContentfulPaint");
+    }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/performance/PerformanceResults.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/performance/PerformanceResults.java
@@ -1,0 +1,27 @@
+package com.saucelabs.saucebindings.performance;
+
+import java.util.Map;
+
+public class PerformanceResults {
+    private String reason;
+    private boolean result;
+    private Map details;
+
+    public PerformanceResults(Map<String, Object> performance) {
+        this.reason = (String) performance.get("reason");
+        this.result = performance.get("result").equals("pass");
+        this.details = (Map<String, Object>) performance.get("details");
+    }
+
+    public boolean isPassed() {
+        return result;
+    }
+
+    public String getReason() {
+        return this.reason;
+    }
+
+    public Map getDetails() {
+        return details;
+    }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/performance/PerformanceResults.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/performance/PerformanceResults.java
@@ -1,27 +1,21 @@
 package com.saucelabs.saucebindings.performance;
 
+import lombok.Getter;
+
 import java.util.Map;
 
+@Getter
 public class PerformanceResults {
-    private String reason;
-    private boolean result;
-    private Map details;
+    private final String reason;
+    private final boolean passed;
+    private final Map<String, Object> details;
 
+    /**
+     * @param performance Map of the raw results from Sauce Labs when executing performance result
+     */
     public PerformanceResults(Map<String, Object> performance) {
         this.reason = (String) performance.get("reason");
-        this.result = performance.get("result").equals("pass");
+        this.passed = performance.get("result").equals("pass");
         this.details = (Map<String, Object>) performance.get("details");
-    }
-
-    public boolean isPassed() {
-        return result;
-    }
-
-    public String getReason() {
-        return this.reason;
-    }
-
-    public Map getDetails() {
-        return details;
     }
 }

--- a/java/main/src/test/java/com/saucelabs/saucebindings/budget.yml
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/budget.yml
@@ -1,0 +1,6 @@
+"https://www.saucedemo.com":
+  "speedIndex": 1500
+  "lastVisualChange": 18000
+  "load": 2000
+"https://saucelabs.com/platform/analytics-performance/sauce-performance":
+  "score": 0.4

--- a/java/main/src/test/java/com/saucelabs/saucebindings/integration/PerformanceTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/integration/PerformanceTest.java
@@ -13,7 +13,12 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.openqa.selenium.By;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.yaml.snakeyaml.Yaml;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +40,6 @@ public class PerformanceTest {
     @Before
     public void setup() {
         SauceOptions sauceOptions = SauceOptions.chrome()
-                .setBrowserVersion("85.0")
                 .setName(testName.getMethodName())
                 .setCapturePerformance()
                 .build();
@@ -141,5 +145,24 @@ public class PerformanceTest {
 
         PerformanceMetrics performanceMetrics = session.performance().getMetrics();
         Assert.assertNull(performanceMetrics.getLoad());
+    }
+
+    @Test
+    public void useBudget() {
+        File budget = new File("src/test/java/com/saucelabs/saucebindings/budget.yml");
+        Map<String, Object> failures = session.performance().getBudgetFailures(serialize(budget));
+
+        Assert.assertTrue(failures.isEmpty());
+    }
+
+    public Map<String, Map<String, Object>> serialize(File file) {
+        InputStream input = null;
+        try {
+            input = new FileInputStream(file);
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+        Yaml yaml = new Yaml();
+        return yaml.load(input);
     }
 }

--- a/java/main/src/test/java/com/saucelabs/saucebindings/integration/PerformanceTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/integration/PerformanceTest.java
@@ -1,0 +1,97 @@
+package com.saucelabs.saucebindings.integration;
+
+import com.saucelabs.saucebindings.SauceSession;
+import com.saucelabs.saucebindings.options.SauceOptions;
+import com.saucelabs.saucebindings.performance.PerformanceMetrics;
+import com.saucelabs.saucebindings.performance.PerformanceResults;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.openqa.selenium.By;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+public class PerformanceTest {
+    private SauceSession session;
+    private RemoteWebDriver driver;
+
+    @After
+    public void cleanUp() {
+        if (session != null) {
+            session.stop(true);
+        }
+    }
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Before
+    public void setup() {
+        SauceOptions sauceOptions = SauceOptions.chrome()
+                .setName(testName.getMethodName())
+                .setCapturePerformance()
+                .build();
+        session = new SauceSession(sauceOptions);
+        driver = session.start();
+    }
+
+    @Test
+    public void performanceResults() {
+        driver.get("https://www.saucedemo.com");
+
+        PerformanceResults performanceResults = session.performance().getResults();
+        // We don't actually care if this "passes" or "fails" just that these methods are returning correct values
+        if (performanceResults.isPassed()) {
+            Assert.assertTrue(performanceResults.getDetails().isEmpty());
+            Assert.assertNull(performanceResults.getReason());
+        } else {
+            Assert.assertTrue(performanceResults.getReason().contains("Metrics"));
+            Assert.assertFalse(performanceResults.getDetails().isEmpty());
+        }
+    }
+
+    @Test
+    public void performanceDetails() {
+        driver.get("https://www.saucedemo.com");
+
+        PerformanceMetrics performanceMetrics = session.performance().getMetrics();
+        Assert.assertTrue(performanceMetrics.getLoad() < 1500);
+    }
+
+    @Test
+    public void disablePerformance() {
+        driver.get("https://www.saucedemo.com");
+
+        PerformanceMetrics performanceMetrics1 = session.performance().getMetrics();
+
+        // Disabling performance prevents previous metrics from being overridden
+        session.performance().disable();
+
+        driver.findElement(By.id("user-name")).sendKeys("standard_user");
+        driver.findElement(By.id("password")).sendKeys("secret_sauce");
+        driver.findElement(By.id("login-button")).click();
+
+        PerformanceMetrics performanceMetrics2 = session.performance().getMetrics();
+
+        // Disabled means the metrics haven't changed
+        // If metrics were captured for filling the form, load would be null
+        Assert.assertEquals(performanceMetrics1.getLoad(), performanceMetrics2.getLoad());
+    }
+
+    @Test
+    public void enablePerformance() {
+        driver.get("https://www.saucedemo.com");
+
+        session.performance().disable();
+        session.performance().enable();
+
+        driver.findElement(By.id("user-name")).sendKeys("standard_user");
+        driver.findElement(By.id("password")).sendKeys("secret_sauce");
+        driver.findElement(By.id("login-button")).click();
+
+        PerformanceMetrics performanceMetrics = session.performance().getMetrics();
+        Assert.assertNull(performanceMetrics.getLoad());
+    }
+}

--- a/java/main/src/test/java/com/saucelabs/saucebindings/integration/PerformanceTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/integration/PerformanceTest.java
@@ -13,6 +13,10 @@ import org.junit.rules.TestName;
 import org.openqa.selenium.By;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 public class PerformanceTest {
     private SauceSession session;
     private RemoteWebDriver driver;
@@ -30,6 +34,7 @@ public class PerformanceTest {
     @Before
     public void setup() {
         SauceOptions sauceOptions = SauceOptions.chrome()
+                .setBrowserVersion("85.0")
                 .setName(testName.getMethodName())
                 .setCapturePerformance()
                 .build();
@@ -49,6 +54,40 @@ public class PerformanceTest {
         } else {
             Assert.assertTrue(performanceResults.getReason().contains("Metrics"));
             Assert.assertFalse(performanceResults.getDetails().isEmpty());
+        }
+    }
+
+    @Test
+    public void performanceMetricResults() {
+        driver.get("https://www.saucedemo.com");
+
+        PerformanceResults performanceResults = session.performance().getResults("firstInteractive");
+        if (performanceResults.isPassed()) {
+            Assert.assertTrue(performanceResults.getDetails().isEmpty());
+            Assert.assertNull(performanceResults.getReason());
+        } else {
+            Map<String, Object> firstInteractive = (Map<String, Object>) performanceResults.getDetails().get("firstInteractive");
+            Assert.assertTrue((Long) firstInteractive.get("actual") < 5000);
+        }
+    }
+
+    @Test
+    public void performanceMetricsResults() {
+        driver.get("https://www.saucedemo.com");
+
+        List<String> metrics = new ArrayList<String>();
+        metrics.add("firstInteractive");
+        metrics.add("load");
+
+        PerformanceResults performanceResults = session.performance().getResults(metrics);
+        if (performanceResults.isPassed()) {
+            Assert.assertTrue(performanceResults.getDetails().isEmpty());
+            Assert.assertNull(performanceResults.getReason());
+        } else if (performanceResults.getDetails().get("firstInteractive") == null) {
+            Assert.assertNotNull(performanceResults.getDetails().get("load"));
+        } else {
+            Map<String, Object> firstInteractive = (Map<String, Object>) performanceResults.getDetails().get("firstInteractive");
+            Assert.assertTrue((Long) firstInteractive.get("actual") < 5000);
         }
     }
 

--- a/java/main/src/test/java/com/saucelabs/saucebindings/integration/PerformanceTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/integration/PerformanceTest.java
@@ -2,6 +2,7 @@ package com.saucelabs.saucebindings.integration;
 
 import com.saucelabs.saucebindings.SauceSession;
 import com.saucelabs.saucebindings.options.SauceOptions;
+import com.saucelabs.saucebindings.performance.JankinessResults;
 import com.saucelabs.saucebindings.performance.PerformanceMetrics;
 import com.saucelabs.saucebindings.performance.PerformanceResults;
 import org.junit.After;
@@ -40,6 +41,14 @@ public class PerformanceTest {
                 .build();
         session = new SauceSession(sauceOptions);
         driver = session.start();
+    }
+
+    @Test
+    public void jankinessResults() {
+        driver.get("https://www.saucedemo.com");
+
+        JankinessResults jankinessResults = session.performance().getJankinessResults();
+        Assert.assertTrue(jankinessResults.getScore() > 0.7);
     }
 
     @Test

--- a/java/testng/src/test/java/com/saucelabs/saucebindings/testng/examples/BrowserOptionsTest.java
+++ b/java/testng/src/test/java/com/saucelabs/saucebindings/testng/examples/BrowserOptionsTest.java
@@ -2,7 +2,6 @@ package com.saucelabs.saucebindings.testng.examples;
 
 import com.saucelabs.saucebindings.options.SauceOptions;
 import com.saucelabs.saucebindings.testng.SauceBaseTest;
-import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.testng.annotations.Test;
 
@@ -12,7 +11,7 @@ public class BrowserOptionsTest extends SauceBaseTest {
     // 2. Create Sauce Options with Sauce Labs class for browser specific details
     @Override
     protected SauceOptions createSauceOptions() {
-        ChromeOptions browserOptions = new ChromeOptions();
+        FirefoxOptions browserOptions = new FirefoxOptions();
         browserOptions.addArguments("--start-fullscreen");
 
         return SauceOptions.firefox(browserOptions).build();


### PR DESCRIPTION
Three options here.

The one I did for Accessibility was like:

```java
PerformanceResults results = session.getPerformanceResults();
```

The one that is probably "most Java" is:
```java
PerformanceResults results = new Performance(session).getResults();
```

The one I implemented here is:
```java
PerformanceResults results = session.performance().getResults();
```

Thoughts/Preferences?