### PR TITLE
[junit5] provide static builder to initialize internal Builder class

### DIFF
--- a/java/junit5/src/main/java/com/saucelabs/saucebindings/junit5/SauceBindingsExtension.java
+++ b/java/junit5/src/main/java/com/saucelabs/saucebindings/junit5/SauceBindingsExtension.java
@@ -40,6 +40,10 @@ public class SauceBindingsExtension implements TestWatcher, BeforeEachCallback, 
     this.buildName = CITools.getBuildName() + ": " + CITools.getBuildNumber();
   }
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   @Override
   public void beforeEach(ExtensionContext context) {
     SauceOptions options = updateOptions(context);

--- a/java/junit5/src/test/java/com/saucelabs/saucebindings/junit5/CapabilitiesTest.java
+++ b/java/junit5/src/test/java/com/saucelabs/saucebindings/junit5/CapabilitiesTest.java
@@ -24,7 +24,7 @@ public class CapabilitiesTest {
 
   @RegisterExtension
   static SauceBindingsExtension sauceExtension =
-      new SauceBindingsExtension.Builder().withCapabilities(getCapabilities()).build();
+      SauceBindingsExtension.builder().withCapabilities(getCapabilities()).build();
 
   @Test
   public void useCustomCapabilities(SauceSession session, WebDriver driver) {

--- a/java/junit5/src/test/java/com/saucelabs/saucebindings/junit5/DataCenterTest.java
+++ b/java/junit5/src/test/java/com/saucelabs/saucebindings/junit5/DataCenterTest.java
@@ -10,7 +10,7 @@ import org.openqa.selenium.WebDriver;
 public class DataCenterTest {
   @RegisterExtension
   static SauceBindingsExtension sauceExtension =
-      new SauceBindingsExtension.Builder().withDataCenter(DataCenter.EU_CENTRAL).build();
+      SauceBindingsExtension.builder().withDataCenter(DataCenter.EU_CENTRAL).build();
 
   @Test
   public void setDataCenter(SauceSession session, WebDriver driver) {

--- a/java/junit5/src/test/java/com/saucelabs/saucebindings/junit5/OptionsTest.java
+++ b/java/junit5/src/test/java/com/saucelabs/saucebindings/junit5/OptionsTest.java
@@ -20,7 +20,7 @@ public class OptionsTest {
 
   @RegisterExtension
   static SauceBindingsExtension sauceExtension =
-      new SauceBindingsExtension.Builder().withSauceOptions(getSauceOptions()).build();
+      SauceBindingsExtension.builder().withSauceOptions(getSauceOptions()).build();
 
   @Test
   public void useCustomOptions(SauceSession session, WebDriver driver) {

--- a/java/junit5/src/test/java/com/saucelabs/saucebindings/junit5/examples/CapabilitiesExample.java
+++ b/java/junit5/src/test/java/com/saucelabs/saucebindings/junit5/examples/CapabilitiesExample.java
@@ -17,7 +17,7 @@ public class CapabilitiesExample {
 
   @RegisterExtension
   SauceBindingsExtension sauceExtension =
-      new SauceBindingsExtension.Builder().withCapabilities(getCapabilities()).build();
+      SauceBindingsExtension.builder().withCapabilities(getCapabilities()).build();
 
   @BeforeEach
   public void setUp(SauceSession session, WebDriver driver) {

--- a/java/junit5/src/test/java/com/saucelabs/saucebindings/junit5/examples/DataCenterExample.java
+++ b/java/junit5/src/test/java/com/saucelabs/saucebindings/junit5/examples/DataCenterExample.java
@@ -14,7 +14,7 @@ public class DataCenterExample {
 
   @RegisterExtension
   static SauceBindingsExtension sauceExtension =
-      new SauceBindingsExtension.Builder().withDataCenter(DataCenter.EU_CENTRAL).build();
+      SauceBindingsExtension.builder().withDataCenter(DataCenter.EU_CENTRAL).build();
 
   @BeforeEach
   public void setUp(SauceSession session, WebDriver driver) {

--- a/java/junit5/src/test/java/com/saucelabs/saucebindings/junit5/examples/OptionsExample.java
+++ b/java/junit5/src/test/java/com/saucelabs/saucebindings/junit5/examples/OptionsExample.java
@@ -17,7 +17,7 @@ public class OptionsExample {
 
   @RegisterExtension
   static SauceBindingsExtension sauceExtension =
-      new SauceBindingsExtension.Builder().withSauceOptions(getSauceOptions()).build();
+      SauceBindingsExtension.builder().withSauceOptions(getSauceOptions()).build();
 
   @BeforeEach
   public void setUp(SauceSession session, WebDriver driver) {


### PR DESCRIPTION

# One-line summary

Instead of: `new SauceBindingsExtension.Builder()`
support: `SauceBindingsExtension.builder()`

## Description
A little easier to work with

## Types of Changes

- Refactor/improvements
