### PR TITLE
[java] implement global toggle to noop session commands

### DIFF
--- a/java/main/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -8,7 +8,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Objects;
-
 import lombok.Getter;
 import lombok.Setter;
 import org.openqa.selenium.Capabilities;

--- a/java/main/src/main/java/com/saucelabs/saucebindings/SauceSession.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/SauceSession.java
@@ -7,6 +7,8 @@ import com.saucelabs.saucebindings.options.SauceOptions;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.Objects;
+
 import lombok.Getter;
 import lombok.Setter;
 import org.openqa.selenium.Capabilities;
@@ -44,6 +46,10 @@ public class SauceSession {
    * @return the driver instance for using as normal in your tests.
    */
   public RemoteWebDriver start() {
+    if (isDisabled()) {
+      return null;
+    }
+
     this.driver = createRemoteWebDriver(getSauceUrl(), sauceOptions.toCapabilities());
     return driver;
   }
@@ -98,7 +104,11 @@ public class SauceSession {
    * @return an object with the accessibility analysis
    */
   public Results getAccessibilityResults(AxeBuilder builder) {
+    if (isDisabled()) {
+      return null;
+    }
     validateSessionStarted("getAccessibilityResults()");
+
     return builder.analyze(driver);
   }
 
@@ -125,7 +135,11 @@ public class SauceSession {
    *     Providing Context for Selenium Commands</a>
    */
   public void annotate(String comment) {
+    if (isDisabled()) {
+      return;
+    }
     validateSessionStarted("annotate()");
+
     driver.executeScript("sauce:context=" + comment);
   }
 
@@ -138,7 +152,11 @@ public class SauceSession {
    *     Test Annotation Methods</a>
    */
   public void pause() {
+    if (isDisabled()) {
+      return;
+    }
     validateSessionStarted("pause()");
+
     String sauceTestLink =
         String.format("https://app.saucelabs.com/tests/%s", this.driver.getSessionId());
     driver.executeScript("sauce: break");
@@ -158,7 +176,11 @@ public class SauceSession {
    *     Test Annotation Methods</a>
    */
   public void disableLogging() {
+    if (isDisabled()) {
+      return;
+    }
     validateSessionStarted("disableLogging()");
+
     driver.executeScript("sauce: disable log");
   }
 
@@ -171,7 +193,11 @@ public class SauceSession {
    *     Test Annotation Methods</a>
    */
   public void enableLogging() {
+    if (isDisabled()) {
+      return;
+    }
     validateSessionStarted("enableLogging()");
+
     driver.executeScript("sauce: enable log");
   }
 
@@ -184,6 +210,9 @@ public class SauceSession {
    *     Test Annotation Methods</a>
    */
   public void stopNetwork() {
+    if (isDisabled()) {
+      return;
+    }
     validateSessionStarted("stopNetwork()");
     validateMac("Can only stop network for a Mac Platform;");
 
@@ -199,6 +228,9 @@ public class SauceSession {
    *     Test Annotation Methods</a>
    */
   public void startNetwork() {
+    if (isDisabled()) {
+      return;
+    }
     validateSessionStarted("startNetwork()");
     validateMac("Can only start network for a Mac Platform;");
 
@@ -216,7 +248,11 @@ public class SauceSession {
    * @see BaseConfigurations#setName(String)
    */
   public void changeTestName(String name) {
+    if (isDisabled()) {
+      return;
+    }
     validateSessionStarted("changeName()");
+
     driver.executeScript("sauce:job-name=" + name);
   }
 
@@ -231,7 +267,11 @@ public class SauceSession {
    * @see BaseConfigurations#setTags(List)
    */
   public void addTags(List<String> tags) {
+    if (isDisabled()) {
+      return;
+    }
     validateSessionStarted("setTags()");
+
     String tagString = String.join(",", tags);
     driver.executeScript("sauce:job-tags=" + tagString);
   }
@@ -290,5 +330,9 @@ public class SauceSession {
       String error = msg + " current platform is: " + platformName;
       throw new InvalidArgumentException(error);
     }
+  }
+
+  private boolean isDisabled() {
+    return Objects.equals(System.getProperty("saucelabs"), "false");
   }
 }

--- a/java/main/src/test/java/com/saucelabs/saucebindings/examples/DisableTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/examples/DisableTest.java
@@ -1,6 +1,7 @@
 package com.saucelabs.saucebindings.examples;
 
 import com.saucelabs.saucebindings.SauceSession;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriver;
@@ -31,5 +32,10 @@ public class DisableTest {
                     session.stop(true);
                 }
         );
+    }
+
+    @AfterEach
+    public void stopSession() {
+        System.clearProperty("saucelabs");
     }
 }

--- a/java/main/src/test/java/com/saucelabs/saucebindings/examples/DisableTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/examples/DisableTest.java
@@ -1,0 +1,35 @@
+package com.saucelabs.saucebindings.examples;
+
+import com.saucelabs.saucebindings.SauceSession;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+
+import java.util.List;
+
+public class DisableTest {
+
+    @Test
+    public void startSession() {
+        // 1. Toggle off sauce labs
+        System.setProperty("saucelabs", "false");
+
+        // 2. Create a Sauce Session
+        SauceSession session = new SauceSession();
+
+        // 3. Starting the session will not create a driver
+        WebDriver driver = session.start();
+        Assertions.assertNull(driver);
+
+        // 4. All session commands will be ignored
+        Assertions.assertDoesNotThrow(() -> {
+                    session.annotate("This gets ignored");
+                    session.addTags(List.of("ignored"));
+                    session.stopNetwork();
+                    session.enableLogging();
+                    session.getAccessibilityResults();
+                    session.stop(true);
+                }
+        );
+    }
+}

--- a/java/main/src/test/java/com/saucelabs/saucebindings/examples/DisableTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/examples/DisableTest.java
@@ -1,41 +1,40 @@
 package com.saucelabs.saucebindings.examples;
 
 import com.saucelabs.saucebindings.SauceSession;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriver;
 
-import java.util.List;
-
 public class DisableTest {
 
-    @Test
-    public void startSession() {
-        // 1. Toggle off sauce labs
-        System.setProperty("saucelabs", "false");
+  @Test
+  public void startSession() {
+    // 1. Toggle off sauce labs
+    System.setProperty("saucelabs", "false");
 
-        // 2. Create a Sauce Session
-        SauceSession session = new SauceSession();
+    // 2. Create a Sauce Session
+    SauceSession session = new SauceSession();
 
-        // 3. Starting the session will not create a driver
-        WebDriver driver = session.start();
-        Assertions.assertNull(driver);
+    // 3. Starting the session will not create a driver
+    WebDriver driver = session.start();
+    Assertions.assertNull(driver);
 
-        // 4. All session commands will be ignored
-        Assertions.assertDoesNotThrow(() -> {
-                    session.annotate("This gets ignored");
-                    session.addTags(List.of("ignored"));
-                    session.stopNetwork();
-                    session.enableLogging();
-                    session.getAccessibilityResults();
-                    session.stop(true);
-                }
-        );
-    }
+    // 4. All session commands will be ignored
+    Assertions.assertDoesNotThrow(
+        () -> {
+          session.annotate("This gets ignored");
+          session.addTags(List.of("ignored"));
+          session.stopNetwork();
+          session.enableLogging();
+          session.getAccessibilityResults();
+          session.stop(true);
+        });
+  }
 
-    @AfterEach
-    public void stopSession() {
-        System.clearProperty("saucelabs");
-    }
+  @AfterEach
+  public void stopSession() {
+    System.clearProperty("saucelabs");
+  }
 }


### PR DESCRIPTION
# One-line summary

This allows users to put things like annotations and other sauce bindings specific code in frameworks and tests without needing to put conditionals everywhere

## Description
We need to make it as easy as possible for people to toggle between running on Sauce and running locally. Obviously there is a limit to how much can be done

## Types of Changes

- New feature (non-breaking change which adds functionality)

## Considerations

* Is this the right system property name?
* Should we have a public setters/getters for this on Session class?
* I'm not positive this works the way we need it to in the test runner code, but I can't test it without building it.