### PR TITLE
[java] fix capability management of namespaced keys

### DIFF
--- a/java/main/src/main/java/com/saucelabs/saucebindings/options/CapabilityManager.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/options/CapabilityManager.java
@@ -47,7 +47,11 @@ public class CapabilityManager implements Serializable {
       Method method = options.getClass().getMethod(setter, type);
       method.invoke(options, value);
     } catch (NoSuchFieldException e) {
-      throw new InvalidSauceOptionsArgumentException(key + " is not a valid configuration value");
+      if (key.contains(":")) {
+        options.capabilities.setCapability(key, value);
+      } else {
+        throw new InvalidSauceOptionsArgumentException(key + " is not a valid configuration value");
+      }
     } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
       throw new RuntimeException("Unable to set capability for " + key, e);
     }


### PR DESCRIPTION
# One-line summary

Calling `new SauceOptions.merge(myCapabilities.asMap()))` did not work because capabilities can have name-spaced keys (e.g., `moz:debuggerAddress`) and Bindings doesn't handle them.

## Description
* Current code makes sure the key is valid before adding it
* This works for the keys defined in the spec and delineated in the project
* It does not work for valid, but non-specific namespaces

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)
