### PR TITLE
[junit5] fix bug causing all tests to be named the same

### DIFF
--- a/java/junit5/src/main/java/com/saucelabs/saucebindings/junit5/SauceBindingsExtension.java
+++ b/java/junit5/src/main/java/com/saucelabs/saucebindings/junit5/SauceBindingsExtension.java
@@ -68,9 +68,7 @@ public class SauceBindingsExtension implements TestWatcher, BeforeEachCallback {
       return;
     }
 
-    if (sauceOptions.sauce().getName() == null) {
-      sauceOptions.sauce().setName(context.getDisplayName());
-    }
+    sauceOptions.sauce().setName(context.getDisplayName());
 
     session = new SauceSession(sauceOptions);
     session.setDataCenter(dataCenter);


### PR DESCRIPTION
# One-line summary
The extension uses the same options instance for all tests, and users cannot change options after initialization, so the current check does not make sense; user can use session.changeTestName() if needed


## Types of Changes
- Bug fix (non-breaking change which fixes an issue)

