### PR TITLE
[java] allow map to include "sauce:options"

### DIFF
--- a/java/main/src/main/java/com/saucelabs/saucebindings/options/SauceOptions.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/options/SauceOptions.java
@@ -257,6 +257,7 @@ public class SauceOptions extends BaseOptions {
         setTimeouts(timeoutsMap);
         break;
       case "sauce":
+      case "sauce:options":
         sauce().mergeCapabilities((HashMap<String, Object>) value);
         break;
       default:


### PR DESCRIPTION
This will make it easier to initialize in test runner extensions with a `Capabilities` instance.