### PR TITLE
resolves #299 python: adding support to tunnelOwner/tunnelName

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -6,8 +6,12 @@ name: Java
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'java/**'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'java/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,6 +21,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Sauce Connect
+        uses: saucelabs/sauce-connect-action@v2
+        with:
+            username: ${{ secrets.SAUCE_USERNAME }}
+            accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+            tunnelName: "sauce-bindings-${{ github.sha }}"
+            region: us-west
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
@@ -31,3 +38,10 @@ jobs:
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: |
           make python_tests
+
+      - name: Sauce Connect cleanup
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: sauce-connect-log
+          path: ${{ env.SAUCE_CONNECT_DIR_IN_HOST }}/sauce-connect.log

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,20 +5,26 @@ name: Python
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+    paths:
+      - 'python/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+    paths:
+      - 'python/**'
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Test with pytest
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Ruby
 
 on:

--- a/python/saucebindings/configs.py
+++ b/python/saucebindings/configs.py
@@ -7,6 +7,8 @@ class Configs:
         'custom_data': 'customData',
         'public': 'public',
         'tunnel_identifier': 'tunnelIdentifier',
+        'tunnel_name': 'tunnelName',
+        'tunnel_owner': 'tunnelOwner',
         'parent_tunnel': 'parentTunnel'
     }
 

--- a/python/saucebindings/options.py
+++ b/python/saucebindings/options.py
@@ -31,6 +31,7 @@ sauce_configs = {
     'iedriver_version': 'iedriverVersion',
     'max_duration': 'maxDuration',
     'name': 'name',
+    # parent_tunnel is deprecated and being replaced with tunnel_owner.
     'parent_tunnel': 'parentTunnel',
     'prerun': 'prerun',
     'priority': 'priority',
@@ -42,7 +43,10 @@ sauce_configs = {
     'selenium_version': 'seleniumVersion',
     'tags': 'tags',
     'time_zone': 'timeZone',
+    # tunnel_identifier is deprecated and being replaced with tunnel_name.
     'tunnel_identifier': 'tunnelIdentifier',
+    'tunnel_name': 'tunnelName',
+    'tunnel_owner': 'tunnelOwner',
     'video_upload_on_pass': 'videoUploadOnPass',
     'capture_performance': 'capturePerformance'
 }

--- a/python/tests/examples/test_common_options.py
+++ b/python/tests/examples/test_common_options.py
@@ -6,8 +6,8 @@ class TestCommonOptions(object):
 
     def test_creates_session(self):
         # 1. Create SauceOptions instance with common w3c options
-        sauceOptions = SauceOptions.firefox(browserVersion='73.0',
-                                            platformName='Windows 8',
+        sauceOptions = SauceOptions.firefox(browserVersion='128',
+                                            platformName='Windows 11',
                                             unhandledPromptBehavior="ignore")
 
         # 2. Create Session object with SauceOptions object instance

--- a/python/tests/examples/test_sauce_tunnel.py
+++ b/python/tests/examples/test_sauce_tunnel.py
@@ -1,0 +1,26 @@
+import os
+
+from saucebindings.options import SauceOptions
+from saucebindings.session import SauceSession
+
+
+class TestSauceOptions(object):
+
+    def test_creates_session(self):
+        # 1. Create a SauceOptions instance using tunnelName of a tunnel started earlier
+        tunnel_name = "sauce-bindings-{}".format(os.environ.get('GITHUB_SHA') or "test")
+        sauceOptions = SauceOptions.chrome(extendedDebugging=True,
+                                           idleTimeout=45,
+                                           tunnelName=tunnel_name)
+
+        # 2. Create Session object with SauceOptions object instance
+        session = SauceSession(sauceOptions)
+
+        # 3. Start Session to get the Driver
+        driver = session.start()
+
+        # 4. Use the driver in your tests just like normal
+        driver.get('https://www.saucedemo.com/')
+
+        # 5. Stop the Session with whether the test passed or failed
+        session.stop(True)

--- a/python/tests/unit/test_chrome.py
+++ b/python/tests/unit/test_chrome.py
@@ -117,6 +117,20 @@ class TestInit(object):
         assert sauce.tunnel_identifier == 'foobar'
         assert sauce.video_upload_on_pass is False
 
+    def test_accepts_tunnel(self):
+        options = {'build': 'bar',
+                   'idleTimeout': 3,
+                   'name': 'foo',
+                   'tunnelOwner': 'bar',
+                   'tunnelName': 'foobar'}
+
+        sauce = SauceOptions.chrome(**options)
+
+        assert sauce.build == 'bar'
+        assert sauce.name == 'foo'
+        assert sauce.tunnel_owner == 'bar'
+        assert sauce.tunnel_name == 'foobar'
+
     def test_accepts_sauce_values_as_params(self):
         custom_data = {'foo': 'foo',
                        'bar': 'bar'}

--- a/python/tests/unit/test_edge.py
+++ b/python/tests/unit/test_edge.py
@@ -293,6 +293,20 @@ class TestSettingSpecificOptions(object):
         assert options.tunnel_identifier == 'tunnelname'
         assert options.video_upload_on_pass is False
 
+    def test_accepts_tunnel(self):
+        options = {'build': 'bar',
+                   'idleTimeout': 3,
+                   'name': 'foo',
+                   'tunnelOwner': 'bar',
+                   'tunnelName': 'foobar'}
+
+        sauce = SauceOptions.edge(**options)
+
+        assert sauce.build == 'bar'
+        assert sauce.name == 'foo'
+        assert sauce.tunnel_owner == 'bar'
+        assert sauce.tunnel_name == 'foobar'
+
     def test_setting_browser_name(self):
         options = SauceOptions.edge()
 

--- a/python/tests/unit/test_firefox.py
+++ b/python/tests/unit/test_firefox.py
@@ -352,7 +352,7 @@ class TestAddingCapabilities(object):
         assert options.build == 'Sample Build Name'
         assert options.command_timeout == 2
         assert options.custom_data == custom_data
-        assert options.extended_debugging == True
+        assert options.extended_debugging is True
         assert options.idle_timeout == 3
         assert options.geckodriver_version == '0.23'
         assert options.max_duration == 300
@@ -487,3 +487,17 @@ class TestCapabilitiesCreation(object):
                                  }
 
         assert options.to_capabilities() == expected_capabilities
+
+    def test_accepts_tunnel(self):
+        options = {'build': 'bar',
+                   'idleTimeout': 3,
+                   'name': 'foo',
+                   'tunnelOwner': 'bar',
+                   'tunnelName': 'foobar'}
+
+        sauce = SauceOptions.firefox(**options)
+
+        assert sauce.build == 'bar'
+        assert sauce.name == 'foo'
+        assert sauce.tunnel_owner == 'bar'
+        assert sauce.tunnel_name == 'foobar'


### PR DESCRIPTION
# One-line summary

> Issue : #299

## Description

See https://docs.saucelabs.com/dev/test-configuration-options/#tunnelowner and https://docs.saucelabs.com/dev/test-configuration-options/#tunnelname

No breaking changes. `parent_tunnel` and `tunnel_identifier` will be removed in the future.

- Adding `tunnelOwner` (which is the same as `parent_tunnel`) to future-proof python bindings library
- Adding `tunnelName` (which is the same as `tunnel_identifier`) to future-proof python bindings library
- Added SC to e2e tests

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
