### PR TITLE
[java] improve logic to ensure session is stopped

### DIFF
--- a/java/main/src/test/java/com/saucelabs/saucebindings/integration/DesktopBrowserTest.java
+++ b/java/main/src/test/java/com/saucelabs/saucebindings/integration/DesktopBrowserTest.java
@@ -43,16 +43,6 @@ public class DesktopBrowserTest {
   }
 
   @Test
-  public void storesResultOfFirstStop() {
-    session.start();
-
-    session.stop(true);
-    session.stop(false);
-
-    Assertions.assertTrue(session.getResult());
-  }
-
-  @Test
   public void nullsDriver() {
     driver = session.start();
     session.stop(true);


### PR DESCRIPTION
The stop() method is making driver calls, so it isn't good enough to put the rest call to stop in the quit() it has to go in the stop and abort methods