### PR TITLE
[java] move error message and stack trace annotation

### DIFF
--- a/java/junit5/src/main/java/com/saucelabs/saucebindings/junit5/SauceBindingsExtension.java
+++ b/java/junit5/src/main/java/com/saucelabs/saucebindings/junit5/SauceBindingsExtension.java
@@ -7,12 +7,10 @@ import com.saucelabs.saucebindings.options.SauceOptions;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -22,7 +20,6 @@ import org.junit.jupiter.api.extension.TestWatcher;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.RemoteWebDriver;
 
 public class SauceBindingsExtension implements TestWatcher, BeforeEachCallback, ParameterResolver {
   private static final Logger LOGGER = Logger.getLogger(SauceBindingsExtension.class.getName());
@@ -91,7 +88,6 @@ public class SauceBindingsExtension implements TestWatcher, BeforeEachCallback, 
   public void testSuccessful(ExtensionContext context) {
     if (!SauceSession.isDisabled()) {
       SauceSession session = (SauceSession) getStore(context).get("session");
-      RemoteWebDriver driver = session.getDriver();
       try {
         session.stop(true);
       } catch (NoSuchSessionException e) {
@@ -107,14 +103,7 @@ public class SauceBindingsExtension implements TestWatcher, BeforeEachCallback, 
     if (!SauceSession.isDisabled()) {
       SauceSession session = (SauceSession) getStore(context).get("session");
       try {
-        session.annotate("Failure Reason: " + cause.getMessage());
-
-        Arrays.stream(cause.getStackTrace())
-            .map(StackTraceElement::toString)
-            .filter(line -> !line.contains("sun"))
-            .forEach(session::annotate);
-
-        session.stop(false);
+        session.stop(cause);
       } catch (NoSuchSessionException e) {
         LOGGER.severe(
             "Driver quit prematurely; Remove calls to `driver.quit()` to allow"
@@ -128,16 +117,7 @@ public class SauceBindingsExtension implements TestWatcher, BeforeEachCallback, 
     LOGGER.fine("Test Aborted: " + cause.getMessage());
     SauceSession session = (SauceSession) getStore(context).get("session");
     if (session != null) {
-      session.annotate("Test Aborted; marking completed instead of failed");
-      session.annotate("Reason: " + cause.getMessage());
-
-      String stackTrace =
-          Arrays.stream(cause.getStackTrace())
-              .map(StackTraceElement::toString)
-              .collect(Collectors.joining("\n"));
-      session.annotate(stackTrace);
-
-      session.abort();
+      session.abort(cause);
     }
   }
 


### PR DESCRIPTION
# One-line summary
Rather than implementing annotation for cause and stack trace in all three test runners, just put it in one place

## Description
* adds a `stop(Throwable cause)` method (which assumes it is a failing test); this is preferred over `session.stop(false)`
* adds `Throwable cause` as a required parameter on `abort()`

## Types of Changes
- New feature (non-breaking change which adds functionality)

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
