### PR TITLE
Java annotations

### DIFF
--- a/java/main/src/main/java/com/saucelabs/saucebindings/SaucePlatform.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/SaucePlatform.java
@@ -41,6 +41,24 @@ public enum SaucePlatform {
         return PlatformLookup.lookup.get(value);
     }
 
+    /**
+     * Whether the platform is on an Apple Mac OS.
+     *
+     * @return true if platform is OS X or macOS
+     */
+    public boolean isMac() {
+        return this.value.contains("macOS") || this.value.contains("OS X");
+    }
+
+    /**
+     * Whether the platform is Microsoft Windows.
+     *
+     * @return true if platform is Windows OS
+     */
+    public boolean isWindows() {
+        return this.value.contains("Windows");
+    }
+
     public String toString() {
         return this.value;
     }

--- a/java/main/src/main/java/com/saucelabs/saucebindings/SauceSessionNotStartedException.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/SauceSessionNotStartedException.java
@@ -1,0 +1,12 @@
+package com.saucelabs.saucebindings;
+
+public class SauceSessionNotStartedException extends RuntimeException {
+    /**
+     * Some methods will not do anything if a Sauce session has not been started.
+     *
+     * @param message the name of the method that requires the session to be started
+     */
+    public SauceSessionNotStartedException(String message) {
+        super("Session must be started before executing " + message);
+    }
+}

--- a/java/main/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
@@ -1,34 +1,36 @@
 package com.saucelabs.saucebindings;
 
+import com.google.common.collect.ImmutableList;
 import com.saucelabs.saucebindings.options.SauceOptions;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.openqa.selenium.InvalidArgumentException;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
-
 public class SauceSessionTest {
-    private final SauceOptions sauceOptions = spy(new SauceOptions());
-    private final SauceSession sauceSession = spy(new SauceSession());
-    private final SauceSession sauceOptsSession = spy(new SauceSession(sauceOptions));
-    private final RemoteWebDriver dummyRemoteDriver = mock(RemoteWebDriver.class);
-    private final MutableCapabilities dummyMutableCapabilities = mock(MutableCapabilities.class);
+    private SauceOptions sauceOptions = Mockito.spy(new SauceOptions());
+    private SauceSession sauceSession = Mockito.spy(new SauceSession());
+    private final SauceSession sauceOptsSession = Mockito.spy(new SauceSession(sauceOptions));
+    private final RemoteWebDriver dummyRemoteDriver = Mockito.mock(RemoteWebDriver.class);
+    private final MutableCapabilities dummyMutableCapabilities = Mockito.mock(MutableCapabilities.class);
 
     @Rule
     public MockitoRule initRule = MockitoJUnit.rule();
 
     @Before
     public void setUp() {
-        doReturn(dummyRemoteDriver).when(sauceSession).createRemoteWebDriver(any(URL.class), any(MutableCapabilities.class));
+        Mockito.doReturn(dummyRemoteDriver).when(sauceSession)
+                .createRemoteWebDriver(Mockito.any(URL.class), Mockito.any(MutableCapabilities.class));
     }
 
     @Test
@@ -37,19 +39,20 @@ public class SauceSessionTest {
         String actualBrowserVersion = sauceSession.getSauceOptions().getBrowserVersion();
         SaucePlatform actualPlatformName = sauceSession.getSauceOptions().getPlatformName();
 
-        assertEquals(Browser.CHROME, actualBrowser);
-        assertEquals(SaucePlatform.WINDOWS_10, actualPlatformName);
-        assertEquals("latest", actualBrowserVersion);
+        Assert.assertEquals(Browser.CHROME, actualBrowser);
+        Assert.assertEquals(SaucePlatform.WINDOWS_10, actualPlatformName);
+        Assert.assertEquals("latest", actualBrowserVersion);
     }
 
     @Test
     public void sauceSessionUsesProvidedSauceOptions() {
-        doReturn(dummyMutableCapabilities).when(sauceOptions).toCapabilities();
-        doReturn(dummyRemoteDriver).when(sauceOptsSession).createRemoteWebDriver(any(URL.class), eq(dummyMutableCapabilities));
+        Mockito.doReturn(dummyMutableCapabilities).when(sauceOptions).toCapabilities();
+        Mockito.doReturn(dummyRemoteDriver).when(sauceOptsSession)
+                .createRemoteWebDriver(Mockito.any(URL.class), Matchers.eq(dummyMutableCapabilities));
 
         sauceOptsSession.start();
 
-        verify(sauceOptions).toCapabilities();
+        Mockito.verify(sauceOptions).toCapabilities();
     }
 
     @Test
@@ -58,29 +61,29 @@ public class SauceSessionTest {
                 .setPlatformName(SaucePlatform.MAC_MOJAVE));
         SauceOptions sauceOptions = sauceSession.getSauceOptions();
 
-        assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
-        assertEquals(SaucePlatform.MAC_MOJAVE, sauceOptions.getPlatformName());
-        assertEquals("latest", sauceOptions.getBrowserVersion());
+        Assert.assertEquals(Browser.CHROME, sauceOptions.getBrowserName());
+        Assert.assertEquals(SaucePlatform.MAC_MOJAVE, sauceOptions.getPlatformName());
+        Assert.assertEquals("latest", sauceOptions.getBrowserVersion());
     }
 
     @Test
     public void defaultsToUSWestDataCenter() {
         String expectedDataCenterEndpoint = DataCenter.US_WEST.getValue();
-        assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getValue());
+        Assert.assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getValue());
     }
 
     @Test
     public void setsDataCenter() {
         String expectedDataCenterEndpoint = DataCenter.US_EAST.getValue();
         sauceSession.setDataCenter(DataCenter.US_EAST);
-        assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getValue());
+        Assert.assertEquals(expectedDataCenterEndpoint, sauceSession.getDataCenter().getValue());
     }
 
     @Test
     public void setsSauceURLDirectly() throws MalformedURLException {
         sauceSession.setSauceUrl(new URL("http://example.com"));
-        String expetedSauceUrl = "http://example.com";
-        assertEquals(expetedSauceUrl, sauceSession.getSauceUrl().toString());
+        String expectedSauceUrl = "http://example.com";
+        Assert.assertEquals(expectedSauceUrl, sauceSession.getSauceUrl().toString());
     }
 
     @Test
@@ -88,34 +91,158 @@ public class SauceSessionTest {
         sauceSession.start();
         sauceSession.stop(true);
 
-        verify(dummyRemoteDriver).quit();
+        Mockito.verify(dummyRemoteDriver).quit();
     }
 
     @Test
     public void stopWithBooleanTrue() {
         sauceSession.start();
         sauceSession.stop(true);
-        verify(dummyRemoteDriver).executeScript("sauce:job-result=passed");
+        Mockito.verify(dummyRemoteDriver).executeScript("sauce:job-result=passed");
     }
 
     @Test
     public void stopWithBooleanFalse() {
         sauceSession.start();
         sauceSession.stop(false);
-        verify(dummyRemoteDriver).executeScript("sauce:job-result=failed");
+        Mockito.verify(dummyRemoteDriver).executeScript("sauce:job-result=failed");
     }
 
+    @Deprecated
     @Test
     public void stopWithStringPassed() {
         sauceSession.start();
         sauceSession.stop("passed");
-        verify(dummyRemoteDriver).executeScript("sauce:job-result=passed");
+        Mockito.verify(dummyRemoteDriver).executeScript("sauce:job-result=passed");
     }
 
+    @Deprecated
     @Test
     public void stopWithStringFailed() {
         sauceSession.start();
         sauceSession.stop("failed");
-        verify(dummyRemoteDriver).executeScript("sauce:job-result=failed");
+        Mockito.verify(dummyRemoteDriver).executeScript("sauce:job-result=failed");
+    }
+
+    @Test(expected = SauceSessionNotStartedException.class)
+    public void annotateRequiresStart() {
+        sauceSession.annotate("Comment Causes Failure");
+    }
+
+    @Test
+    public void annotates() {
+        sauceSession.start();
+        sauceSession.annotate("Comment in Command List");
+        Mockito.verify(dummyRemoteDriver).executeScript("sauce:context=Comment in Command List");
+    }
+
+    @Test(expected = SauceSessionNotStartedException.class)
+    public void pauseRequiresStart() {
+        sauceSession.pause();
+    }
+
+    @Test
+    public void pauses() {
+        sauceSession.start();
+        sauceSession.pause();
+        Mockito.verify(dummyRemoteDriver).executeScript("sauce: break");
+    }
+
+    @Test(expected = SauceSessionNotStartedException.class)
+    public void disableLoggingRequiresStart() {
+        sauceSession.disableLogging();
+    }
+
+    @Test
+    public void disablesLogs() {
+        sauceSession.start();
+        sauceSession.disableLogging();
+        Mockito.verify(dummyRemoteDriver).executeScript("sauce: disable log");
+    }
+
+    @Test(expected = SauceSessionNotStartedException.class)
+    public void enableLoggingRequiresStart() {
+        sauceSession.enableLogging();
+    }
+
+    @Test
+    public void enablesLogs() {
+        sauceSession.start();
+        sauceSession.enableLogging();
+        Mockito.verify(dummyRemoteDriver).executeScript("sauce: enable log");
+    }
+
+    @Test(expected = SauceSessionNotStartedException.class)
+    public void stopNetworkRequiresStart() {
+        sauceSession.stopNetwork();
+    }
+
+    @Test(expected = InvalidArgumentException.class)
+    public void stopNetworkRequiresMac() {
+        sauceSession.start();
+        sauceSession.stopNetwork();
+    }
+
+    @Test
+    public void stopsNetwork() {
+        // Only works on Mac
+        sauceOptions = Mockito.spy(SauceOptions.safari().build());
+        sauceSession = Mockito.spy(new SauceSession(sauceOptions));
+        Mockito.doReturn(dummyMutableCapabilities).when(sauceOptions).toCapabilities();
+        Mockito.doReturn(dummyRemoteDriver).when(sauceSession)
+                .createRemoteWebDriver(Mockito.any(URL.class), Mockito.eq(dummyMutableCapabilities));
+
+        sauceSession.start();
+        sauceSession.stopNetwork();
+        Mockito.verify(dummyRemoteDriver).executeScript("sauce: stop network");
+    }
+
+    @Test(expected = SauceSessionNotStartedException.class)
+    public void startNetworkRequiresStart() {
+        sauceSession.startNetwork();
+    }
+
+    @Test(expected = InvalidArgumentException.class)
+    public void startNetworkRequiresMac() {
+        sauceSession.start();
+        sauceSession.startNetwork();
+    }
+
+    @Test
+    public void startsNetwork() {
+        // Only works on Mac
+        sauceOptions = Mockito.spy(SauceOptions.safari().build());
+        sauceSession = Mockito.spy(new SauceSession(sauceOptions));
+        Mockito.doReturn(dummyMutableCapabilities).when(sauceOptions).toCapabilities();
+        Mockito.doReturn(dummyRemoteDriver).when(sauceSession)
+                .createRemoteWebDriver(Mockito.any(URL.class), Mockito.eq(dummyMutableCapabilities));
+
+        sauceSession.start();
+        sauceSession.startNetwork();
+        Mockito.verify(dummyRemoteDriver).executeScript("sauce: start network");
+    }
+
+    @Test(expected = SauceSessionNotStartedException.class)
+    public void changeNameRequiresStart() {
+        sauceSession.changeTestName("New Name Causes Failure");
+    }
+
+    @Test
+    public void changesName() {
+        sauceSession.start();
+        sauceSession.changeTestName("New Name");
+        Mockito.verify(dummyRemoteDriver).executeScript("sauce:job-name=New Name");
+    }
+
+    @Test(expected = SauceSessionNotStartedException.class)
+    public void addTagsRequiresStart() {
+        sauceSession.addTags(ImmutableList.of("foo", "bar"));
+    }
+
+    @Test
+    public void addTags() {
+        sauceSession.start();
+        sauceSession.addTags(ImmutableList.of("foo", "bar"));
+        Mockito.verify(dummyRemoteDriver).executeScript("sauce:job-tags=foo,bar");
     }
 }

--- a/java/main/src/test/java/com/saucelabs/saucebindings/integration/DesktopBrowserTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/integration/DesktopBrowserTest.java
@@ -11,7 +11,7 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 
 public class DesktopBrowserTest {
     private SauceSession session = new SauceSession();
-    private RemoteWebDriver webDriver;
+    private RemoteWebDriver driver;
 
     @After
     public void cleanUp() {
@@ -22,8 +22,8 @@ public class DesktopBrowserTest {
 
     @Test
     public void defaultsToUSWest() {
-        webDriver = session.start();
-        Assert.assertNotNull(webDriver);
+        driver = session.start();
+        Assert.assertNotNull(driver);
         Assert.assertTrue(session.getSauceUrl().toString().contains("us-west-"));
     }
 
@@ -33,27 +33,27 @@ public class DesktopBrowserTest {
         options.setPlatformName(SaucePlatform.LINUX);
         session = new SauceSession(options);
         session.setDataCenter(DataCenter.US_EAST);
-        webDriver = session.start();
+        driver = session.start();
 
-        Assert.assertNotNull(webDriver);
+        Assert.assertNotNull(driver);
         Assert.assertTrue(session.getSauceUrl().toString().contains("us-east-1"));
     }
 
     @Test
     public void runsAPACSoutheast() {
         session.setDataCenter(DataCenter.APAC_SOUTHEAST);
-        webDriver = session.start();
+        driver = session.start();
 
-        Assert.assertNotNull(webDriver);
+        Assert.assertNotNull(driver);
         Assert.assertTrue(session.getSauceUrl().toString().contains("apac-southeast"));
     }
 
     @Test
     public void runsEUCentral() {
         session.setDataCenter(DataCenter.EU_CENTRAL);
-        webDriver = session.start();
+        driver = session.start();
 
-        Assert.assertNotNull(webDriver);
+        Assert.assertNotNull(driver);
         Assert.assertTrue(session.getSauceUrl().toString().contains("eu-central-1"));
     }
 
@@ -69,9 +69,26 @@ public class DesktopBrowserTest {
 
     @Test
     public void nullsDriver() {
-        webDriver = session.start();
+        driver = session.start();
         session.stop(true);
 
         Assert.assertNull(session.getDriver());
+    }
+
+    @Test
+    public void stopsNetwork() {
+        session = new SauceSession(SauceOptions.safari());
+        driver = session.start();
+
+        session.stopNetwork();
+
+        driver.get("https://www.saucedemo.com");
+
+        Assert.assertEquals("Failed to open page", driver.getTitle());
+
+        session.startNetwork();
+        driver.get("https://www.saucedemo.com");
+
+        Assert.assertEquals("Swag Labs", driver.getTitle());
     }
 }

--- a/python/saucebindings/exceptions.py
+++ b/python/saucebindings/exceptions.py
@@ -1,0 +1,11 @@
+class SessionNotStartedException(Exception):
+    """
+    Thrown when a method is called that requires an active Sauce Session.
+    """
+    pass
+
+class InvalidPlatformException(Exception):
+    """
+    Thrown when a method is called that requires a different Sauce Platform.
+    """
+    pass

--- a/python/saucebindings/options.py
+++ b/python/saucebindings/options.py
@@ -5,7 +5,6 @@ from .configs import *
 from selenium.webdriver import __version__ as seleniumVersion
 import os
 
-
 w3c_configs = {
     'browser_name': 'browserName',
     'browser_version': 'browserVersion',
@@ -47,6 +46,7 @@ sauce_configs = {
     'video_upload_on_pass': 'videoUploadOnPass',
     'capture_performance': 'capturePerformance'
 }
+
 
 class SauceOptions(object):
 
@@ -197,6 +197,12 @@ class SauceOptions(object):
             self.options[w3c_configs[key]] = value
         else:
             raise AttributeError
+
+    def is_mac(self):
+        return "mac" in self.platform_name or "OS X" in self.platform_name
+
+    def is_windows(self):
+        return "Windows" in self.platform_name
 
     def to_capabilities(self):
         if self.selenium_options:

--- a/python/tests/integration/test_desktop_browser.py
+++ b/python/tests/integration/test_desktop_browser.py
@@ -36,3 +36,21 @@ class TestDataCenter(object):
         assert "eu-central-1" in session.remote_url
 
         session.stop(True)
+
+
+class TestAnnotations(object):
+
+    def test_stops_starts_network(self):
+        sauce_session = SauceSession(SauceOptions.safari())
+        driver = sauce_session.start()
+
+        sauce_session.stop_network()
+
+        driver.get("https://www.saucedemo.com")
+        assert driver.title == "Failed to open page"
+
+        sauce_session.start_network()
+        driver.get("https://www.saucedemo.com")
+        assert driver.title == "Swag Labs"
+
+        sauce_session.stop(True)

--- a/python/tests/unit/test_session.py
+++ b/python/tests/unit/test_session.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from saucebindings.exceptions import SessionNotStartedException, InvalidPlatformException
 from saucebindings.options import SauceOptions
 from saucebindings.session import SauceSession
 
@@ -23,7 +24,7 @@ class TestInit(object):
             SauceSession(data_center='invalid')
 
     def test_accepts_provided_options_instance(self):
-        options = SauceOptions()
+        options = SauceOptions.chrome()
 
         session = SauceSession(options)
 
@@ -70,8 +71,8 @@ class TestStart(object):
                          'browserVersion': 'latest',
                          'platformName': 'Windows 10',
                          'sauce:options': {'build': 'TEST BUILD: 11',
-                                                   'username': os.getenv('SAUCE_USERNAME'),
-                                                   'accessKey': os.getenv('SAUCE_ACCESS_KEY')}}
+                                           'username': os.getenv('SAUCE_USERNAME'),
+                                           'accessKey': os.getenv('SAUCE_ACCESS_KEY')}}
 
         sauce_session = SauceSession()
         mocker.patch.object(sauce_session, 'create_driver')
@@ -79,6 +80,7 @@ class TestStart(object):
         sauce_session.start()
 
         sauce_session.create_driver.assert_called_once_with(default_url, expected_caps)
+
 
 class TestURL(object):
 
@@ -122,3 +124,182 @@ class TestStop(object):
         sauce_session.stop(False)
 
         driver.execute_script.assert_called_once_with('sauce:job-result=failed')
+
+
+class TestAnnotations(object):
+
+    def test_annotation_requires_start(self):
+        sauce_session = SauceSession()
+        with pytest.raises(SessionNotStartedException):
+            sauce_session.annotate("comment")
+
+    def test_annotates(self, mocker):
+        sauce_session = SauceSession()
+        mocker.patch.object(sauce_session, 'create_driver')
+
+        driver = sauce_session.start()
+        mocker.patch.object(driver, 'quit')
+        mocker.patch.object(driver, 'execute_script')
+
+        sauce_session.annotate("comment")
+
+        driver.execute_script.assert_called_once_with("sauce:context=comment")
+
+    def test_pause_requires_start(self):
+        sauce_session = SauceSession()
+        with pytest.raises(SessionNotStartedException):
+            sauce_session.pause()
+
+    def test_pauses(self, mocker):
+        sauce_session = SauceSession()
+        mocker.patch.object(sauce_session, 'create_driver')
+
+        driver = sauce_session.start()
+        mocker.patch.object(driver, 'quit')
+        mocker.patch.object(driver, 'execute_script')
+
+        sauce_session.pause()
+
+        driver.execute_script.assert_called_once_with("sauce: break")
+
+    def test_disable_logging_requires_start(self):
+        sauce_session = SauceSession()
+        with pytest.raises(SessionNotStartedException):
+            sauce_session.disable_logging()
+
+    def test_disables_logging(self, mocker):
+        sauce_session = SauceSession()
+        mocker.patch.object(sauce_session, 'create_driver')
+
+        driver = sauce_session.start()
+        mocker.patch.object(driver, 'quit')
+        mocker.patch.object(driver, 'execute_script')
+
+        sauce_session.disable_logging()
+
+        driver.execute_script.assert_called_once_with("sauce: disable log")
+
+    def test_enable_logging_requires_start(self):
+        sauce_session = SauceSession()
+        with pytest.raises(SessionNotStartedException):
+            sauce_session.enable_logging()
+
+    def test_enables_logging(self, mocker):
+        sauce_session = SauceSession()
+        mocker.patch.object(sauce_session, 'create_driver')
+
+        driver = sauce_session.start()
+        mocker.patch.object(driver, 'quit')
+        mocker.patch.object(driver, 'execute_script')
+
+        sauce_session.enable_logging()
+
+        driver.execute_script.assert_called_once_with("sauce: enable log")
+
+    def test_stop_network_requires_start(self):
+        sauce_session = SauceSession()
+        with pytest.raises(SessionNotStartedException):
+            sauce_session.stop_network()
+
+    def test_stop_network_requires_mac(self, mocker):
+        sauce_session = SauceSession()
+        mocker.patch.object(sauce_session, 'create_driver')
+        sauce_session.start()
+
+        with pytest.raises(InvalidPlatformException):
+            sauce_session.stop_network()
+
+    def test_stops_network(self, mocker):
+        sauce_session = SauceSession(SauceOptions.safari())
+        mocker.patch.object(sauce_session, 'create_driver')
+
+        driver = sauce_session.start()
+        mocker.patch.object(driver, 'quit')
+        mocker.patch.object(driver, 'execute_script')
+
+        sauce_session.stop_network()
+
+        driver.execute_script.assert_called_once_with("sauce: stop network")
+
+    def test_start_network_requires_start(self):
+        sauce_session = SauceSession()
+        with pytest.raises(SessionNotStartedException):
+            sauce_session.start_network()
+
+    def test_start_network_requires_mac(self, mocker):
+        sauce_session = SauceSession()
+        mocker.patch.object(sauce_session, 'create_driver')
+        sauce_session.start()
+
+        with pytest.raises(InvalidPlatformException):
+            sauce_session.start_network()
+
+    def test_starts_network(self, mocker):
+        sauce_session = SauceSession(SauceOptions.safari())
+        mocker.patch.object(sauce_session, 'create_driver')
+
+        driver = sauce_session.start()
+        mocker.patch.object(driver, 'quit')
+        mocker.patch.object(driver, 'execute_script')
+
+        sauce_session.start_network()
+
+        driver.execute_script.assert_called_once_with("sauce: start network")
+
+    def test_change_name_requires_start(self):
+        sauce_session = SauceSession()
+        with pytest.raises(SessionNotStartedException):
+            sauce_session.change_name("New Name")
+
+    def test_changes_name(self, mocker):
+        sauce_session = SauceSession()
+        mocker.patch.object(sauce_session, 'create_driver')
+
+        driver = sauce_session.start()
+        mocker.patch.object(driver, 'quit')
+        mocker.patch.object(driver, 'execute_script')
+
+        sauce_session.change_name("New Name")
+
+        driver.execute_script.assert_called_once_with("sauce:job-name=New Name")
+
+    def test_add_tags_requires_start(self):
+        sauce_session = SauceSession()
+        with pytest.raises(SessionNotStartedException):
+            sauce_session.add_tags(['foo', 'bar'])
+
+    def test_adds_tags_as_array(self, mocker):
+        sauce_session = SauceSession()
+        mocker.patch.object(sauce_session, 'create_driver')
+
+        driver = sauce_session.start()
+        mocker.patch.object(driver, 'quit')
+        mocker.patch.object(driver, 'execute_script')
+
+        sauce_session.add_tags(['foo', 'bar'])
+
+        driver.execute_script.assert_called_once_with("sauce:job-tags=foo,bar")
+
+    def test_adds_tags_as_string(self, mocker):
+        sauce_session = SauceSession()
+        mocker.patch.object(sauce_session, 'create_driver')
+
+        driver = sauce_session.start()
+        mocker.patch.object(driver, 'quit')
+        mocker.patch.object(driver, 'execute_script')
+
+        sauce_session.add_tags('foo')
+
+        driver.execute_script.assert_called_once_with("sauce:job-tags=foo")
+
+    def test_adds_tags_as_csv_string(self, mocker):
+        sauce_session = SauceSession()
+        mocker.patch.object(sauce_session, 'create_driver')
+
+        driver = sauce_session.start()
+        mocker.patch.object(driver, 'quit')
+        mocker.patch.object(driver, 'execute_script')
+
+        sauce_session.add_tags('foo,bar')
+
+        driver.execute_script.assert_called_once_with("sauce:job-tags=foo,bar")

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -22,8 +22,7 @@ Metrics/PerceivedComplexity:
   Max: 11
 
 Metrics/ClassLength:
-  Exclude:
-    - 'lib/sauce_bindings/options.rb'
+  Enabled: false
 
 Metrics/LineLength:
   Max: 120

--- a/ruby/lib/sauce_bindings.rb
+++ b/ruby/lib/sauce_bindings.rb
@@ -2,6 +2,7 @@
 
 require 'sauce_bindings/version'
 require 'sauce_bindings/options'
+require 'sauce_bindings/errors'
 require 'sauce_bindings/session'
 require 'sauce_bindings/base_configurations'
 require 'sauce_bindings/vdc_configurations'

--- a/ruby/lib/sauce_bindings/errors.rb
+++ b/ruby/lib/sauce_bindings/errors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SauceBindings
+  class SessionNotStartedError < RuntimeError; end
+
+  class InvalidPlatformError < RuntimeError; end
+end

--- a/ruby/lib/sauce_bindings/options.rb
+++ b/ruby/lib/sauce_bindings/options.rb
@@ -111,6 +111,14 @@ module SauceBindings
       end
     end
 
+    def mac?
+      @platform_name.include?('mac') || @platform_name.include?('OS X')
+    end
+
+    def windows?
+      @platform_name.include?('Windows')
+    end
+
     private
 
     def key_value(key)

--- a/ruby/lib/sauce_bindings/session.rb
+++ b/ruby/lib/sauce_bindings/session.rb
@@ -31,18 +31,12 @@ module SauceBindings
       return if @driver.nil?
 
       unless result.is_a?(TrueClass) || result.is_a?(FalseClass)
-        raise ArgumentError, "Result must be a boolean value representing whether a test has passed"
+        raise ArgumentError, 'Result must be a boolean value representing whether a test has passed'
       end
 
       SauceWhisk::Jobs.change_status(@driver.session_id, result)
-      # Add output for the Sauce OnDemand Jenkins plugin
-      # The first print statement will automatically populate links on Jenkins to Sauce
-      # The second print statement will output the job link to logging/console
-      puts "SauceOnDemandSessionID=#{@driver.session_id} job-name=#{@options.name}"
+      print_results
 
-      test_link = data_center == :US_WEST ? '' : "#{DATA_CENTERS[data_center]}."
-
-      puts "Test Job Link: https://app.#{test_link}saucelabs.com/tests/#{@driver.session_id}"
       @driver.quit
     end
 
@@ -57,8 +51,64 @@ module SauceBindings
     end
 
     def accessibility_results(js_lib: nil, frames: true, cross_origin: false)
+      validate_session_started('accessibility_results')
       sa11y = Sa11y::Analyze.new(driver, js_lib: js_lib, frames: frames, cross_origin: cross_origin)
       sa11y.results
+    end
+
+    def annotate(comment)
+      validate_session_started('annotate')
+      driver.execute_script("sauce:context=#{comment}")
+    end
+
+    def pause
+      validate_session_started('pause')
+      driver.execute_script('sauce: break')
+      puts "\nThis test has been stopped; no more driver commands will be accepted"
+      puts "\nYou can take manual control of the test from the Sauce Labs UI here: #{test_link}"
+      @driver = nil
+    end
+
+    def disable_logging
+      validate_session_started('disable_logging')
+      driver.execute_script('sauce: disable log')
+    end
+
+    def enable_logging
+      validate_session_started('enable_logging')
+      driver.execute_script('sauce: enable log')
+    end
+
+    def stop_network
+      validate_session_started('stop_network')
+      unless options.mac?
+        error = "Can only start or stop the network on a Mac; current platform is: #{options.platform_name}"
+        raise InvalidPlatformError, error
+      end
+
+      driver.execute_script('sauce: stop network')
+    end
+
+    def start_network
+      validate_session_started('start_network')
+      unless options.mac?
+        error = "Can only start or stop the network on a Mac; current platform is: #{options.platform_name}"
+        raise InvalidPlatformError, error
+      end
+
+      driver.execute_script('sauce: start network')
+    end
+
+    def change_name(name)
+      validate_session_started('change_name')
+
+      driver.execute_script("sauce:job-name=#{name}")
+    end
+
+    def add_tags(tags)
+      tags = Array(tags)
+      validate_session_started('tags=')
+      driver.execute_script("sauce:job-tags=#{tags.join(',')}")
     end
 
     def url
@@ -70,6 +120,26 @@ module SauceBindings
       caps[:listener] = listener if listener
       caps[:http_client] = http_client if http_client
       caps
+    end
+
+    private
+
+    def test_link
+      dc = data_center == :US_WEST ? '' : "#{DATA_CENTERS[data_center]}."
+      "https://app.#{dc}saucelabs.com/tests/#{@driver.session_id}"
+    end
+
+    def validate_session_started(method)
+      raise SessionNotStartedError, "session must be started before executing ##{method}" unless driver
+    end
+
+    def print_results
+      # Add output for the Sauce OnDemand Jenkins plugin
+      # The first print statement will automatically populate links on Jenkins to Sauce
+      # The second print statement will output the job link to logging/console
+      puts "SauceOnDemandSessionID=#{@driver.session_id} job-name=#{@options.name}"
+
+      puts "Test Job Link: #{test_link}"
     end
   end
 end

--- a/ruby/spec/integration/desktop_spec.rb
+++ b/ruby/spec/integration/desktop_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 
 module SauceBindings
   describe Session do
-    describe 'starts with data center' do
-      before { WebMock.allow_net_connect! }
+    before { WebMock.allow_net_connect! }
 
+    describe '#data_center=' do
       it 'defaults to US West' do
         @session = Session.new
         driver = @session.start
@@ -17,7 +17,8 @@ module SauceBindings
 
       it 'executes on US East' do
         options = Options.chrome(platform_name: 'Linux')
-        @session = Session.new(options, data_center: :US_EAST)
+        @session = Session.new(options)
+        @session.data_center = :US_EAST
         driver = @session.start
 
         expect(driver).not_to be_nil
@@ -25,7 +26,8 @@ module SauceBindings
       end
 
       it 'executes on EU Central' do
-        @session = Session.new(data_center: :EU_CENTRAL)
+        @session = Session.new
+        @session.data_center = :EU_CENTRAL
         driver = @session.start
 
         expect(driver).not_to be_nil
@@ -34,11 +36,29 @@ module SauceBindings
 
       it 'executes on APAC' do
         pending 'Adding Data Center to Sauce Whisk'
-        @session = Session.new(data_center: :APAC_SOUTHEAST)
+        @session = Session.new
+        @session.data_center = :APAC_SOUTHEAST
         driver = @session.start
 
         expect(driver).not_to be_nil
         expect(@session.url).to include('apac-southeast-1')
+      end
+    end
+
+    describe '#stop_network' do
+      it 'stops and starts the network' do
+        @session = Session.new(Options.safari)
+        driver = @session.start
+
+        @session.stop_network
+        driver.get('https://www.saucedemo.com')
+
+        expect(driver.title).to eq 'Failed to open page'
+
+        @session.start_network
+        driver.get('https://www.saucedemo.com')
+
+        expect(driver.title).to eq 'Swag Labs'
       end
     end
   end


### PR DESCRIPTION
Implementing these: https://docs.saucelabs.com/basics/test-config-annotation/test-annotation/

Naming stuff is hard. These sound good?
* I changed "context" to "annotate" could also be "comment"
* I changed "break" to "pause" could also be "debug"
* ~I changed "public" to be set with "setVisibility" could also be "setJobVisibility"~
*  I changed "public" to be set with "changeTestVisibility" instead of the above based on feedback
* ~I changed "job-name" to be set with "changeName" could also be "setName" or "setJobName"~
* I changed "job-name" to be set with "changeTestName" instead of the above based on feedback

This is also adding a check to make sure session has started before executing session methods.
And ensures starting/stopping network only works for Macs

This is in Draft status while I implement Python. No reason to wait on Feedback for the Java, though.