### PR TITLE
Java visual

### DIFF
--- a/.github/workflows/jdk8.yml
+++ b/.github/workflows/jdk8.yml
@@ -1,7 +1,9 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: JDK 8
+env:
+  SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
+  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
 
 on:
   push:
@@ -19,9 +21,6 @@ jobs:
         with:
           java-version: 1.8
       - name: Test with Maven
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: make java_tests
   junit4:
     runs-on: ubuntu-latest
@@ -32,9 +31,6 @@ jobs:
         with:
           java-version: 1.8
       - name: Test with Maven
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: make junit4_tests
   junit5:
     runs-on: ubuntu-latest
@@ -45,7 +41,4 @@ jobs:
         with:
           java-version: 1.8
       - name: Test with Maven
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: make junit5_tests

--- a/.github/workflows/jdk9.yml
+++ b/.github/workflows/jdk9.yml
@@ -2,6 +2,10 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: JDK 9+
+env:
+  SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
+  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
 
 on:
   push:
@@ -19,9 +23,6 @@ jobs:
         with:
           java-version: 9
       - name: Test with Maven
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: cd java/main && mvn clean test -Dmaven.javadoc.skip=true;
   junit4:
     runs-on: ubuntu-latest
@@ -32,9 +33,6 @@ jobs:
         with:
           java-version: 9
       - name: Test with Maven
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: cd java/junit4 && mvn clean test -Dmaven.javadoc.skip=true;
   junit5:
     runs-on: ubuntu-latest
@@ -45,7 +43,4 @@ jobs:
         with:
           java-version: 9
       - name: Test with Maven
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: cd java/junit5 && mvn clean test -Dmaven.javadoc.skip=true;

--- a/java/main/src/main/java/com/saucelabs/saucebindings/GitManager.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/GitManager.java
@@ -1,0 +1,24 @@
+package com.saucelabs.saucebindings;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class GitManager {
+    private static String currentBranch = "_default_";
+
+    public static String getCurrentBranch() {
+        try {
+            Process process = Runtime.getRuntime().exec("git rev-parse --abbrev-ref HEAD");
+            process.waitFor();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            String line = reader.readLine();
+            if (!line.contains("fatal:")) {
+                currentBranch = line;
+            }
+        } catch (IOException | InterruptedException e) {
+            // Ignore exception and use default
+        }
+        return currentBranch;
+    }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/SauceVisualException.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/SauceVisualException.java
@@ -1,0 +1,7 @@
+package com.saucelabs.saucebindings;
+
+public class SauceVisualException extends RuntimeException {
+    public SauceVisualException(String message) {
+        super(message);
+    }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/VisualResults.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/VisualResults.java
@@ -1,0 +1,53 @@
+package com.saucelabs.saucebindings;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Setter @Getter
+public class VisualResults {
+    Map<String, Object> results;
+    private Map<String, Object> totals;
+
+    private final Boolean passed;
+    private final String message;
+    private final String status;
+    private final List<VisualSnapshot> snapshots = new ArrayList<>();
+    private final Long totalNew;
+    private final Long totalChanged;
+    private final Long totalRejected;
+    private final Long totalAccepted;
+    private final Long total;
+
+    public static VisualResults generate(RemoteWebDriver driver) {
+        return new VisualResults(driver);
+    }
+
+    private VisualResults(RemoteWebDriver driver) {
+        results = (Map<String, Object>) driver.executeScript("/*@visual.end*/");
+
+        this.passed = (Boolean) results.get("passed");
+        this.message = (String) results.get("message");
+        this.status = (String) results.get("status"); // success, failure, error, timeout, cancelled
+
+        for (Map state : (List<Map>) results.get("states")) {
+            snapshots.add(new VisualSnapshot(state));
+        }
+
+        this.totals = (Map) results.get("totals");
+        this.totalNew = (Long) totals.get("new");
+        this.totalChanged = (Long) totals.get("changed");
+        this.totalRejected = (Long) totals.get("rejected");
+        this.totalAccepted = (Long) totals.get("accepted");
+        this.total = (Long) totals.get("all");
+    }
+
+    public String getSummary() {
+        String disposition = getPassed() ? getStatus() : getMessage();
+        return "Totals: " + getTotals() + "; Disposition: " + disposition + "\n";
+    }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/VisualSession.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/VisualSession.java
@@ -1,18 +1,25 @@
 package com.saucelabs.saucebindings;
 
 import com.saucelabs.saucebindings.options.SauceOptions;
+import com.saucelabs.saucebindings.options.VisualOptions;
 import org.openqa.selenium.InvalidArgumentException;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.HashMap;
 import java.util.Map;
 
 public class VisualSession extends SauceSession {
+    private VisualOptions visualOptions;
+
     public VisualSession(String testName) {
-        super(SauceOptions.chrome().setName(testName).build());
+        this(new VisualOptions(SauceOptions.chrome().setName(testName).build()));
+    }
+
+    public VisualSession(VisualOptions options) {
+        super(options.getSauceOptions());
+        this.visualOptions = options;
     }
 
     @Override
@@ -25,15 +32,7 @@ public class VisualSession extends SauceSession {
     }
 
     public RemoteWebDriver start() {
-        MutableCapabilities capabilities = getSauceOptions().toCapabilities();
-
-        String sauceVisualApiKey = SystemManager.get("SCREENER_API_KEY");
-        Map<String, Object> visual = new HashMap<>();
-        visual.put("apiKey", sauceVisualApiKey);
-        visual.put("projectName", new CITools().getBuildName());
-        visual.put("branch", "_default_");
-
-        capabilities.setCapability("sauce:visual", visual);
+        MutableCapabilities capabilities = visualOptions.toCapabilities();
 
         this.driver = createRemoteWebDriver(getSauceUrl(), capabilities);
         driver.executeScript("/*@visual.init*/", getSauceOptions().sauce().getName());

--- a/java/main/src/main/java/com/saucelabs/saucebindings/VisualSession.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/VisualSession.java
@@ -1,0 +1,56 @@
+package com.saucelabs.saucebindings;
+
+import com.saucelabs.saucebindings.options.SauceOptions;
+import org.openqa.selenium.InvalidArgumentException;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+public class VisualSession extends SauceSession {
+    public VisualSession(String testName) {
+        super(SauceOptions.chrome().setName(testName).build());
+    }
+
+    @Override
+    public URL getSauceUrl() {
+        try {
+            return new URL("https://hub.screener.io/wd/hub");
+        } catch (MalformedURLException e) {
+            throw new InvalidArgumentException("Invalid URL", e);
+        }
+    }
+
+    public RemoteWebDriver start() {
+        MutableCapabilities capabilities = getSauceOptions().toCapabilities();
+
+        String sauceVisualApiKey = SystemManager.get("SCREENER_API_KEY");
+        Map<String, Object> visual = new HashMap<>();
+        visual.put("apiKey", sauceVisualApiKey);
+        visual.put("projectName", new CITools().getBuildName());
+        visual.put("branch", "_default_");
+
+        capabilities.setCapability("sauce:visual", visual);
+
+        this.driver = createRemoteWebDriver(getSauceUrl(), capabilities);
+        driver.executeScript("/*@visual.init*/", getSauceOptions().sauce().getName());
+
+        return driver;
+    }
+
+    public void takeSnapshot(String name) {
+        driver.executeScript("/*@visual.snapshot*/", name);
+    }
+
+    public Map<String, Object> getResults() {
+        return (Map<String, Object>) driver.executeScript("/*@visual.end*/");
+    }
+
+    public void stop() {
+        System.out.println("\n Visual Results: " + getResults());
+        super.quit();
+    }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/VisualSession.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/VisualSession.java
@@ -3,15 +3,14 @@ package com.saucelabs.saucebindings;
 import com.saucelabs.saucebindings.options.SauceOptions;
 import com.saucelabs.saucebindings.options.VisualOptions;
 import org.openqa.selenium.InvalidArgumentException;
-import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Map;
 
 public class VisualSession extends SauceSession {
-    private VisualOptions visualOptions;
+    private VisualResults visualResults;
+    private final VisualOptions visualOptions;
 
     public VisualSession(String testName) {
         this(new VisualOptions(SauceOptions.chrome().setName(testName).build()));
@@ -23,6 +22,13 @@ public class VisualSession extends SauceSession {
     }
 
     @Override
+    public RemoteWebDriver start() {
+        this.driver = createRemoteWebDriver(getSauceUrl(), visualOptions.toCapabilities());
+        newVisualTest(getSauceOptions().sauce().getName());
+        return driver;
+    }
+
+    @Override
     public URL getSauceUrl() {
         try {
             return new URL("https://hub.screener.io/wd/hub");
@@ -31,25 +37,49 @@ public class VisualSession extends SauceSession {
         }
     }
 
-    public RemoteWebDriver start() {
-        MutableCapabilities capabilities = visualOptions.toCapabilities();
-
-        this.driver = createRemoteWebDriver(getSauceUrl(), capabilities);
-        driver.executeScript("/*@visual.init*/", getSauceOptions().sauce().getName());
-
-        return driver;
+    public void newVisualTest(String testName) {
+        validateVisualStatus();
+        driver.executeScript("/*@visual.init*/", testName);
     }
 
     public void takeSnapshot(String name) {
+        validateVisualStatus();
         driver.executeScript("/*@visual.snapshot*/", name);
     }
 
-    public Map<String, Object> getResults() {
-        return (Map<String, Object>) driver.executeScript("/*@visual.end*/");
+    public VisualResults getVisualResults() {
+        if (visualResults == null) {
+            this.visualResults = VisualResults.generate(driver);
+        }
+        return visualResults;
+    }
+
+    @Override
+    public void stop(Boolean passed) {
+        String result = passed ? "passed" : "failed";
+        stop(result);
+    }
+
+    @Override
+    public void stop(String result) {
+        if (driver != null) {
+            System.out.println(getVisualResults().getSummary());
+            super.stop(result);
+        }
     }
 
     public void stop() {
-        System.out.println("\n Visual Results: " + getResults());
-        super.quit();
+        if (driver != null) {
+            VisualResults results = getVisualResults();
+            System.out.println(results.getSummary());
+            String result = results.getPassed() ? "passed" : "failed";
+            super.stop(result);
+        }
+    }
+
+    private void validateVisualStatus() {
+        if (this.visualResults != null) {
+            throw new SauceVisualException("Can not execute Visual Commands after calling getVisualResults()");
+        }
     }
 }

--- a/java/main/src/main/java/com/saucelabs/saucebindings/VisualSnapshot.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/VisualSnapshot.java
@@ -1,0 +1,26 @@
+package com.saucelabs.saucebindings;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Setter @Getter
+public class VisualSnapshot {
+    private final String name;
+    private final String groupName;
+    private final String status;
+    private final String url;
+
+    public VisualSnapshot(Map<String, String> results) {
+        this.name = results.get("name");
+        this.groupName = results.get("groupName");
+        this.status = results.get("status");
+        this.url = results.get("url");
+    }
+
+    @Override
+    public String toString() {
+        return name + ": " + url;
+    }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/options/VisualOptions.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/options/VisualOptions.java
@@ -1,6 +1,7 @@
 package com.saucelabs.saucebindings.options;
 
 import com.saucelabs.saucebindings.CITools;
+import com.saucelabs.saucebindings.GitManager;
 import com.saucelabs.saucebindings.SauceSession;
 import com.saucelabs.saucebindings.SystemManager;
 import lombok.AccessLevel;
@@ -73,7 +74,7 @@ public class VisualOptions extends BaseOptions {
         }
 
         if (branch == null) {
-            branch = "_default_";
+            branch = GitManager.getCurrentBranch();
         }
 
         capabilityManager.addCapabilities();

--- a/java/main/src/main/java/com/saucelabs/saucebindings/options/VisualOptions.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/options/VisualOptions.java
@@ -1,0 +1,86 @@
+package com.saucelabs.saucebindings.options;
+
+import com.saucelabs.saucebindings.CITools;
+import com.saucelabs.saucebindings.SauceSession;
+import com.saucelabs.saucebindings.SystemManager;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Accessors(chain = true) @Setter @Getter
+public class VisualOptions extends BaseOptions {
+    @Setter(AccessLevel.NONE) private SauceOptions sauceOptions;
+    private String projectName;
+    private String viewportSize;
+    private String branch;
+    private String baseBranch;
+    private Map<String, Object> diffOptions = null;
+    private String ignore;
+    private Boolean failOnNewStates = null;
+    private Boolean alwaysAcceptBaseBranch = null;
+    private Boolean disableBranchBaseline = null;
+    private Boolean scrollAndStitchScreenshots = null;
+    private Boolean disableCORS = null;
+    private Boolean iframes = null;
+    private Map<String, Object> iframesOptions = null;
+
+    public final List<String> validOptions = Arrays.asList(
+            "projectName",
+            "viewportSize",
+            "branch",
+            "baseBranch",
+            "diffOptions",
+            "ignore",
+            "failOnNewStates",
+            "alwaysAcceptBaseBranch",
+            "disableBranchBaseline",
+            "scrollAndStitchScreenshots",
+            "disableCORS",
+            "iframes",
+            "iframesOptions");
+
+    public VisualOptions(String testName) {
+        this(SauceOptions.chrome().setName(testName).build());
+    }
+
+    public VisualOptions(SauceOptions options) {
+        if (options.sauce().getName() == null) {
+            String msg = "Visual Tests Require setting a name in SauceOptions";
+            throw new InvalidSauceOptionsArgumentException(msg);
+        }
+
+        this.sauceOptions = options;
+        capabilityManager = new CapabilityManager(this);
+    }
+
+    /**
+     * @return instance of MutableCapabilities representing all key value pairs set in SauceOptions
+     * @see SauceSession#start()
+     */
+    public MutableCapabilities toCapabilities() {
+        String msg = "Environment Variable or System Property for 'SCREENER_API_KEY' must be provided";
+        String sauceVisualApiKey = SystemManager.get("SCREENER_API_KEY", msg);
+        capabilities.setCapability("apiKey", sauceVisualApiKey);
+
+        if (projectName == null) {
+            projectName = CITools.getBuildName();
+        }
+
+        if (branch == null) {
+            branch = "_default_";
+        }
+
+        capabilityManager.addCapabilities();
+
+        MutableCapabilities toReturn = getSauceOptions().toCapabilities();
+        toReturn.setCapability("sauce:visual", capabilities);
+
+        return toReturn;
+    }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/options/VisualOptions.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/options/VisualOptions.java
@@ -84,4 +84,22 @@ public class VisualOptions extends BaseOptions {
 
         return toReturn;
     }
+
+    /**
+     * Use Case is pulling serialized information from JSON/YAML, converting it to a HashMap and passing it in
+     * This is a preferred pattern as it avoids conditionals in code
+     * Warning: For VisualOptions this adds a hard coded Test Name that needs to be updated
+     *
+     * @param capabilitiesToMerge a Map object representing key value pairs to convert to capabilities
+     */
+    public void mergeCapabilities(Map<String, Object> capabilitiesToMerge) {
+        for (Map.Entry<String, Object> entry : capabilitiesToMerge.entrySet()) {
+            String key = entry.getKey();
+            if (key.equals("visual")) {
+                ((Map<String, Object>) entry.getValue()).forEach(this::setCapability);
+            } else {
+                sauceOptions.setCapability(key, entry.getValue());
+            }
+        }
+    }
 }

--- a/java/main/src/test/java/com/saucelabs/saucebindings/examples/VisualOptionsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/examples/VisualOptionsTest.java
@@ -1,0 +1,41 @@
+package com.saucelabs.saucebindings.examples;
+
+import com.saucelabs.saucebindings.VisualSession;
+import com.saucelabs.saucebindings.options.SauceOptions;
+import com.saucelabs.saucebindings.options.VisualOptions;
+import org.junit.Test;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+public class VisualOptionsTest {
+
+    @Test
+    public void visualOptions() {
+
+        // 1. Create Sauce Options object with desired test settings
+        // Note: setting the test name is required
+        SauceOptions sauceOptions = SauceOptions.chrome()
+                .setName("Example Visual Options Test")
+                .build();
+
+        // 2. Create Visual Options instance with Sauce Options instance
+        VisualOptions visualOptions = new VisualOptions(sauceOptions);
+
+        // 3. Set desired visual options
+        visualOptions.setFailOnNewStates(false);
+
+        // 4. Create Visual Session instance with Visual Options instance
+        VisualSession session = new VisualSession(visualOptions);
+
+        // 5. Start Session to get the driver
+        RemoteWebDriver driver = session.start();
+
+        // 6. Use the driver in your tests just like normal
+        driver.get("https://www.saucedemo.com/");
+
+        // 7. Take snapshot
+        session.takeSnapshot("Name of Snapshot");
+
+        // 8. Stop the Session
+        session.stop();
+    }
+}

--- a/java/main/src/test/java/com/saucelabs/saucebindings/examples/VisualTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/examples/VisualTest.java
@@ -1,0 +1,27 @@
+package com.saucelabs.saucebindings.examples;
+
+import com.saucelabs.saucebindings.VisualSession;
+import org.junit.Test;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+public class VisualTest {
+
+    @Test
+    public void visualSession() {
+
+        // 1. Create Visual Session object with minimum required
+        VisualSession session = new VisualSession("Example test name");
+
+        // 2. Start Session to get the driver
+        RemoteWebDriver driver = session.start();
+
+        // 3. Use the driver in your tests just like normal
+        driver.get("https://www.saucedemo.com/");
+
+        // 4. Take snapshot
+        session.takeSnapshot("Name of Snapshot");
+
+        // 5. Stop the Session
+        session.stop();
+    }
+}

--- a/java/main/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
@@ -1,0 +1,130 @@
+package com.saucelabs.saucebindings.integration;
+
+import com.saucelabs.saucebindings.GitManager;
+import com.saucelabs.saucebindings.SauceVisualException;
+import com.saucelabs.saucebindings.VisualResults;
+import com.saucelabs.saucebindings.VisualSession;
+import com.saucelabs.saucebindings.VisualSnapshot;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class VisualTest {
+    private VisualSession session;
+    private RemoteWebDriver driver;
+
+    @Before
+    public void setup() {
+        System.setProperty("BUILD_NAME", "Sauce Bindings");
+    }
+
+    @After
+    public void cleanUp() {
+        if (session != null) {
+            session.stop();
+        }
+    }
+
+    @Test
+    public void startsSession() {
+        session = new VisualSession("VisualTest startsSession");
+        driver = session.start();
+
+        assertNotNull(driver);
+        assertTrue(session.getSauceUrl().toString().contains("screener.io"));
+    }
+
+    @Test
+    public void getVisualResults() {
+        session = new VisualSession("VisualTest getVisualResults");
+        driver = session.start();
+
+        session.takeSnapshot("Blank");
+
+        VisualResults results = session.getVisualResults();
+
+        assertTrue(results.getPassed());
+        assertEquals("success", results.getStatus());
+
+        assertNull(results.getMessage());
+
+        assertEquals(Long.valueOf(1), results.getTotal());
+        assertEquals(Long.valueOf(1), results.getTotalAccepted());
+        assertEquals(Long.valueOf(0), results.getTotalNew());
+        assertEquals(Long.valueOf(0), results.getTotalChanged());
+        assertEquals(Long.valueOf(0), results.getTotalRejected());
+
+        List<VisualSnapshot> states = results.getSnapshots();
+        assertEquals(1, states.size());
+
+        VisualSnapshot snapshot = results.getSnapshots().get(0);
+        assertEquals("Blank", snapshot.getName());
+        assertEquals("VisualTest getVisualResults", snapshot.getGroupName());
+        assertEquals("accepted", snapshot.getStatus());
+        String url = snapshot.getUrl();
+        assertTrue(url.contains(GitManager.getCurrentBranch()));
+        assertTrue(url.contains("Blank"));
+        assertTrue(url.contains("Windows"));
+    }
+
+    @Test
+    public void runMultipleTests() {
+        session = new VisualSession("VisualTest runMultipleTests 1");
+        driver = session.start();
+
+        session.takeSnapshot("Blank1");
+
+        session.newVisualTest("VisualTest runMultipleTests 2");
+
+        session.takeSnapshot("Blank2");
+
+        VisualSnapshot test1 = session.getVisualResults().getSnapshots().get(0);
+        VisualSnapshot test2 = session.getVisualResults().getSnapshots().get(1);
+        assertEquals("Blank1", test1.getName());
+        assertEquals("VisualTest runMultipleTests 1", test1.getGroupName());
+        assertEquals("Blank2", test2.getName());
+        assertEquals("VisualTest runMultipleTests 2", test2.getGroupName());
+    }
+
+    @Test
+    public void stopSendsVisualResultToSauce() {
+        session = new VisualSession("VisualTest stopSendsVisualResultToSauce");
+        driver = session.start();
+
+        session.stop();
+        assertEquals("passed", session.getResult());
+    }
+
+    @Test
+    public void stopParameterOverridesVisualResult() {
+        session = new VisualSession("VisualTest stopParameterOverridesVisualResult");
+        driver = session.start();
+
+        session.stop(false);
+        assertEquals("failed", session.getResult());
+    }
+
+    @Test
+    public void canNotTakeScreenshotAfterGettingVisualResults() {
+        session = new VisualSession("VisualTest stopParameterOverridesVisualResult");
+        driver = session.start();
+
+        session.getVisualResults();
+
+        try {
+            session.takeSnapshot("Blank Page");
+            fail("This should throw a SauceVisualException");
+        } catch (SauceVisualException ex) {
+            // Expected Behavior
+        }
+    }
+}

--- a/java/main/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/integration/VisualTest.java
@@ -5,6 +5,7 @@ import com.saucelabs.saucebindings.SauceVisualException;
 import com.saucelabs.saucebindings.VisualResults;
 import com.saucelabs.saucebindings.VisualSession;
 import com.saucelabs.saucebindings.VisualSnapshot;
+import com.saucelabs.saucebindings.options.VisualOptions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,7 +46,9 @@ public class VisualTest {
 
     @Test
     public void getVisualResults() {
-        session = new VisualSession("VisualTest getVisualResults");
+        VisualOptions visualOptions = new VisualOptions("VisualTest getVisualResults");
+        visualOptions.setFailOnNewStates(false);
+        session = new VisualSession(visualOptions);
         driver = session.start();
 
         session.takeSnapshot("Blank");

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options.yml
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options.yml
@@ -49,6 +49,77 @@ exampleValues:
     tunnelIdentifier: 'tunnelname'
     videoUploadOnPass: false
 
+visualValues:
+  browserName: 'firefox'
+  browserVersion: '68'
+  platformName: 'macOS 10.13'
+  acceptInsecureCerts: true
+  pageLoadStrategy: 'eager'
+  setWindowRect: true
+  unhandledPromptBehavior: "accept"
+  strictFileInteractability: true
+  timeouts:
+    implicit: 1000
+    pageLoad: 59000
+    script: 29000
+  visual:
+    projectName: 'My Project'
+    viewportSize: 393x786
+    baseBranch: baseBranch
+    ignore: '#some-id, .some-selector'
+    failOnNewStates: true
+    alwaysAcceptBaseBranch: true
+    disableBranchBaseline: true
+    scrollAndStitchScreenshots: true
+    disableCORS: true
+    iframes: true
+    diffOptions:
+      structure: true
+      layout: true
+      style: true
+      content: true
+      minLayoutPosition: 4
+      minLayoutDimension: 10
+    iframesOptions:
+      maxFrames: Infinity
+  sauce:
+    avoidProxy: true
+    build: 'Sample Build Name'
+    capturePerformance: true
+    chromedriverVersion: '71'
+    commandTimeout: 2
+    customData:
+      foo: 'foo'
+      bar: 'bar'
+    extendedDebugging: true
+    idleTimeout: 3
+    iedriverVersion: '3.141.0'
+    maxDuration: 300
+    name: 'Sample Test Name'
+    parentTunnel: 'Mommy'
+    prerun:
+      executable: "http://url.to/your/executable.exe"
+      args:
+        - --silent
+        - -a
+        - -q
+      background: false
+      timeout: 120
+    priority: 0
+    jobVisibility: 'team'
+    recordLogs: false
+    recordScreenshots: false
+    recordVideo: false
+    screenResolution: '10x10'
+    seleniumVersion: '3.141.59'
+    tags:
+      - foo
+      - bar
+      - foobar
+    timeZone: 'San Francisco'
+    tunnelIdentifier: 'tunnelname'
+    videoUploadOnPass: false
+
 badBrowser:
   browserName: "netscape"
 

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/VisualOptionsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/VisualOptionsTest.java
@@ -2,6 +2,7 @@ package com.saucelabs.saucebindings.options;
 
 import com.saucelabs.saucebindings.Browser;
 import com.saucelabs.saucebindings.CITools;
+import com.saucelabs.saucebindings.GitManager;
 import com.saucelabs.saucebindings.SaucePlatform;
 import com.saucelabs.saucebindings.SystemManager;
 import org.junit.Test;
@@ -21,7 +22,7 @@ public class VisualOptionsTest {
 
         MutableCapabilities visualCapabilities = new MutableCapabilities();
         visualCapabilities.setCapability("apiKey", System.getenv("SCREENER_API_KEY"));
-        visualCapabilities.setCapability("branch", "_default_");
+        visualCapabilities.setCapability("branch", GitManager.getCurrentBranch());
         visualCapabilities.setCapability("projectName", CITools.getBuildName());
 
         assertEquals(visualCapabilities, visualOptions.toCapabilities().getCapability("sauce:visual"));

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/VisualOptionsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/VisualOptionsTest.java
@@ -1,0 +1,157 @@
+package com.saucelabs.saucebindings.options;
+
+import com.saucelabs.saucebindings.Browser;
+import com.saucelabs.saucebindings.CITools;
+import com.saucelabs.saucebindings.SaucePlatform;
+import com.saucelabs.saucebindings.SystemManager;
+import org.junit.Test;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class VisualOptionsTest {
+    @Test
+    public void createsDefaultVisualOptions() {
+        VisualOptions visualOptions = new VisualOptions("Required Test Name");
+
+        MutableCapabilities visualCapabilities = new MutableCapabilities();
+        visualCapabilities.setCapability("apiKey", System.getenv("SCREENER_API_KEY"));
+        visualCapabilities.setCapability("branch", "_default_");
+        visualCapabilities.setCapability("projectName", CITools.getBuildName());
+
+        assertEquals(visualCapabilities, visualOptions.toCapabilities().getCapability("sauce:visual"));
+    }
+
+    @Test
+    public void acceptsVisualOptions() {
+        SauceOptions sauceOptions = SauceOptions.firefox()
+                .setPlatformName(SaucePlatform.MAC_HIGH_SIERRA)
+                .setBrowserVersion("99")
+                .setName("Visual Options Needs a Name")
+                .build();
+
+        Map<String, Object> diffOptions = new HashMap<>();
+        diffOptions.put("structure", true);
+        diffOptions.put("layout", true);
+        diffOptions.put("style", true);
+        diffOptions.put("content", true);
+        diffOptions.put("minLayoutPosition", 4);
+        diffOptions.put("minLayoutDimension", 10);
+
+        Map<String, Object> iframesOptions = new HashMap<>();
+        iframesOptions.put("maxFrames", "Infinity");
+
+        VisualOptions visualOptions = new VisualOptions(sauceOptions);
+        visualOptions
+                .setProjectName("Visual Options Project Name")
+                .setViewportSize("1024x768")
+                .setBranch("branch")
+                .setBaseBranch("baseBranch")
+                .setDiffOptions(diffOptions)
+                .setIgnore("#some-id, .some-selector")
+                .setFailOnNewStates(true)
+                .setAlwaysAcceptBaseBranch(true)
+                .setDisableBranchBaseline(true)
+                .setScrollAndStitchScreenshots(true)
+                .setDisableCORS(true)
+                .setIframes(true)
+                .setIframesOptions(iframesOptions);
+
+        assertEquals("Visual Options Project Name", visualOptions.getProjectName());
+        assertEquals("1024x768", visualOptions.getViewportSize());
+        assertEquals("baseBranch", visualOptions.getBaseBranch());
+        assertEquals(diffOptions, visualOptions.getDiffOptions());
+        assertEquals("#some-id, .some-selector", visualOptions.getIgnore());
+        assertTrue(visualOptions.getFailOnNewStates());
+        assertTrue(visualOptions.getAlwaysAcceptBaseBranch());
+        assertTrue(visualOptions.getDisableBranchBaseline());
+        assertTrue(visualOptions.getScrollAndStitchScreenshots());
+        assertTrue(visualOptions.getDisableCORS());
+        assertTrue(visualOptions.getIframes());
+        assertEquals(iframesOptions, visualOptions.getIframesOptions());
+        assertEquals(SaucePlatform.MAC_HIGH_SIERRA, visualOptions.getSauceOptions().platformName);
+        assertEquals(Browser.FIREFOX, visualOptions.getSauceOptions().browserName);
+        assertEquals("99", visualOptions.getSauceOptions().browserVersion);
+    }
+
+    @Test
+    public void parsesCapabilitiesFromVisualOptions() {
+        Map<String, Object> diffOptions = new HashMap<>();
+        diffOptions.put("structure", true);
+        diffOptions.put("layout", true);
+        diffOptions.put("style", true);
+        diffOptions.put("content", true);
+        diffOptions.put("minLayoutPosition", 4);
+        diffOptions.put("minLayoutDimension", 10);
+
+        Map<String, Object> iframesOptions = new HashMap<>();
+        iframesOptions.put("maxFrames", "Infinity");
+
+        SauceOptions sauceOptions = SauceOptions.firefox()
+                .setPlatformName(SaucePlatform.MAC_HIGH_SIERRA)
+                .setBrowserVersion("68")
+                .setName("Parses Name From Sauce Options")
+                .build();
+
+        VisualOptions visualOptions = new VisualOptions(sauceOptions);
+        visualOptions
+                .setProjectName("My Project")
+                .setViewportSize("1024x768")
+                .setBranch("branch")
+                .setBaseBranch("baseBranch")
+                .setDiffOptions(diffOptions)
+                .setIgnore("#some-id, .some-selector")
+                .setFailOnNewStates(true)
+                .setAlwaysAcceptBaseBranch(true)
+                .setDisableBranchBaseline(true)
+                .setScrollAndStitchScreenshots(true)
+                .setDisableCORS(true)
+                .setIframes(true)
+                .setIframesOptions(iframesOptions);
+
+        MutableCapabilities visualCapabilities = new MutableCapabilities();
+        visualCapabilities.setCapability("projectName", "My Project");
+        visualCapabilities.setCapability("viewportSize", "1024x768");
+        visualCapabilities.setCapability("branch", "branch");
+        visualCapabilities.setCapability("baseBranch", "baseBranch");
+        visualCapabilities.setCapability("diffOptions", diffOptions);
+        visualCapabilities.setCapability("ignore", "#some-id, .some-selector");
+        visualCapabilities.setCapability("failOnNewStates", true);
+        visualCapabilities.setCapability("alwaysAcceptBaseBranch", true);
+        visualCapabilities.setCapability("disableBranchBaseline", true);
+        visualCapabilities.setCapability("scrollAndStitchScreenshots", true);
+        visualCapabilities.setCapability("disableCORS", true);
+        visualCapabilities.setCapability("iframes", true);
+        visualCapabilities.setCapability("iframesOptions", iframesOptions);
+        visualCapabilities.setCapability("apiKey", System.getenv("SCREENER_API_KEY"));
+
+        MutableCapabilities actualCapabilities = visualOptions.toCapabilities();
+        assertEquals(visualCapabilities, actualCapabilities.getCapability("sauce:visual"));
+
+        MutableCapabilities sauceLabsCapabilities = new MutableCapabilities();
+        sauceLabsCapabilities.setCapability("name", "Parses Name From Sauce Options");
+        sauceLabsCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
+        sauceLabsCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
+
+        // Dynamic, not worried about testing this here, just need to know it is there
+        sauceLabsCapabilities.setCapability("build", visualOptions.getSauceOptions().sauce().getBuild());
+
+        assertEquals(sauceLabsCapabilities, actualCapabilities.getCapability("sauce:options"));
+    }
+
+    @Test
+    public void requiresTestName() {
+        SauceOptions sauceOptions = SauceOptions.chrome().build();
+        try {
+            new VisualOptions(sauceOptions);
+            fail("Expecting InvalidSauceOptionsArgumentException");
+        } catch (InvalidSauceOptionsArgumentException e) {
+            // Expected result
+        }
+    }
+}

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/VisualOptionsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/VisualOptionsTest.java
@@ -3,12 +3,24 @@ package com.saucelabs.saucebindings.options;
 import com.saucelabs.saucebindings.Browser;
 import com.saucelabs.saucebindings.CITools;
 import com.saucelabs.saucebindings.GitManager;
+import com.saucelabs.saucebindings.JobVisibility;
+import com.saucelabs.saucebindings.PageLoadStrategy;
+import com.saucelabs.saucebindings.Prerun;
 import com.saucelabs.saucebindings.SaucePlatform;
 import com.saucelabs.saucebindings.SystemManager;
+import com.saucelabs.saucebindings.UnhandledPromptBehavior;
+import lombok.SneakyThrows;
 import org.junit.Test;
 import org.openqa.selenium.MutableCapabilities;
+import org.yaml.snakeyaml.Yaml;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -155,4 +167,103 @@ public class VisualOptionsTest {
             // Expected result
         }
     }
+
+    @Test
+    public void setsCapabilitiesFromMap() {
+        Map<String, Object> map = serialize("visualValues");
+        VisualOptions visualOptions = new VisualOptions("Required Test Name");
+
+        visualOptions.mergeCapabilities(map);
+
+        Map<String, Object> diffOptions = new HashMap<>();
+        diffOptions.put("structure", true);
+        diffOptions.put("layout", true);
+        diffOptions.put("style", true);
+        diffOptions.put("content", true);
+        diffOptions.put("minLayoutPosition", 4);
+        diffOptions.put("minLayoutDimension", 10);
+
+        Map<String, Object> iframesOptions = new HashMap<>();
+        iframesOptions.put("maxFrames", "Infinity");
+
+        Map<String, Object> customData = new HashMap<>();
+        customData.put("foo", "foo");
+        customData.put("bar", "bar");
+
+        List<String> args = new ArrayList<>();
+        args.add("--silent");
+        args.add("-a");
+        args.add("-q");
+
+        Map<Prerun, Object> prerun = new HashMap<>();
+        prerun.put(Prerun.EXECUTABLE, "http://url.to/your/executable.exe");
+        prerun.put(Prerun.ARGS, args);
+        prerun.put(Prerun.BACKGROUND, false);
+        prerun.put(Prerun.TIMEOUT, 120);
+
+        List<String> tags = new ArrayList<>();
+        tags.add("foo");
+        tags.add("bar");
+        tags.add("foobar");
+
+        SauceOptions sauceOptions = visualOptions.getSauceOptions();
+
+        assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
+        assertEquals("68", sauceOptions.getBrowserVersion());
+        assertEquals(SaucePlatform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
+        assertEquals(true, sauceOptions.getAcceptInsecureCerts());
+        assertEquals(PageLoadStrategy.EAGER, sauceOptions.getPageLoadStrategy());
+        assertEquals(true, sauceOptions.getSetWindowRect());
+        assertEquals(UnhandledPromptBehavior.ACCEPT, sauceOptions.getUnhandledPromptBehavior());
+        assertEquals(true, sauceOptions.getStrictFileInteractability());
+        assertEquals(Duration.ofSeconds(1), sauceOptions.getImplicitWaitTimeout());
+        assertEquals(Duration.ofSeconds(59), sauceOptions.getPageLoadTimeout());
+        assertEquals(Duration.ofSeconds(29), sauceOptions.getScriptTimeout());
+        assertEquals(true, sauceOptions.sauce().getAvoidProxy());
+        assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
+        assertEquals(true, sauceOptions.sauce().getCapturePerformance());
+        assertEquals("71", sauceOptions.sauce().getChromedriverVersion());
+        assertEquals(Integer.valueOf(2), sauceOptions.sauce().getCommandTimeout());
+        assertEquals(customData, sauceOptions.sauce().getCustomData());
+        assertEquals(true, sauceOptions.sauce().getExtendedDebugging());
+        assertEquals(Integer.valueOf(3), sauceOptions.sauce().getIdleTimeout());
+        assertEquals("3.141.0", sauceOptions.sauce().getIedriverVersion());
+        assertEquals(Integer.valueOf(300), sauceOptions.sauce().getMaxDuration());
+        assertEquals("Sample Test Name", sauceOptions.sauce().getName());
+        assertEquals("Mommy", sauceOptions.sauce().getParentTunnel());
+        assertEquals(prerun, sauceOptions.sauce().getPrerun());
+        assertEquals(Integer.valueOf(0), sauceOptions.sauce().getPriority());
+        assertEquals(JobVisibility.TEAM, sauceOptions.sauce().getJobVisibility());
+        assertEquals(false, sauceOptions.sauce().getRecordLogs());
+        assertEquals(false, sauceOptions.sauce().getRecordScreenshots());
+        assertEquals(false, sauceOptions.sauce().getRecordVideo());
+        assertEquals("10x10", sauceOptions.sauce().getScreenResolution());
+        assertEquals("3.141.59", sauceOptions.sauce().getSeleniumVersion());
+        assertEquals(tags, sauceOptions.sauce().getTags());
+        assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
+        assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
+        assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());
+
+        assertEquals("My Project", visualOptions.getProjectName());
+        assertEquals("393x786", visualOptions.getViewportSize());
+        assertEquals("baseBranch", visualOptions.getBaseBranch());
+        assertEquals(diffOptions, visualOptions.getDiffOptions());
+        assertEquals("#some-id, .some-selector", visualOptions.getIgnore());
+        assertTrue(visualOptions.getFailOnNewStates());
+        assertTrue(visualOptions.getAlwaysAcceptBaseBranch());
+        assertTrue(visualOptions.getDisableBranchBaseline());
+        assertTrue(visualOptions.getScrollAndStitchScreenshots());
+        assertTrue(visualOptions.getDisableCORS());
+        assertTrue(visualOptions.getIframes());
+        assertEquals(iframesOptions, visualOptions.getIframesOptions());
+    }
+
+    @SneakyThrows
+    public Map<String, Object> serialize(String key) {
+        InputStream input = new FileInputStream(new File("src/test/java/com/saucelabs/saucebindings/options.yml"));
+        Yaml yaml = new Yaml();
+        Map<String, Object> data = yaml.load(input);
+        return (Map<String, Object>) data.get(key);
+    }
+
 }


### PR DESCRIPTION
This is a PR against #275, and it'll stay in Draft until that one is merged.
It subsumes #259 

I finally really like this API!

Easiest to see what this does from the examples:

Using default:
https://github.com/saucelabs/sauce_bindings/blob/11d774517a0b2c293c1c2c28939aa36375d1eeaa/java/main/src/test/java/com/saucelabs/saucebindings/examples/VisualTest.java#L12-L26

Updating Options:
https://github.com/saucelabs/sauce_bindings/blob/11d774517a0b2c293c1c2c28939aa36375d1eeaa/java/main/src/test/java/com/saucelabs/saucebindings/examples/VisualOptionsTest.java#L14-L39

Cool things this does:
* Automatically populates the default branch name with the actual branch name if it can determine it
* Automatically populates the Sauce Labs job with pass/fail based on whether Visual tests pass/fail
* Useful error when attempting to send a visual command after getting results (i.e., calling "end")

I still need to add javadocs because that's important and stuff
