### PR TITLE
[java] create CI Tool classes instead of using a map of constants

### DIFF
--- a/java/main/src/main/java/com/saucelabs/saucebindings/CITools.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/CITools.java
@@ -32,7 +32,7 @@ public abstract class CITools {
           "TRAVIS_JOB_ID", TravisCI::new);
 
   public static String getCiToolName() {
-    return getCiTool().getToolName();
+    return getCiTool().getClientPlatform();
   }
 
   /**
@@ -56,7 +56,8 @@ public abstract class CITools {
   private static CITool getCiTool() {
     if (ciTool != null) {
       return ciTool;
-    } else if (SystemManager.get("SAUCE_BUILD_NAME") != null) {
+    } else if (SystemManager.get("SAUCE_CLIENT_PLATFORM") != null) {
+      // Override the CI Tool lookup when this environment variable is set.
       return new DefaultTool();
     } else {
       for (Map.Entry<String, Supplier<CITool>> tool : KNOWN_TOOLS.entrySet()) {

--- a/java/main/src/main/java/com/saucelabs/saucebindings/SystemManager.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/SystemManager.java
@@ -26,10 +26,17 @@ public class SystemManager {
    * @return the value of the provided field name
    */
   public static String get(String key) {
+    String systemPropertyKey = key.toLowerCase().replace("_", ".");
+    String systemEnvKey = key.toUpperCase().replace(".", "_");
+
     if (System.getProperty(key) != null) {
-      return System.getProperty(key);
+      return System.getProperty(systemPropertyKey);
     } else if (System.getenv(key) != null) {
       return System.getenv(key);
+    } else if (System.getProperty(systemPropertyKey) != null) {
+      return System.getProperty(systemPropertyKey);
+    } else if (System.getenv(systemEnvKey) != null) {
+      return System.getenv(systemEnvKey);
     } else {
       return null;
     }

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/Bamboo.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/Bamboo.java
@@ -1,0 +1,19 @@
+package com.saucelabs.saucebindings.citools;
+
+public class Bamboo implements CITool {
+
+  @Override
+  public String getToolName() {
+    return "Bamboo";
+  }
+
+  @Override
+  public String getBuildName() {
+    return System.getenv("bamboo_shortJobName");
+  }
+
+  @Override
+  public String getBuildNumber() {
+    return System.getenv("bamboo_buildNumber");
+  }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/Bamboo.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/Bamboo.java
@@ -1,19 +1,23 @@
 package com.saucelabs.saucebindings.citools;
 
+import com.saucelabs.saucebindings.SystemManager;
+
 public class Bamboo implements CITool {
 
   @Override
-  public String getToolName() {
+  public String getClientPlatform() {
     return "Bamboo";
   }
 
   @Override
   public String getBuildName() {
-    return System.getenv("bamboo_shortJobName");
+    String buildName = SystemManager.get("SAUCE_BUILD_NAME");
+    return buildName != null ? buildName : System.getenv("bamboo_shortJobName");
   }
 
   @Override
   public String getBuildNumber() {
-    return System.getenv("bamboo_buildNumber");
+    String buildNumber = SystemManager.get("SAUCE_BUILD_NUMBER");
+    return buildNumber != null ? buildNumber : System.getenv("bamboo_buildNumber");
   }
 }

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/CITool.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/CITool.java
@@ -1,7 +1,7 @@
 package com.saucelabs.saucebindings.citools;
 
 public interface CITool {
-  String getToolName();
+  String getClientPlatform();
 
   String getBuildName();
 

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/CITool.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/CITool.java
@@ -1,0 +1,9 @@
+package com.saucelabs.saucebindings.citools;
+
+public interface CITool {
+  String getToolName();
+
+  String getBuildName();
+
+  String getBuildNumber();
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/CircleCI.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/CircleCI.java
@@ -1,19 +1,23 @@
 package com.saucelabs.saucebindings.citools;
 
+import com.saucelabs.saucebindings.SystemManager;
+
 public class CircleCI implements CITool {
 
   @Override
-  public String getToolName() {
+  public String getClientPlatform() {
     return "Circle CI";
   }
 
   @Override
   public String getBuildName() {
-    return System.getenv("CIRCLE_JOB");
+    String buildName = SystemManager.get("SAUCE_BUILD_NAME");
+    return buildName != null ? buildName : System.getenv("CIRCLE_JOB");
   }
 
   @Override
   public String getBuildNumber() {
-    return System.getenv("CIRCLE_BUILD_NUM");
+    String buildNumber = SystemManager.get("SAUCE_BUILD_NUMBER");
+    return buildNumber != null ? buildNumber : System.getenv("CIRCLE_BUILD_NUM");
   }
 }

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/CircleCI.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/CircleCI.java
@@ -1,0 +1,19 @@
+package com.saucelabs.saucebindings.citools;
+
+public class CircleCI implements CITool {
+
+  @Override
+  public String getToolName() {
+    return "Circle CI";
+  }
+
+  @Override
+  public String getBuildName() {
+    return System.getenv("CIRCLE_JOB");
+  }
+
+  @Override
+  public String getBuildNumber() {
+    return System.getenv("CIRCLE_BUILD_NUM");
+  }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/DefaultTool.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/DefaultTool.java
@@ -1,0 +1,24 @@
+package com.saucelabs.saucebindings.citools;
+
+import com.saucelabs.saucebindings.SystemManager;
+
+public class DefaultTool implements CITool {
+
+  @Override
+  public String getToolName() {
+    String toolName = SystemManager.get("SAUCE_TOOL_NAME");
+    return toolName != null ? toolName : "Unknown";
+  }
+
+  @Override
+  public String getBuildName() {
+    String buildName = SystemManager.get("SAUCE_BUILD_NAME");
+    return buildName != null ? buildName : "Undefined Build Name";
+  }
+
+  @Override
+  public String getBuildNumber() {
+    String buildNumber = SystemManager.get("SAUCE_BUILD_NUMBER");
+    return buildNumber != null ? buildNumber : String.valueOf(System.currentTimeMillis());
+  }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/DefaultTool.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/DefaultTool.java
@@ -5,9 +5,9 @@ import com.saucelabs.saucebindings.SystemManager;
 public class DefaultTool implements CITool {
 
   @Override
-  public String getToolName() {
-    String toolName = SystemManager.get("SAUCE_TOOL_NAME");
-    return toolName != null ? toolName : "Unknown";
+  public String getClientPlatform() {
+    String clientPlatform = SystemManager.get("SAUCE_CLIENT_PLATFORM");
+    return clientPlatform != null ? clientPlatform : "Unknown";
   }
 
   @Override

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/GitHub.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/GitHub.java
@@ -1,0 +1,21 @@
+package com.saucelabs.saucebindings.citools;
+
+public class GitHub implements CITool {
+
+  @Override
+  public String getToolName() {
+    return "GitHub";
+  }
+
+  @Override
+  public String getBuildName() {
+    String workflow = System.getenv("GITHUB_WORKFLOW");
+    String jobName = System.getenv("GITHUB_JOB");
+    return workflow + " / " + jobName;
+  }
+
+  @Override
+  public String getBuildNumber() {
+    return System.getenv("GITHUB_RUN_NUMBER");
+  }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/GitHub.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/GitHub.java
@@ -1,21 +1,26 @@
 package com.saucelabs.saucebindings.citools;
 
+import com.saucelabs.saucebindings.SystemManager;
+
 public class GitHub implements CITool {
 
   @Override
-  public String getToolName() {
+  public String getClientPlatform() {
     return "GitHub";
   }
 
   @Override
   public String getBuildName() {
+    String buildName = SystemManager.get("SAUCE_BUILD_NAME");
     String workflow = System.getenv("GITHUB_WORKFLOW");
     String jobName = System.getenv("GITHUB_JOB");
-    return workflow + " / " + jobName;
+
+    return buildName != null ? buildName : workflow + " / " + jobName;
   }
 
   @Override
   public String getBuildNumber() {
-    return System.getenv("GITHUB_RUN_NUMBER");
+    String buildNumber = SystemManager.get("SAUCE_BUILD_NUMBER");
+    return buildNumber != null ? buildNumber : System.getenv("GITHUB_RUN_NUMBER");
   }
 }

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/GitLab.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/GitLab.java
@@ -1,19 +1,23 @@
 package com.saucelabs.saucebindings.citools;
 
+import com.saucelabs.saucebindings.SystemManager;
+
 public class GitLab implements CITool {
 
   @Override
-  public String getToolName() {
+  public String getClientPlatform() {
     return "GitLab";
   }
 
   @Override
   public String getBuildName() {
-    return System.getenv("CI_JOB_NAME");
+    String buildName = SystemManager.get("SAUCE_BUILD_NAME");
+    return buildName != null ? buildName : System.getenv("CI_JOB_NAME");
   }
 
   @Override
   public String getBuildNumber() {
-    return System.getenv("CI_JOB_ID");
+    String buildNumber = SystemManager.get("SAUCE_BUILD_NUMBER");
+    return buildNumber != null ? buildNumber : System.getenv("CI_JOB_ID");
   }
 }

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/GitLab.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/GitLab.java
@@ -1,0 +1,19 @@
+package com.saucelabs.saucebindings.citools;
+
+public class GitLab implements CITool {
+
+  @Override
+  public String getToolName() {
+    return "GitLab";
+  }
+
+  @Override
+  public String getBuildName() {
+    return System.getenv("CI_JOB_NAME");
+  }
+
+  @Override
+  public String getBuildNumber() {
+    return System.getenv("CI_JOB_ID");
+  }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/Jenkins.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/Jenkins.java
@@ -1,0 +1,19 @@
+package com.saucelabs.saucebindings.citools;
+
+public class Jenkins implements CITool {
+
+  @Override
+  public String getToolName() {
+    return "Jenkins";
+  }
+
+  @Override
+  public String getBuildName() {
+    return System.getenv("BUILD_NAME");
+  }
+
+  @Override
+  public String getBuildNumber() {
+    return System.getenv("BUILD_NUMBER");
+  }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/Jenkins.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/Jenkins.java
@@ -1,19 +1,23 @@
 package com.saucelabs.saucebindings.citools;
 
+import com.saucelabs.saucebindings.SystemManager;
+
 public class Jenkins implements CITool {
 
   @Override
-  public String getToolName() {
+  public String getClientPlatform() {
     return "Jenkins";
   }
 
   @Override
   public String getBuildName() {
-    return System.getenv("BUILD_NAME");
+    String buildName = SystemManager.get("SAUCE_BUILD_NAME");
+    return buildName != null ? buildName : System.getenv("BUILD_NAME");
   }
 
   @Override
   public String getBuildNumber() {
-    return System.getenv("BUILD_NUMBER");
+    String buildNumber = SystemManager.get("SAUCE_BUILD_NUMBER");
+    return buildNumber != null ? buildNumber : System.getenv("BUILD_NUMBER");
   }
 }

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/TeamCity.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/TeamCity.java
@@ -1,0 +1,19 @@
+package com.saucelabs.saucebindings.citools;
+
+public class TeamCity implements CITool {
+
+  @Override
+  public String getToolName() {
+    return "Team City";
+  }
+
+  @Override
+  public String getBuildName() {
+    return System.getenv("TEAMCITY_PROJECT_NAME");
+  }
+
+  @Override
+  public String getBuildNumber() {
+    return System.getenv("BUILD_NUMBER");
+  }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/TeamCity.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/TeamCity.java
@@ -1,19 +1,23 @@
 package com.saucelabs.saucebindings.citools;
 
+import com.saucelabs.saucebindings.SystemManager;
+
 public class TeamCity implements CITool {
 
   @Override
-  public String getToolName() {
+  public String getClientPlatform() {
     return "Team City";
   }
 
   @Override
   public String getBuildName() {
-    return System.getenv("TEAMCITY_PROJECT_NAME");
+    String buildName = SystemManager.get("SAUCE_BUILD_NAME");
+    return buildName != null ? buildName : System.getenv("TEAMCITY_PROJECT_NAME");
   }
 
   @Override
   public String getBuildNumber() {
-    return System.getenv("BUILD_NUMBER");
+    String buildNumber = SystemManager.get("SAUCE_BUILD_NUMBER");
+    return buildNumber != null ? buildNumber : System.getenv("BUILD_NUMBER");
   }
 }

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/TravisCI.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/TravisCI.java
@@ -1,0 +1,19 @@
+package com.saucelabs.saucebindings.citools;
+
+public class TravisCI implements CITool {
+
+  @Override
+  public String getToolName() {
+    return "Travis CI";
+  }
+
+  @Override
+  public String getBuildName() {
+    return System.getenv("TRAVIS_JOB_NAME");
+  }
+
+  @Override
+  public String getBuildNumber() {
+    return System.getenv("TRAVIS_JOB_NUMBER");
+  }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/citools/TravisCI.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/citools/TravisCI.java
@@ -1,19 +1,23 @@
 package com.saucelabs.saucebindings.citools;
 
+import com.saucelabs.saucebindings.SystemManager;
+
 public class TravisCI implements CITool {
 
   @Override
-  public String getToolName() {
+  public String getClientPlatform() {
     return "Travis CI";
   }
 
   @Override
   public String getBuildName() {
-    return System.getenv("TRAVIS_JOB_NAME");
+    String buildName = SystemManager.get("SAUCE_BUILD_NAME");
+    return buildName != null ? buildName : System.getenv("TRAVIS_JOB_NAME");
   }
 
   @Override
   public String getBuildNumber() {
-    return System.getenv("TRAVIS_JOB_NUMBER");
+    String buildNumber = SystemManager.get("SAUCE_BUILD_NUMBER");
+    return buildNumber != null ? buildNumber : System.getenv("TRAVIS_JOB_NUMBER");
   }
 }


### PR DESCRIPTION
# One-line summary

Allow user-defined build name and number as well as better GitHub default

## Description
Instead of a complicated map of environment variables, this creates a new class for each CI Tool.

As for GitHub, `GITHUB_JOB` for this repo is e.g., `main`, `junit5`, `junit4` (https://github.com/saucelabs/sauce_bindings/blob/main/.github/workflows/java.yml#L62), which isn't super helpful on Sauce —  `Automated / Builds/ main: 149` (https://app.saucelabs.com/builds/vdc/c9e1a2beb1b03686b0c248e4dc73921b)

This PR adds `GITHUB_WORKFLOW`, so it will look like: `Java / main: 149`. It might be even better to add project? so `saucebindings / Java / main: 149`? 

Also, user can now adjust it to be whatever they want:
```
System.setProperty("sauce.build.name", System.getenv("GITHUB_WORKFLOW") + " -  " +  System.getenv("GITHUB_JOB"))
```

`SystemManager` class also now checks for screaming snake case in environment variables and lowercase dot separated in system properties

## Types of Changes
- New feature (non-breaking change which adds functionality)

