### PR TITLE
[java] all user to no-op Sauce Session methods

### DIFF
--- a/java/main/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -42,7 +42,8 @@ public class SauceSession {
    * Checks if the feature is disabled in either system property or environment variable.
    *
    * @return false if the feature is disabled, true otherwise.
-   */public boolean isEnabled() {
+   */
+  public boolean isEnabled() {
     return !SystemManager.getBoolean("sauce.disabled")
         && !SystemManager.getBoolean("SAUCE_DISABLED");
   }
@@ -54,7 +55,7 @@ public class SauceSession {
    */
   public RemoteWebDriver start() {
     if (!isEnabled()) {
-      return null;
+      throw new RuntimeException("Sauce is Disabled by System Property or Environment Variable.");
     }
 
     this.driver = createRemoteWebDriver(getSauceUrl(), sauceOptions.toCapabilities());

--- a/java/main/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -39,11 +39,24 @@ public class SauceSession {
   }
 
   /**
+   * Checks if the feature is disabled in either system property or environment variable.
+   *
+   * @return false if the feature is disabled, true otherwise.
+   */public boolean isEnabled() {
+    return !SystemManager.getBoolean("sauce.disabled")
+        && !SystemManager.getBoolean("SAUCE_DISABLED");
+  }
+
+  /**
    * Starts the session on Sauce Labs.
    *
    * @return the driver instance for using as normal in your tests.
    */
   public RemoteWebDriver start() {
+    if (!isEnabled()) {
+      return null;
+    }
+
     this.driver = createRemoteWebDriver(getSauceUrl(), sauceOptions.toCapabilities());
     return driver;
   }
@@ -98,6 +111,10 @@ public class SauceSession {
    * @return an object with the accessibility analysis
    */
   public Results getAccessibilityResults(AxeBuilder builder) {
+    if (!isEnabled()) {
+      return null;
+    }
+
     validateSessionStarted("getAccessibilityResults()");
     return builder.analyze(driver);
   }
@@ -109,6 +126,11 @@ public class SauceSession {
    * @param passed true if the test has passed, otherwise false
    */
   public void stop(Boolean passed) {
+    if (!isEnabled()) {
+      return;
+    }
+
+    // TODO: Log a warning if the driver is null
     if (this.driver != null) {
       String update = passed ? "passed" : "failed";
       updateResult(update);
@@ -125,6 +147,10 @@ public class SauceSession {
    *     Providing Context for Selenium Commands</a>
    */
   public void annotate(String comment) {
+    if (!isEnabled()) {
+      return;
+    }
+
     validateSessionStarted("annotate()");
     driver.executeScript("sauce:context=" + comment);
   }
@@ -138,6 +164,10 @@ public class SauceSession {
    *     Test Annotation Methods</a>
    */
   public void pause() {
+    if (!isEnabled()) {
+      return;
+    }
+
     validateSessionStarted("pause()");
     String sauceTestLink =
         String.format("https://app.saucelabs.com/tests/%s", this.driver.getSessionId());
@@ -158,6 +188,10 @@ public class SauceSession {
    *     Test Annotation Methods</a>
    */
   public void disableLogging() {
+    if (!isEnabled()) {
+      return;
+    }
+
     validateSessionStarted("disableLogging()");
     driver.executeScript("sauce: disable log");
   }
@@ -171,6 +205,10 @@ public class SauceSession {
    *     Test Annotation Methods</a>
    */
   public void enableLogging() {
+    if (!isEnabled()) {
+      return;
+    }
+
     validateSessionStarted("enableLogging()");
     driver.executeScript("sauce: enable log");
   }
@@ -184,6 +222,10 @@ public class SauceSession {
    *     Test Annotation Methods</a>
    */
   public void stopNetwork() {
+    if (!isEnabled()) {
+      return;
+    }
+
     validateSessionStarted("stopNetwork()");
     validateMac("Can only stop network for a Mac Platform;");
 
@@ -199,6 +241,10 @@ public class SauceSession {
    *     Test Annotation Methods</a>
    */
   public void startNetwork() {
+    if (!isEnabled()) {
+      return;
+    }
+
     validateSessionStarted("startNetwork()");
     validateMac("Can only start network for a Mac Platform;");
 
@@ -216,6 +262,10 @@ public class SauceSession {
    * @see BaseConfigurations#setName(String)
    */
   public void changeTestName(String name) {
+    if (!isEnabled()) {
+      return;
+    }
+
     validateSessionStarted("changeName()");
     driver.executeScript("sauce:job-name=" + name);
   }
@@ -231,6 +281,10 @@ public class SauceSession {
    * @see BaseConfigurations#setTags(List)
    */
   public void addTags(List<String> tags) {
+    if (!isEnabled()) {
+      return;
+    }
+
     validateSessionStarted("setTags()");
     String tagString = String.join(",", tags);
     driver.executeScript("sauce:job-tags=" + tagString);

--- a/java/main/src/main/java/com/saucelabs/saucebindings/SystemManager.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/SystemManager.java
@@ -34,4 +34,16 @@ public class SystemManager {
       return null;
     }
   }
+
+  /**
+   * Shortcut for getting the boolean value of a System Property or Environment Variable
+   *
+   * @param key the name of the property or environment variable
+   * @return whether the provided key is set
+   */
+  public static boolean getBoolean(String key) {
+      boolean property = Boolean.getBoolean(key);
+      boolean env = Boolean.parseBoolean(System.getenv(key));
+      return property || env;
+  }
 }

--- a/java/main/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/SauceSessionTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openqa.selenium.InvalidArgumentException;
@@ -260,5 +261,16 @@ public class SauceSessionTest {
     sauceSession.start();
     sauceSession.addTags(ImmutableList.of("foo", "bar"));
     Mockito.verify(dummyRemoteDriver).executeScript("sauce:job-tags=foo,bar");
+  }
+
+  @Test
+  public void disablesSauce() {
+    try (MockedStatic<SystemManager> systemManager = Mockito.mockStatic(SystemManager.class)) {
+      systemManager.when(() -> SystemManager.getBoolean("sauce.disabled")).thenReturn(true);
+      sauceSession.start();
+
+      Mockito.verify(sauceSession, Mockito.never())
+          .createRemoteWebDriver(Mockito.any(URL.class), Mockito.any(MutableCapabilities.class));
+    }
   }
 }


### PR DESCRIPTION
Sometimes you want to run your tests locally and sometimes you want to run on Sauce Labs.

If you add a bunch of Sauce Labs specific features to your code (which we want to encourage), it's going to be a pain to disable or add conditionals for everything. If we allow users to disable running on Sauce with a System Property or Environment Variable, then they can keep all those custom methods (like annotations or stop methods) where they are without conditionals.

For instance, the JUnit5 extension will do this:
```java
  @Override
  public void testFailed(ExtensionContext context, Throwable cause) {
    if (isExtensionDisabled()) {
      return;
    }

    if (session != null) {
      session.annotate("Failure Reason: " + cause.getMessage());
      Arrays.stream(cause.getStackTrace())
          .map(StackTraceElement::toString)
          .filter(line -> !line.contains("sun"))
          .forEach(session::annotate);
      session.stop(false);
    }
  }
```

With this PR, we can remove the conditional to return. `stop()` and `annotate()` just won't do anything if Sauce is disabled.

This is easy with `void` methods. Just don't do anything.
`start()` and the accessibility methods actually return objects, though. I'm not sure whether to error or return `null`. I kind of want to return `null` for `start()` and throw an error for accessibility, but that doesn't seem right for them to be different.

What do you think? Does this make sense, or does it seem counter-intuitive? Should we return nulls or throw an error?