### PR TITLE
fixing baseUrl issue introduced in #314

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -12,7 +12,7 @@ const config = {
   tagline: "Make Your Testing Sweeter with Sauce",
   url: "https://saucelabs.github.io",
   favicon: "img/favicon.ico",
-  baseUrl: "/",
+  baseUrl: '/sauce_bindings/',
   organizationName: "saucelabs",
   projectName: "sauce_bindings",
   onBrokenLinks: "warn",


### PR DESCRIPTION
# One-line summary

> Issue : #314

## Description

baseUrl has to be `/sauce_bindings`