### PR TITLE
WIP - override what user passes in with what is in a config file

### DIFF
--- a/java/junit5/pom.xml
+++ b/java/junit5/pom.xml
@@ -75,6 +75,12 @@
             <artifactId>junit-jupiter</artifactId>
             <version>5.10.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.2</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
Throwing this out there for us to discuss.

The idea is that a plugin can override what the user has in their code and run a platform configuration based on what is in a config file. This needs to be done from the Test Runner library in order to make sure all the custom information for test and build name and tags, etc isn't overridden.

Really we need a lot more work on the plugin and understanding what is possible before this is really useful. But I'm imagining a scenario where a user can have the 4 configurations they care about in the file, and when they use the plugin to right click and "Run on All Sauce Platforms" have the IDE run that test 4 times, once with each of the different configurations.