### PR TITLE
Adding tags for Sauce Bindings, and restructuring tag setters so they…

### DIFF
--- a/java/main/src/main/java/com/saucelabs/saucebindings/options/SauceLabsOptions.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/options/SauceLabsOptions.java
@@ -7,7 +7,6 @@ import com.saucelabs.saucebindings.SauceSession;
 import com.saucelabs.saucebindings.SystemManager;
 import java.net.URL;
 import java.util.*;
-
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -147,14 +146,13 @@ public class SauceLabsOptions extends BaseOptions {
     } else if ("tags".equals(key)) {
       try {
         List<String> tagsList = (List) value;
-        for (String tag: tagsList) {
+        for (String tag : tagsList) {
           tags.add(tag);
         }
       } catch (ClassCastException e) {
         throw new RuntimeException(e);
       }
-    }
-    else {
+    } else {
       super.setCapability(key, value);
     }
   }
@@ -168,8 +166,8 @@ public class SauceLabsOptions extends BaseOptions {
   }
 
   /**
-   * @deprecated This method is no longer supported
    * @return whether CI is accounted for in code
+   * @deprecated This method is no longer supported
    */
   @Deprecated
   public boolean isKnownCI() {

--- a/java/main/src/main/java/com/saucelabs/saucebindings/options/SauceLabsOptions.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/options/SauceLabsOptions.java
@@ -6,10 +6,8 @@ import com.saucelabs.saucebindings.Prerun;
 import com.saucelabs.saucebindings.SauceSession;
 import com.saucelabs.saucebindings.SystemManager;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -44,7 +42,18 @@ public class SauceLabsOptions extends BaseOptions {
   private Boolean recordVideo = null;
   private String screenResolution;
   private String seleniumVersion;
-  private List<String> tags = null;
+
+  public BaseOptions setTags(List<String> tags) {
+    this.tags.addAll(tags);
+    return this;
+  }
+
+  public BaseOptions setTag(String tags) {
+    this.tags.add(tags);
+    return this;
+  }
+
+  private List<String> tags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
   private String timeZone;
   private String tunnelIdentifier;
   private Boolean videoUploadOnPass = null;
@@ -135,7 +144,17 @@ public class SauceLabsOptions extends BaseOptions {
                 prerunMap.put(Prerun.valueOf(keyString), val);
               });
       setPrerun(prerunMap);
-    } else {
+    } else if ("tags".equals(key)) {
+      try {
+        List<String> tagsList = (List) value;
+        for (String tag: tagsList) {
+          tags.add(tag);
+        }
+      } catch (ClassCastException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    else {
       super.setCapability(key, value);
     }
   }

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/ChromeConfigurationsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/ChromeConfigurationsTest.java
@@ -2,10 +2,8 @@ package com.saucelabs.saucebindings.options;
 
 import com.saucelabs.saucebindings.*;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.UnexpectedAlertBehaviour;
@@ -126,6 +124,10 @@ public class ChromeConfigurationsTest {
             .disableVideoUploadOnPass()
             .build();
 
+    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
+    expectedTags.addAll(tags);
+
     Assertions.assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
     Assertions.assertEquals(true, sauceOptions.sauce().getCapturePerformance());
     Assertions.assertEquals("71", sauceOptions.sauce().getChromedriverVersion());
@@ -143,7 +145,7 @@ public class ChromeConfigurationsTest {
     Assertions.assertEquals(false, sauceOptions.sauce().getRecordScreenshots());
     Assertions.assertEquals(false, sauceOptions.sauce().getRecordVideo());
     Assertions.assertEquals("1024x768", sauceOptions.sauce().getScreenResolution());
-    Assertions.assertEquals(tags, sauceOptions.sauce().getTags());
+    Assertions.assertEquals(expectedTags, sauceOptions.sauce().getTags());
     Assertions.assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
     Assertions.assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
     Assertions.assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/ChromeConfigurationsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/ChromeConfigurationsTest.java
@@ -3,7 +3,6 @@ package com.saucelabs.saucebindings.options;
 import com.saucelabs.saucebindings.*;
 import java.time.Duration;
 import java.util.*;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.UnexpectedAlertBehaviour;
@@ -124,7 +123,7 @@ public class ChromeConfigurationsTest {
             .disableVideoUploadOnPass()
             .build();
 
-    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    // Fix up the tags in the "expected" option to account for the sauce-bindings tags
     List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
     expectedTags.addAll(tags);
 

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/EdgeConfigurationsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/EdgeConfigurationsTest.java
@@ -2,10 +2,8 @@ package com.saucelabs.saucebindings.options;
 
 import com.saucelabs.saucebindings.*;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.edge.EdgeOptions;
@@ -115,6 +113,10 @@ public class EdgeConfigurationsTest {
             .disableVideoUploadOnPass()
             .build();
 
+    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
+    expectedTags.addAll(tags);
+
     Assertions.assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
     Assertions.assertEquals(Integer.valueOf(2), sauceOptions.sauce().getCommandTimeout());
     Assertions.assertEquals(customData, sauceOptions.sauce().getCustomData());
@@ -130,7 +132,7 @@ public class EdgeConfigurationsTest {
     Assertions.assertEquals(false, sauceOptions.sauce().getRecordVideo());
     Assertions.assertEquals("3.141.0", sauceOptions.sauce().getSeleniumVersion());
     Assertions.assertEquals("1024x768", sauceOptions.sauce().getScreenResolution());
-    Assertions.assertEquals(tags, sauceOptions.sauce().getTags());
+    Assertions.assertEquals(expectedTags, sauceOptions.sauce().getTags());
     Assertions.assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
     Assertions.assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
     Assertions.assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/EdgeConfigurationsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/EdgeConfigurationsTest.java
@@ -3,7 +3,6 @@ package com.saucelabs.saucebindings.options;
 import com.saucelabs.saucebindings.*;
 import java.time.Duration;
 import java.util.*;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.edge.EdgeOptions;
@@ -113,7 +112,7 @@ public class EdgeConfigurationsTest {
             .disableVideoUploadOnPass()
             .build();
 
-    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    // Fix up the tags in the "expected" option to account for the sauce-bindings tags
     List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
     expectedTags.addAll(tags);
 

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/FirefoxConfigurationsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/FirefoxConfigurationsTest.java
@@ -3,7 +3,6 @@ package com.saucelabs.saucebindings.options;
 import com.saucelabs.saucebindings.*;
 import java.time.Duration;
 import java.util.*;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.UnexpectedAlertBehaviour;
@@ -117,7 +116,7 @@ public class FirefoxConfigurationsTest {
             .disableVideoUploadOnPass()
             .build();
 
-    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    // Fix up the tags in the "expected" option to account for the sauce-bindings tags
     List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
     expectedTags.addAll(tags);
 

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/FirefoxConfigurationsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/FirefoxConfigurationsTest.java
@@ -2,10 +2,8 @@ package com.saucelabs.saucebindings.options;
 
 import com.saucelabs.saucebindings.*;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.UnexpectedAlertBehaviour;
@@ -119,6 +117,10 @@ public class FirefoxConfigurationsTest {
             .disableVideoUploadOnPass()
             .build();
 
+    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
+    expectedTags.addAll(tags);
+
     Assertions.assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
     Assertions.assertEquals(Integer.valueOf(2), sauceOptions.sauce().getCommandTimeout());
     Assertions.assertEquals(customData, sauceOptions.sauce().getCustomData());
@@ -136,7 +138,7 @@ public class FirefoxConfigurationsTest {
     Assertions.assertEquals(false, sauceOptions.sauce().getRecordVideo());
     Assertions.assertEquals("3.141.0", sauceOptions.sauce().getSeleniumVersion());
     Assertions.assertEquals("1024x768", sauceOptions.sauce().getScreenResolution());
-    Assertions.assertEquals(tags, sauceOptions.sauce().getTags());
+    Assertions.assertEquals(expectedTags, sauceOptions.sauce().getTags());
     Assertions.assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
     Assertions.assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
     Assertions.assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/InternetExplorerConfigurationsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/InternetExplorerConfigurationsTest.java
@@ -2,10 +2,8 @@ package com.saucelabs.saucebindings.options;
 
 import com.saucelabs.saucebindings.*;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.UnexpectedAlertBehaviour;
@@ -119,6 +117,10 @@ public class InternetExplorerConfigurationsTest {
             .disableVideoUploadOnPass()
             .build();
 
+    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
+    expectedTags.addAll(tags);
+
     Assertions.assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
     Assertions.assertEquals(Integer.valueOf(2), sauceOptions.sauce().getCommandTimeout());
     Assertions.assertEquals(customData, sauceOptions.sauce().getCustomData());
@@ -134,7 +136,7 @@ public class InternetExplorerConfigurationsTest {
     Assertions.assertEquals(false, sauceOptions.sauce().getRecordVideo());
     Assertions.assertEquals("3.141.0", sauceOptions.sauce().getSeleniumVersion());
     Assertions.assertEquals("1024x768", sauceOptions.sauce().getScreenResolution());
-    Assertions.assertEquals(tags, sauceOptions.sauce().getTags());
+    Assertions.assertEquals(expectedTags, sauceOptions.sauce().getTags());
     Assertions.assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
     Assertions.assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
     Assertions.assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/InternetExplorerConfigurationsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/InternetExplorerConfigurationsTest.java
@@ -3,7 +3,6 @@ package com.saucelabs.saucebindings.options;
 import com.saucelabs.saucebindings.*;
 import java.time.Duration;
 import java.util.*;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.UnexpectedAlertBehaviour;
@@ -117,7 +116,7 @@ public class InternetExplorerConfigurationsTest {
             .disableVideoUploadOnPass()
             .build();
 
-    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    // Fix up the tags in the "expected" option to account for the sauce-bindings tags
     List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
     expectedTags.addAll(tags);
 

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/SafariConfigurationsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/SafariConfigurationsTest.java
@@ -3,7 +3,6 @@ package com.saucelabs.saucebindings.options;
 import com.saucelabs.saucebindings.*;
 import java.time.Duration;
 import java.util.*;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.UnexpectedAlertBehaviour;
@@ -116,7 +115,7 @@ public class SafariConfigurationsTest {
             .disableVideoUploadOnPass()
             .build();
 
-    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    // Fix up the tags in the "expected" option to account for the sauce-bindings tags
     List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
     expectedTags.addAll(tags);
 

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/SafariConfigurationsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/SafariConfigurationsTest.java
@@ -2,10 +2,8 @@ package com.saucelabs.saucebindings.options;
 
 import com.saucelabs.saucebindings.*;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.UnexpectedAlertBehaviour;
@@ -118,6 +116,10 @@ public class SafariConfigurationsTest {
             .disableVideoUploadOnPass()
             .build();
 
+    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
+    expectedTags.addAll(tags);
+
     Assertions.assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
     Assertions.assertEquals(Integer.valueOf(2), sauceOptions.sauce().getCommandTimeout());
     Assertions.assertEquals(customData, sauceOptions.sauce().getCustomData());
@@ -133,7 +135,7 @@ public class SafariConfigurationsTest {
     Assertions.assertEquals(false, sauceOptions.sauce().getRecordVideo());
     Assertions.assertEquals("3.141.0", sauceOptions.sauce().getSeleniumVersion());
     Assertions.assertEquals("1024x768", sauceOptions.sauce().getScreenResolution());
-    Assertions.assertEquals(tags, sauceOptions.sauce().getTags());
+    Assertions.assertEquals(expectedTags, sauceOptions.sauce().getTags());
     Assertions.assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
     Assertions.assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
     Assertions.assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/SauceOptionsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/SauceOptionsTest.java
@@ -5,7 +5,6 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.*;
-
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -117,7 +116,7 @@ public class SauceOptionsTest {
     sauceOptions.sauce().setTunnelIdentifier("tunnelname");
     sauceOptions.sauce().setVideoUploadOnPass(false);
 
-    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    // Fix up the tags in the "expected" option to account for the sauce-bindings tags
     List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
     expectedTags.addAll(tags);
 
@@ -187,7 +186,7 @@ public class SauceOptionsTest {
     tags.add("bar");
     tags.add("foobar");
 
-    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    // Fix up the tags in the "expected" option to account for the sauce-bindings tags
     List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
     expectedTags.addAll(tags);
 
@@ -369,7 +368,7 @@ public class SauceOptionsTest {
     sauceOptions.sauce().setTunnelIdentifier("tunnelname");
     sauceOptions.sauce().setVideoUploadOnPass(false);
 
-    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    // Fix up the tags in the "expected" option to account for the sauce-bindings tags
     List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
     expectedTags.addAll(tags);
 
@@ -400,7 +399,6 @@ public class SauceOptionsTest {
     sauceCapabilities.setCapability("videoUploadOnPass", false);
     sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
     sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
-
 
     MutableCapabilities expectedCapabilities = new MutableCapabilities();
     expectedCapabilities.setCapability("browserName", "chrome");

--- a/java/main/src/test/java/com/saucelabs/saucebindings/options/SauceOptionsTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/options/SauceOptionsTest.java
@@ -4,10 +4,8 @@ import com.saucelabs.saucebindings.*;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -119,6 +117,10 @@ public class SauceOptionsTest {
     sauceOptions.sauce().setTunnelIdentifier("tunnelname");
     sauceOptions.sauce().setVideoUploadOnPass(false);
 
+    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
+    expectedTags.addAll(tags);
+
     Assertions.assertEquals(true, sauceOptions.sauce().getAvoidProxy());
     Assertions.assertEquals("Sample Build Name", sauceOptions.sauce().getBuild());
     Assertions.assertEquals(true, sauceOptions.sauce().getCapturePerformance());
@@ -139,7 +141,7 @@ public class SauceOptionsTest {
     Assertions.assertEquals(false, sauceOptions.sauce().getRecordVideo());
     Assertions.assertEquals("10x10", sauceOptions.sauce().getScreenResolution());
     Assertions.assertEquals("3.141.59", sauceOptions.sauce().getSeleniumVersion());
-    Assertions.assertEquals(tags, sauceOptions.sauce().getTags());
+    Assertions.assertEquals(expectedTags, sauceOptions.sauce().getTags());
     Assertions.assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
     Assertions.assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
     Assertions.assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());
@@ -185,6 +187,10 @@ public class SauceOptionsTest {
     tags.add("bar");
     tags.add("foobar");
 
+    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
+    expectedTags.addAll(tags);
+
     Assertions.assertEquals(Browser.FIREFOX, sauceOptions.getBrowserName());
     Assertions.assertEquals("68", sauceOptions.getBrowserVersion());
     Assertions.assertEquals(SaucePlatform.MAC_HIGH_SIERRA, sauceOptions.getPlatformName());
@@ -217,7 +223,7 @@ public class SauceOptionsTest {
     Assertions.assertEquals(false, sauceOptions.sauce().getRecordVideo());
     Assertions.assertEquals("10x10", sauceOptions.sauce().getScreenResolution());
     Assertions.assertEquals("3.141.59", sauceOptions.sauce().getSeleniumVersion());
-    Assertions.assertEquals(tags, sauceOptions.sauce().getTags());
+    Assertions.assertEquals(expectedTags, sauceOptions.sauce().getTags());
     Assertions.assertEquals("San Francisco", sauceOptions.sauce().getTimeZone());
     Assertions.assertEquals("tunnelname", sauceOptions.sauce().getTunnelIdentifier());
     Assertions.assertEquals(false, sauceOptions.sauce().getVideoUploadOnPass());
@@ -308,6 +314,7 @@ public class SauceOptionsTest {
     sauceCapabilities.setCapability("build", "Build Name");
     sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
     sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
+    sauceCapabilities.setCapability("tags", "[sauce-bindings, java]");
     expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
     MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
 
@@ -362,6 +369,10 @@ public class SauceOptionsTest {
     sauceOptions.sauce().setTunnelIdentifier("tunnelname");
     sauceOptions.sauce().setVideoUploadOnPass(false);
 
+    //Fix up the tags in the "expected" option to account for the sauce-bindings tags
+    List<String> expectedTags = new ArrayList<>(Arrays.asList("sauce-bindings", "java"));
+    expectedTags.addAll(tags);
+
     MutableCapabilities sauceCapabilities = new MutableCapabilities();
     sauceCapabilities.setCapability("avoidProxy", true);
     sauceCapabilities.setCapability("build", "Sample Build Name");
@@ -383,12 +394,13 @@ public class SauceOptionsTest {
     sauceCapabilities.setCapability("recordVideo", false);
     sauceCapabilities.setCapability("screenResolution", "10x10");
     sauceCapabilities.setCapability("seleniumVersion", "3.141.59");
-    sauceCapabilities.setCapability("tags", tags);
+    sauceCapabilities.setCapability("tags", expectedTags);
     sauceCapabilities.setCapability("timeZone", "San Francisco");
     sauceCapabilities.setCapability("tunnelIdentifier", "tunnelname");
     sauceCapabilities.setCapability("videoUploadOnPass", false);
     sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
     sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
+
 
     MutableCapabilities expectedCapabilities = new MutableCapabilities();
     expectedCapabilities.setCapability("browserName", "chrome");
@@ -423,6 +435,8 @@ public class SauceOptionsTest {
     sauceCapabilities.setCapability("build", "Build Name");
     sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
     sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
+    sauceCapabilities.setCapability("tags", Arrays.asList("sauce-bindings", "java"));
+
     expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
     MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();
 
@@ -448,6 +462,7 @@ public class SauceOptionsTest {
 
     sauceOptions.sauce().setBuild("CUSTOM BUILD: 12");
     sauceCapabilities.setCapability("build", "CUSTOM BUILD: 12");
+    sauceCapabilities.setCapability("tags", "[sauce-bindings, java]");
 
     sauceOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
     expectedCapabilities.setCapability("pageLoadStrategy", PageLoadStrategy.EAGER);
@@ -473,6 +488,7 @@ public class SauceOptionsTest {
     sauceCapabilities.setCapability("public", JobVisibility.SHARE);
     sauceCapabilities.setCapability("username", SystemManager.get("SAUCE_USERNAME"));
     sauceCapabilities.setCapability("accessKey", SystemManager.get("SAUCE_ACCESS_KEY"));
+    sauceCapabilities.setCapability("tags", "[sauce-bindings, java]");
 
     expectedCapabilities.setCapability("sauce:options", sauceCapabilities);
     MutableCapabilities actualCapabilities = sauceOptions.toCapabilities();


### PR DESCRIPTION
… append, not overwrite

# One-line summary

> Issue : #1234 (only if appropriate)

## Description
We want to be able to track who is using Sauce Bindings and overall usage. This PR adds that functionality, and makes it so that when you set tags, you append to the existing list, rather than overwriting it.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)

## Tasks
_List of tasks you will do to complete the PR_
  - [ ] Created Task 1
  - [ ] Created Task 2
  - [ ] To-do Task 3

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
