### PR TITLE
Add tunnelOwner option for python

### DIFF
--- a/python/saucebindings/configs.py
+++ b/python/saucebindings/configs.py
@@ -7,6 +7,7 @@ class Configs:
         'custom_data': 'customData',
         'public': 'public',
         'tunnel_identifier': 'tunnelIdentifier',
+        'tunnel_owner': 'tunnelOwner',
         'parent_tunnel': 'parentTunnel'
     }
 

--- a/python/saucebindings/options.py
+++ b/python/saucebindings/options.py
@@ -43,6 +43,7 @@ sauce_configs = {
     'tags': 'tags',
     'time_zone': 'timeZone',
     'tunnel_identifier': 'tunnelIdentifier',
+    'tunnel_owner': 'tunnelOwner',
     'video_upload_on_pass': 'videoUploadOnPass',
     'capture_performance': 'capturePerformance'
 }

--- a/python/tests/options.yml
+++ b/python/tests/options.yml
@@ -43,6 +43,7 @@ exampleValues:
     - foobar
   timeZone: 'San Francisco'
   tunnelIdentifier: 'tunnelname'
+  tunnelOwner: 'tunnelowner'
   videoUploadOnPass: false
 
 invalidOption:

--- a/python/tests/unit/test_chrome.py
+++ b/python/tests/unit/test_chrome.py
@@ -87,6 +87,7 @@ class TestInit(object):
                    'tags': ['foo', 'bar'],
                    'timeZone': 'Foo',
                    'tunnelIdentifier': 'foobar',
+                   'tunnelOwner': 'baz',
                    'videoUploadOnPass': False}
 
         sauce = SauceOptions.chrome(**options)
@@ -115,6 +116,7 @@ class TestInit(object):
         assert sauce.tags == ['foo', 'bar']
         assert sauce.time_zone == 'Foo'
         assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.tunnel_owner == 'baz'
         assert sauce.video_upload_on_pass is False
 
     def test_accepts_sauce_values_as_params(self):
@@ -144,6 +146,7 @@ class TestInit(object):
                                     tags=['foo', 'bar'],
                                     timeZone='Foo',
                                     tunnelIdentifier='foobar',
+                                    tunnelOwner='baz',
                                     videoUploadOnPass=False)
 
         assert sauce.build == 'bar'
@@ -170,6 +173,7 @@ class TestInit(object):
         assert sauce.tags == ['foo', 'bar']
         assert sauce.time_zone == 'Foo'
         assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.tunnel_owner == 'baz'
         assert sauce.video_upload_on_pass is False
 
     def test_accepts_selenium_browser_options_instance(self):
@@ -282,6 +286,7 @@ class TestSettingSpecificOptions(object):
         options.tags = tags
         options.time_zone = 'San Francisco'
         options.tunnel_identifier = 'tunnelname'
+        options.tunnel_owner = 'tunnelowner'
         options.video_upload_on_pass = False
 
         assert options.build == 'Sample Build Name'
@@ -304,6 +309,7 @@ class TestSettingSpecificOptions(object):
         assert options.tags == tags
         assert options.time_zone == 'San Francisco'
         assert options.tunnel_identifier == 'tunnelname'
+        assert options.tunnel_owner == 'tunnelowner'
         assert options.video_upload_on_pass is False
 
     def test_setting_browser_name(self):
@@ -384,6 +390,7 @@ class TestCapabilitiesCreation(object):
         options.tags = tags
         options.time_zone = 'San Francisco'
         options.tunnel_identifier = 'tunnelname'
+        options.tunnel_owner = 'tunnelowner'
         options.video_upload_on_pass = False
 
         expected_capabilities = {'browserName': 'chrome',
@@ -410,6 +417,7 @@ class TestCapabilitiesCreation(object):
                                                    'tags': ['foo', 'bar'],
                                                    'timeZone': 'San Francisco',
                                                    'tunnelIdentifier': 'tunnelname',
+                                                   'tunnelOwner': 'tunnelowner',
                                                    'videoUploadOnPass': False,
                                                    'username': os.getenv('SAUCE_USERNAME'),
                                                    'accessKey': os.getenv('SAUCE_ACCESS_KEY')}}

--- a/python/tests/unit/test_edge.py
+++ b/python/tests/unit/test_edge.py
@@ -84,6 +84,7 @@ class TestInit(object):
                    'tags': ['foo', 'bar'],
                    'timeZone': 'Foo',
                    'tunnelIdentifier': 'foobar',
+                   'tunnelOwner': 'baz',
                    'videoUploadOnPass': False}
 
         sauce = SauceOptions.edge(**options)
@@ -110,6 +111,7 @@ class TestInit(object):
         assert sauce.tags == ['foo', 'bar']
         assert sauce.time_zone == 'Foo'
         assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.tunnel_owner == 'baz'
         assert sauce.video_upload_on_pass is False
 
     def test_accepts_sauce_values_as_params(self):
@@ -137,6 +139,7 @@ class TestInit(object):
                                     tags=['foo', 'bar'],
                                     timeZone='Foo',
                                     tunnelIdentifier='foobar',
+                                    tunnelOwner='baz',
                                     videoUploadOnPass=False)
 
         assert sauce.build == 'bar'
@@ -161,6 +164,7 @@ class TestInit(object):
         assert sauce.tags == ['foo', 'bar']
         assert sauce.time_zone == 'Foo'
         assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.tunnel_owner == 'baz'
         assert sauce.video_upload_on_pass is False
 
     def test_accepts_selenium_browser_options_instance(self):
@@ -271,6 +275,7 @@ class TestSettingSpecificOptions(object):
         options.tags = tags
         options.time_zone = 'San Francisco'
         options.tunnel_identifier = 'tunnelname'
+        options.tunnel_owner = 'tunnelowner'
         options.video_upload_on_pass = False
 
         assert options.build == 'Sample Build Name'
@@ -291,6 +296,7 @@ class TestSettingSpecificOptions(object):
         assert options.tags == tags
         assert options.time_zone == 'San Francisco'
         assert options.tunnel_identifier == 'tunnelname'
+        assert options.tunnel_owner == 'tunnelowner'
         assert options.video_upload_on_pass is False
 
     def test_setting_browser_name(self):
@@ -369,6 +375,7 @@ class TestCapabilitiesCreation(object):
         options.tags = tags
         options.time_zone = 'San Francisco'
         options.tunnel_identifier = 'tunnelname'
+        options.tunnel_owner = 'tunnelowner'
         options.video_upload_on_pass = False
 
         expected_capabilities = {'browserName': 'MicrosoftEdge',
@@ -393,6 +400,7 @@ class TestCapabilitiesCreation(object):
                                                    'tags': ['foo', 'bar'],
                                                    'timeZone': 'San Francisco',
                                                    'tunnelIdentifier': 'tunnelname',
+                                                   'tunnelOwner': 'tunnelowner',
                                                    'videoUploadOnPass': False,
                                                    'username': os.getenv('SAUCE_USERNAME'),
                                                    'accessKey': os.getenv('SAUCE_ACCESS_KEY')}}

--- a/python/tests/unit/test_firefox.py
+++ b/python/tests/unit/test_firefox.py
@@ -87,6 +87,7 @@ class TestInit(object):
                    'tags': ['foo', 'bar'],
                    'timeZone': 'Foo',
                    'tunnelIdentifier': 'foobar',
+                   'tunnelOwner': 'baz',
                    'videoUploadOnPass': False}
 
         sauce = SauceOptions.firefox(**options)
@@ -114,6 +115,7 @@ class TestInit(object):
         assert sauce.tags == ['foo', 'bar']
         assert sauce.time_zone == 'Foo'
         assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.tunnel_owner == 'baz'
         assert sauce.video_upload_on_pass is False
 
     def test_accepts_sauce_values_as_params(self):
@@ -142,6 +144,7 @@ class TestInit(object):
                                      tags=['foo', 'bar'],
                                      timeZone='Foo',
                                      tunnelIdentifier='foobar',
+                                     tunnelOwner='baz',
                                      videoUploadOnPass=False)
 
         assert sauce.build == 'bar'
@@ -167,6 +170,7 @@ class TestInit(object):
         assert sauce.tags == ['foo', 'bar']
         assert sauce.time_zone == 'Foo'
         assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.tunnel_owner == 'baz'
         assert sauce.video_upload_on_pass is False
 
     def test_accepts_selenium_browser_options_instance(self):
@@ -278,6 +282,7 @@ class TestSettingSpecificOptions(object):
         options.tags = tags
         options.time_zone = 'San Francisco'
         options.tunnel_identifier = 'tunnelname'
+        options.tunnel_owner = 'tunnelowner'
         options.video_upload_on_pass = False
 
         assert options.build == 'Sample Build Name'
@@ -299,6 +304,7 @@ class TestSettingSpecificOptions(object):
         assert options.tags == tags
         assert options.time_zone == 'San Francisco'
         assert options.tunnel_identifier == 'tunnelname'
+        assert options.tunnel_owner == 'tunnelowner'
         assert options.video_upload_on_pass is False
 
     def test_setting_browser_name(self):
@@ -369,6 +375,7 @@ class TestAddingCapabilities(object):
         assert options.tags == tags
         assert options.time_zone == 'San Francisco'
         assert options.tunnel_identifier == 'tunnelname'
+        assert options.tunnel_owner == 'tunnelowner'
         assert options.video_upload_on_pass is False
 
 
@@ -436,6 +443,7 @@ class TestCapabilitiesCreation(object):
         options.tags = tags
         options.time_zone = 'San Francisco'
         options.tunnel_identifier = 'tunnelname'
+        options.tunnel_owner = 'tunnelowner'
         options.video_upload_on_pass = False
 
         expected_capabilities = {'browserName': 'firefox',
@@ -461,6 +469,7 @@ class TestCapabilitiesCreation(object):
                                                    'tags': ['foo', 'bar'],
                                                    'timeZone': 'San Francisco',
                                                    'tunnelIdentifier': 'tunnelname',
+                                                   'tunnelOwner': 'tunnelowner',
                                                    'videoUploadOnPass': False,
                                                    'username': os.getenv('SAUCE_USERNAME'),
                                                    'accessKey': os.getenv('SAUCE_ACCESS_KEY')}}

--- a/python/tests/unit/test_ie.py
+++ b/python/tests/unit/test_ie.py
@@ -86,6 +86,7 @@ class TestInit(object):
                    'tags': ['foo', 'bar'],
                    'timeZone': 'Foo',
                    'tunnelIdentifier': 'foobar',
+                   'tunnelOwner': 'baz',
                    'videoUploadOnPass': False}
 
         sauce = SauceOptions.ie(**options)
@@ -113,6 +114,7 @@ class TestInit(object):
         assert sauce.tags == ['foo', 'bar']
         assert sauce.time_zone == 'Foo'
         assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.tunnel_owner == 'baz'
         assert sauce.video_upload_on_pass is False
 
     def test_accepts_sauce_values_as_params(self):
@@ -142,6 +144,7 @@ class TestInit(object):
                              tags=['foo', 'bar'],
                              timeZone='Foo',
                              tunnelIdentifier='foobar',
+                             tunnelOwner='baz',
                              videoUploadOnPass=False)
 
         assert sauce.avoid_proxy is True
@@ -168,6 +171,7 @@ class TestInit(object):
         assert sauce.tags == ['foo', 'bar']
         assert sauce.time_zone == 'Foo'
         assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.tunnel_owner == 'baz'
         assert sauce.video_upload_on_pass is False
 
     def test_accepts_selenium_browser_options_instance(self):
@@ -279,6 +283,7 @@ class TestSettingSpecificOptions(object):
         options.tags = tags
         options.time_zone = 'San Francisco'
         options.tunnel_identifier = 'tunnelname'
+        options.tunnel_owner = 'tunnelowner'
         options.video_upload_on_pass = False
 
         assert options.build == 'Sample Build Name'
@@ -300,6 +305,7 @@ class TestSettingSpecificOptions(object):
         assert options.tags == tags
         assert options.time_zone == 'San Francisco'
         assert options.tunnel_identifier == 'tunnelname'
+        assert options.tunnel_owner == 'tunnelowner'
         assert options.video_upload_on_pass is False
 
     def test_setting_browser_name(self):
@@ -379,6 +385,7 @@ class TestCapabilitiesCreation(object):
         options.tags = tags
         options.time_zone = 'San Francisco'
         options.tunnel_identifier = 'tunnelname'
+        options.tunnel_owner = 'tunnelowner'
         options.video_upload_on_pass = False
 
         expected_capabilities = {'browserName': 'internet explorer',
@@ -404,6 +411,7 @@ class TestCapabilitiesCreation(object):
                                                    'tags': ['foo', 'bar'],
                                                    'timeZone': 'San Francisco',
                                                    'tunnelIdentifier': 'tunnelname',
+                                                   'tunnelOwner': 'tunnelowner',
                                                    'videoUploadOnPass': False,
                                                    'username': os.getenv('SAUCE_USERNAME'),
                                                    'accessKey': os.getenv('SAUCE_ACCESS_KEY')}}

--- a/python/tests/unit/test_old_options.py
+++ b/python/tests/unit/test_old_options.py
@@ -98,6 +98,7 @@ class TestInit(object):
                    'tags': ['foo', 'bar'],
                    'timeZone': 'Foo',
                    'tunnelIdentifier': 'foobar',
+                   'tunnelOwner': 'baz',
                    'videoUploadOnPass': False}
 
         sauce = SauceOptions(**options)
@@ -129,6 +130,7 @@ class TestInit(object):
         assert sauce.tags == ['foo', 'bar']
         assert sauce.time_zone == 'Foo'
         assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.tunnel_owner == 'baz'
         assert sauce.video_upload_on_pass is False
 
     def test_accepts_sauce_values_as_params(self):
@@ -161,6 +163,7 @@ class TestInit(object):
                              tags=['foo', 'bar'],
                              timeZone='Foo',
                              tunnelIdentifier='foobar',
+                             tunnelOwner='baz',
                              videoUploadOnPass=False)
 
         assert sauce.avoid_proxy is True
@@ -190,6 +193,7 @@ class TestInit(object):
         assert sauce.tags == ['foo', 'bar']
         assert sauce.time_zone == 'Foo'
         assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.tunnel_owner == 'baz'
         assert sauce.video_upload_on_pass is False
 
     def test_accepts_selenium_browser_options_instance(self):
@@ -308,6 +312,7 @@ class TestSettingSpecificOptions(object):
         options.tags = tags
         options.time_zone = 'San Francisco'
         options.tunnel_identifier = 'tunnelname'
+        options.tunnel_owner = 'tunnelowner'
         options.video_upload_on_pass = False
 
         assert options.avoid_proxy is True
@@ -387,6 +392,7 @@ class TestAddingCapabilities(object):
         assert options.tags == tags
         assert options.time_zone == 'San Francisco'
         assert options.tunnel_identifier == 'tunnelname'
+        assert options.tunnel_owner == 'tunnelowner'
         assert options.video_upload_on_pass is False
 
 
@@ -459,6 +465,7 @@ class TestCapabilitiesCreation(object):
         options.tags = tags
         options.time_zone = 'San Francisco'
         options.tunnel_identifier = 'tunnelname'
+        options.tunnel_owner = 'tunnelowner'
         options.video_upload_on_pass = False
 
         expected_capabilities = {'browserName': 'chrome',
@@ -488,6 +495,7 @@ class TestCapabilitiesCreation(object):
                                                    'tags': ['foo', 'bar'],
                                                    'timeZone': 'San Francisco',
                                                    'tunnelIdentifier': 'tunnelname',
+                                                   'tunnelOwner': 'tunnelowner',
                                                    'videoUploadOnPass': False,
                                                    'username': os.getenv('SAUCE_USERNAME'),
                                                    'accessKey': os.getenv('SAUCE_ACCESS_KEY')}}

--- a/python/tests/unit/test_safari.py
+++ b/python/tests/unit/test_safari.py
@@ -83,6 +83,7 @@ class TestInit(object):
                    'tags': ['foo', 'bar'],
                    'timeZone': 'Foo',
                    'tunnelIdentifier': 'foobar',
+                   'tunnelOwner': 'baz',
                    'videoUploadOnPass': False}
 
         sauce = SauceOptions.safari(**options)
@@ -109,6 +110,7 @@ class TestInit(object):
         assert sauce.tags == ['foo', 'bar']
         assert sauce.time_zone == 'Foo'
         assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.tunnel_owner == 'baz'
         assert sauce.video_upload_on_pass is False
 
     def test_accepts_sauce_values_as_params(self):
@@ -137,6 +139,7 @@ class TestInit(object):
                              tags=['foo', 'bar'],
                              timeZone='Foo',
                              tunnelIdentifier='foobar',
+                             tunnelOwner='baz',
                              videoUploadOnPass=False)
 
         assert sauce.avoid_proxy is True
@@ -162,6 +165,7 @@ class TestInit(object):
         assert sauce.tags == ['foo', 'bar']
         assert sauce.time_zone == 'Foo'
         assert sauce.tunnel_identifier == 'foobar'
+        assert sauce.tunnel_owner == 'baz'
         assert sauce.video_upload_on_pass is False
 
     def test_accepts_w3c_sauce_options_capabilities(self):
@@ -259,6 +263,7 @@ class TestSettingSpecificOptions(object):
         options.tags = tags
         options.time_zone = 'San Francisco'
         options.tunnel_identifier = 'tunnelname'
+        options.tunnel_owner = 'tunnelowner'
         options.video_upload_on_pass = False
 
         assert options.build == 'Sample Build Name'
@@ -279,6 +284,7 @@ class TestSettingSpecificOptions(object):
         assert options.tags == tags
         assert options.time_zone == 'San Francisco'
         assert options.tunnel_identifier == 'tunnelname'
+        assert options.tunnel_owner == 'tunnelowner'
         assert options.video_upload_on_pass is False
 
     def test_setting_browser_name(self):
@@ -357,6 +363,7 @@ class TestCapabilitiesCreation(object):
         options.tags = tags
         options.time_zone = 'San Francisco'
         options.tunnel_identifier = 'tunnelname'
+        options.tunnel_owner = 'tunnelowner'
         options.video_upload_on_pass = False
 
         expected_capabilities = {'browserName': 'safari',
@@ -381,6 +388,7 @@ class TestCapabilitiesCreation(object):
                                                    'tags': ['foo', 'bar'],
                                                    'timeZone': 'San Francisco',
                                                    'tunnelIdentifier': 'tunnelname',
+                                                   'tunnelOwner': 'tunnelowner',
                                                    'videoUploadOnPass': False,
                                                    'username': os.getenv('SAUCE_USERNAME'),
                                                    'accessKey': os.getenv('SAUCE_ACCESS_KEY')}}


### PR DESCRIPTION
I need this option for a project where I want to use a tunnel that I don't own. I added it for Python because I use Robot Framework.