### PR TITLE
[java] implement session methods with SauceREST library

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: cd java/main && mvn clean test -Dmaven.javadoc.skip=true;
+        run: cd java/main && mvn clean test -Dmaven.javadoc.skip=true
   junit4:
     runs-on: ubuntu-latest
     steps:

--- a/java/main/pom.xml
+++ b/java/main/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <version>4.22.0</version>
+      <version>4.25.0</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
@@ -103,6 +103,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>2.0.13</version>
+    </dependency>
+    <dependency>
+      <groupId>com.saucelabs</groupId>
+      <artifactId>saucerest</artifactId>
+      <version>2.5.3</version>
     </dependency>
   </dependencies>
 

--- a/java/main/src/main/java/com/saucelabs/saucebindings/Assets.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/Assets.java
@@ -1,0 +1,26 @@
+package com.saucelabs.saucebindings;
+
+import com.saucelabs.saucerest.TestAsset;
+import com.saucelabs.saucerest.model.jobs.JobAssets;
+import java.nio.file.Path;
+
+public class Assets {
+
+  private final SauceRest rest;
+
+  public Assets(SauceRest rest) {
+    this.rest = rest;
+  }
+
+  public JobAssets listAll() {
+    return rest.listAssets();
+  }
+
+  public void downloadAll(Path path) {
+    rest.downloadAllAssets(path);
+  }
+
+  public void download(Path path, TestAsset asset) {
+    rest.downloadAsset(path, asset);
+  }
+}

--- a/java/main/src/main/java/com/saucelabs/saucebindings/SauceRest.java
+++ b/java/main/src/main/java/com/saucelabs/saucebindings/SauceRest.java
@@ -1,0 +1,98 @@
+package com.saucelabs.saucebindings;
+
+import com.saucelabs.saucerest.SauceREST;
+import com.saucelabs.saucerest.TestAsset;
+import com.saucelabs.saucerest.api.JobsEndpoint;
+import com.saucelabs.saucerest.model.jobs.Job;
+import com.saucelabs.saucerest.model.jobs.JobAssets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.openqa.selenium.remote.SessionId;
+
+public class SauceRest {
+
+  private final String id;
+  private final JobsEndpoint jobs;
+
+  public SauceRest(DataCenter dataCenter, SessionId id) {
+    this.id = id.toString();
+    SauceREST rest =
+        new SauceREST(com.saucelabs.saucerest.DataCenter.fromString(dataCenter.name()));
+    this.jobs = rest.getJobsEndpoint();
+  }
+
+  @SneakyThrows
+  public void setResult(Boolean result) {
+    jobs.changeResults(id, result);
+  }
+
+  public Map<String, String> getCustomData() {
+    return getDetails().customData;
+  }
+
+  @SneakyThrows
+  public void addCustomData(Map<String, String> data) {
+    jobs.addCustomData(id, data);
+  }
+
+  public List<String> getTags() {
+    return getDetails().tags;
+  }
+
+  @SneakyThrows
+  public void addTags(List<String> tags) {
+    jobs.addTags(id, tags);
+  }
+
+  @SneakyThrows
+  public void changeName(String name) {
+    jobs.changeName(id, name);
+  }
+
+  @SneakyThrows
+  public String getName() {
+    return jobs.getJobDetails(id).name;
+  }
+
+  @SneakyThrows
+  public void changeBuild(String build) {
+    jobs.changeBuild(id, build);
+  }
+
+  @SneakyThrows
+  public String getBuild() {
+    return String.valueOf(jobs.getJobDetails(id).build);
+  }
+
+  @SneakyThrows
+  public void stop() {
+    jobs.stopJob(id);
+  }
+
+  @SneakyThrows
+  public void delete() {
+    jobs.deleteJob(id);
+  }
+
+  @SneakyThrows
+  public JobAssets listAssets() {
+    return jobs.listJobAssets(id);
+  }
+
+  @SneakyThrows
+  public void downloadAllAssets(Path path) {
+    jobs.downloadAllAssets(id, path);
+  }
+
+  @SneakyThrows
+  public void downloadAsset(Path path, TestAsset asset) {
+    jobs.downloadJobAsset(id, path, asset);
+  }
+
+  @SneakyThrows
+  private Job getDetails() {
+    return jobs.getJobDetails(id);
+  }
+}

--- a/java/main/src/test/java/com/saucelabs/saucebindings/integration/DesktopBrowserTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/integration/DesktopBrowserTest.java
@@ -49,7 +49,7 @@ public class DesktopBrowserTest {
     session.stop(true);
     session.stop(false);
 
-    Assertions.assertEquals("passed", session.getResult());
+    Assertions.assertTrue(session.getResult());
   }
 
   @Test


### PR DESCRIPTION
# One-line summary

Use REST API where possible

## Description
REST API should be preferred over sending commands via execute script to the driver
It is especially useful when stopping the session if the driver is corrupted or inaccessible. This should reduce 90 second timeout errors
Mostly this is internal implementation details.

Obviously there is a lot more we can do here down the road, but here are the new user facing methods...
```
// Assets
session.assets.listAssets()
session.assets.downloadAll(Path path)
session.assets.download(Path path, TestAsset asset)

// Update after session start
session.changeBuildName(String name)
session.changeTestName(String name)
session.AddTag(String tag)
session.AddCustomData(String key, Object value)

// Getters
session.getTags()
session.getCustomData()

// Session Change
session.delete()
```



## Types of Changes
- New feature (non-breaking change which adds functionality)

## Considerations
I'm mostly just looking for feedback on this implementation and the general idea. This wasn't as hard to implement as I was concerned with, and there's no reason we have to implement everything all at once.
